### PR TITLE
feat: project publication management with org access control

### DIFF
--- a/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -48,8 +48,8 @@ const MAX_SYSTEM_PROMPT_LENGTH = 8000;
 const SETTINGS_TABS = [
   "General",
   "Models",
-  "Document ingestion",
   "Knowledge indexing",
+  "Document ingestion",
   "Context retrieval",
   "Context augmentation",
   "Answer generation",

--- a/client/src/lib/api/projects.ts
+++ b/client/src/lib/api/projects.ts
@@ -59,3 +59,23 @@ export function reindexProject(
     token,
   });
 }
+
+export function publishProject(
+  token: string,
+  projectId: string,
+): Promise<ProjectResponse> {
+  return apiFetch<ProjectResponse>(`/projects/${projectId}/publish`, {
+    method: "POST",
+    token,
+  });
+}
+
+export function unpublishProject(
+  token: string,
+  projectId: string,
+): Promise<ProjectResponse> {
+  return apiFetch<ProjectResponse>(`/projects/${projectId}/unpublish`, {
+    method: "POST",
+    token,
+  });
+}

--- a/client/src/lib/hooks/use-projects.ts
+++ b/client/src/lib/hooks/use-projects.ts
@@ -6,7 +6,9 @@ import {
   deleteProject,
   getProject,
   listProjects,
+  publishProject,
   reindexProject,
+  unpublishProject,
   updateProject,
 } from "@/lib/api/projects";
 import type { CreateProjectRequest, UpdateProjectRequest } from "@/lib/types/api";
@@ -81,6 +83,32 @@ export function useReindexProject(projectId: string) {
       queryClient.invalidateQueries({ queryKey: ["projects"] });
       queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
       queryClient.invalidateQueries({ queryKey: ["documents", projectId] });
+    },
+  });
+}
+
+export function usePublishProject(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => publishProject(token!, projectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
+    },
+  });
+}
+
+export function useUnpublishProject(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => unpublishProject(token!, projectId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["projects"] });
+      queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
     },
   });
 }

--- a/server/src/raggae/application/constants.py
+++ b/server/src/raggae/application/constants.py
@@ -1,3 +1,33 @@
+ALLOWED_LLM_MODELS: dict[str, frozenset[str]] = {
+    "openai": frozenset({
+        "gpt-5.2", "gpt-5.2-pro", "gpt-5.1", "gpt-5", "gpt-5-mini", "gpt-5-nano",
+        "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
+    }),
+    "gemini": frozenset({
+        "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3-deep-think-preview",
+    }),
+    "anthropic": frozenset({
+        "claude-opus-4-6-20260205", "claude-opus-4-5-20251101",
+        "claude-sonnet-4-6-20260217", "claude-sonnet-4-20250514",
+        "claude-haiku-4-5-20251001",
+    }),
+    "inmemory": frozenset({
+        "inmemory-chat-accurate", "inmemory-chat-balanced", "inmemory-chat-fast",
+    }),
+}
+
+ALLOWED_EMBEDDING_MODELS: dict[str, frozenset[str]] = {
+    "openai": frozenset({
+        "text-embedding-3-large", "text-embedding-3-small", "text-embedding-ada-002",
+    }),
+    "gemini": frozenset({
+        "gemini-embedding-001", "text-multilingual-embedding-002",
+    }),
+    "inmemory": frozenset({
+        "inmemory-embed-accurate", "inmemory-embed-balanced", "inmemory-embed-fast",
+    }),
+}
+
 MAX_PROJECT_SYSTEM_PROMPT_LENGTH = 8000
 MIN_PROJECT_CHAT_HISTORY_WINDOW_SIZE = 1
 MAX_PROJECT_CHAT_HISTORY_WINDOW_SIZE = 40

--- a/server/src/raggae/application/use_cases/chat/delete_conversation.py
+++ b/server/src/raggae/application/use_cases/chat/delete_conversation.py
@@ -3,9 +3,13 @@ from uuid import UUID
 from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class DeleteConversation:
@@ -15,9 +19,11 @@ class DeleteConversation:
         self,
         project_repository: ProjectRepository,
         conversation_repository: ConversationRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._conversation_repository = conversation_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -26,8 +32,20 @@ class DeleteConversation:
         user_id: UUID,
     ) -> None:
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         conversation = await self._conversation_repository.find_by_id(conversation_id)
         if (

--- a/server/src/raggae/application/use_cases/chat/get_conversation.py
+++ b/server/src/raggae/application/use_cases/chat/get_conversation.py
@@ -6,23 +6,29 @@ from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
 from raggae.application.interfaces.repositories.message_repository import MessageRepository
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class GetConversation:
-    """Use Case: Get conversation details for a user-owned project."""
+    """Use Case: Get conversation details for a user with access to the project."""
 
     def __init__(
         self,
         project_repository: ProjectRepository,
         conversation_repository: ConversationRepository,
         message_repository: MessageRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._conversation_repository = conversation_repository
         self._message_repository = message_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -31,8 +37,20 @@ class GetConversation:
         user_id: UUID,
     ) -> ConversationDetailDTO:
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         conversation = await self._conversation_repository.find_by_id(conversation_id)
         if (

--- a/server/src/raggae/application/use_cases/chat/list_conversation_messages.py
+++ b/server/src/raggae/application/use_cases/chat/list_conversation_messages.py
@@ -5,9 +5,13 @@ from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
 from raggae.application.interfaces.repositories.message_repository import MessageRepository
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class ListConversationMessages:
@@ -18,10 +22,12 @@ class ListConversationMessages:
         project_repository: ProjectRepository,
         conversation_repository: ConversationRepository,
         message_repository: MessageRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._conversation_repository = conversation_repository
         self._message_repository = message_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -32,8 +38,20 @@ class ListConversationMessages:
         offset: int = 0,
     ) -> list[MessageDTO]:
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         conversation = await self._conversation_repository.find_by_id(conversation_id)
         if (

--- a/server/src/raggae/application/use_cases/chat/list_conversations.py
+++ b/server/src/raggae/application/use_cases/chat/list_conversations.py
@@ -4,20 +4,26 @@ from raggae.application.dto.conversation_dto import ConversationDTO
 from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class ListConversations:
-    """Use Case: List conversations for a user-owned project."""
+    """Use Case: List conversations for a project the user has access to."""
 
     def __init__(
         self,
         project_repository: ProjectRepository,
         conversation_repository: ConversationRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._conversation_repository = conversation_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -27,8 +33,20 @@ class ListConversations:
         offset: int = 0,
     ) -> list[ConversationDTO]:
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         conversations = await self._conversation_repository.find_by_project_and_user(
             project_id=project_id,

--- a/server/src/raggae/application/use_cases/chat/send_message.py
+++ b/server/src/raggae/application/use_cases/chat/send_message.py
@@ -13,6 +13,9 @@ from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
 from raggae.application.interfaces.repositories.message_repository import MessageRepository
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.application.interfaces.services.chat_security_policy import ChatSecurityPolicy
 from raggae.application.interfaces.services.conversation_title_generator import (
@@ -39,6 +42,7 @@ from raggae.domain.exceptions.project_exceptions import (
     ProjectNotFoundError,
     ProjectReindexInProgressError,
 )
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 from raggae.infrastructure.services.prompt_builder import build_rag_prompt
 
 _API_KEY_PROVIDERS = {"openai", "gemini", "anthropic"}
@@ -58,6 +62,7 @@ class SendMessage:
         provider_api_key_resolver: ProviderApiKeyResolver | None = None,
         project_llm_service_resolver: ProjectLLMServiceResolver | None = None,
         project_reranker_service_resolver: ProjectRerankerServiceResolver | None = None,
+        organization_member_repository: OrganizationMemberRepository | None = None,
         llm_provider: str = "openai",
         chat_security_policy: ChatSecurityPolicy | None = None,
         default_chunk_limit: int = 8,
@@ -74,6 +79,7 @@ class SendMessage:
         self._provider_api_key_resolver = provider_api_key_resolver
         self._project_llm_service_resolver = project_llm_service_resolver
         self._project_reranker_service_resolver = project_reranker_service_resolver
+        self._organization_member_repository = organization_member_repository
         self._llm_provider = llm_provider
         self._default_chunk_limit = max(1, default_chunk_limit)
         self._max_chunk_limit = max(1, max_chunk_limit)
@@ -98,6 +104,7 @@ class SendMessage:
         project = await self._project_repository.find_by_id(project_id)
         if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        await self._check_project_access(project, user_id)
         if project.is_reindexing():
             raise ProjectReindexInProgressError(f"Project {project_id} is currently reindexing")
         effective_retrieval_strategy = project.retrieval_strategy
@@ -307,6 +314,7 @@ class SendMessage:
         project = await self._project_repository.find_by_id(project_id)
         if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        await self._check_project_access(project, user_id)
         if project.is_reindexing():
             raise ProjectReindexInProgressError(f"Project {project_id} is currently reindexing")
         effective_retrieval_strategy = project.retrieval_strategy
@@ -667,5 +675,21 @@ class SendMessage:
             removed = trimmed.pop(0)
             total_chars -= len(removed)
         return trimmed
+
+    async def _check_project_access(self, project: Project, user_id: UUID) -> None:
+        if project.user_id == user_id:
+            return
+        if project.organization_id is None or self._organization_member_repository is None:
+            raise ProjectNotFoundError(f"Project {project.id} not found")
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=project.organization_id,
+            user_id=user_id,
+        )
+        if member is None:
+            raise ProjectNotFoundError(f"Project {project.id} not found")
+        if member.role in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+            return
+        if not project.is_published:
+            raise ProjectNotFoundError(f"Project {project.id} not found")
 
     _MAX_CONVERSATION_TITLE_LENGTH = 80

--- a/server/src/raggae/application/use_cases/chat/send_message.py
+++ b/server/src/raggae/application/use_cases/chat/send_message.py
@@ -142,9 +142,7 @@ class SendMessage:
             ):
                 raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
         if conversation is None:
-            raise ConversationNotFoundError(
-                f"Conversation {conversation_id} not found"
-            )
+            raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
         if not skip_user_message_save:
             current_user_message_id = uuid4()
             await self._message_repository.save(
@@ -352,9 +350,7 @@ class SendMessage:
             ):
                 raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
         if conversation is None:
-            raise ConversationNotFoundError(
-                f"Conversation {conversation_id} not found"
-            )
+            raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
         if not skip_user_message_save:
             current_user_message_id = uuid4()
             await self._message_repository.save(
@@ -485,10 +481,10 @@ class SendMessage:
             else:
                 source_documents = self._extract_source_documents(relevant_chunks)
                 reliability_percent = self._compute_reliability_percent(relevant_chunks)
-        except LLMGenerationError:
+        except LLMGenerationError as exc:
             accumulated_answer = (
                 "I found relevant context but could not generate an answer right now. "
-                "Please try again in a few seconds."
+                f"Provider error: {exc}"
             )
             source_documents = []
             reliability_percent = 0
@@ -662,9 +658,7 @@ class SendMessage:
                 continue
             label = "User" if message.role == "user" else "Assistant"
             history.append(f"{label}: {message.content}")
-        return self._truncate_history_by_chars(
-            history[-history_window_size :], history_max_chars
-        )
+        return self._truncate_history_by_chars(history[-history_window_size:], history_max_chars)
 
     def _truncate_history_by_chars(self, history: list[str], history_max_chars: int) -> list[str]:
         total_chars = sum(len(item) for item in history)

--- a/server/src/raggae/application/use_cases/chat/update_conversation.py
+++ b/server/src/raggae/application/use_cases/chat/update_conversation.py
@@ -3,21 +3,27 @@ from uuid import UUID
 from raggae.application.interfaces.repositories.conversation_repository import (
     ConversationRepository,
 )
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class UpdateConversation:
-    """Use Case: Update conversation metadata for a user-owned project."""
+    """Use Case: Update conversation metadata for a user with access to the project."""
 
     def __init__(
         self,
         project_repository: ProjectRepository,
         conversation_repository: ConversationRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._conversation_repository = conversation_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -27,8 +33,20 @@ class UpdateConversation:
         title: str,
     ) -> None:
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         conversation = await self._conversation_repository.find_by_id(conversation_id)
         if (

--- a/server/src/raggae/application/use_cases/organization/list_organization_projects.py
+++ b/server/src/raggae/application/use_cases/organization/list_organization_projects.py
@@ -12,6 +12,7 @@ from raggae.domain.exceptions.organization_exceptions import (
     OrganizationAccessDeniedError,
     OrganizationNotFoundError,
 )
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class ListOrganizationProjects:
@@ -40,4 +41,6 @@ class ListOrganizationProjects:
                 f"User {user_id} cannot access organization projects for {organization_id}"
             )
         projects = await self._project_repository.find_by_organization_id(organization_id)
+        if member.role == OrganizationMemberRole.USER:
+            projects = [p for p in projects if p.is_published]
         return [ProjectDTO.from_entity(project) for project in projects]

--- a/server/src/raggae/application/use_cases/project/publish_project.py
+++ b/server/src/raggae/application/use_cases/project/publish_project.py
@@ -1,0 +1,41 @@
+from uuid import UUID
+
+from raggae.application.dto.project_dto import ProjectDTO
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class PublishProject:
+    """Use Case: Publish a project (OWNER or MAKER only)."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
+    ) -> None:
+        self._project_repository = project_repository
+        self._organization_member_repository = organization_member_repository
+
+    async def execute(self, project_id: UUID, user_id: UUID) -> ProjectDTO:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None or member.role not in {
+                OrganizationMemberRole.OWNER,
+                OrganizationMemberRole.MAKER,
+            }:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+        published = project.publish()
+        await self._project_repository.save(published)
+        return ProjectDTO.from_entity(published)

--- a/server/src/raggae/application/use_cases/project/unpublish_project.py
+++ b/server/src/raggae/application/use_cases/project/unpublish_project.py
@@ -1,0 +1,41 @@
+from uuid import UUID
+
+from raggae.application.dto.project_dto import ProjectDTO
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class UnpublishProject:
+    """Use Case: Unpublish a project (OWNER or MAKER only)."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
+    ) -> None:
+        self._project_repository = project_repository
+        self._organization_member_repository = organization_member_repository
+
+    async def execute(self, project_id: UUID, user_id: UUID) -> ProjectDTO:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None or member.role not in {
+                OrganizationMemberRole.OWNER,
+                OrganizationMemberRole.MAKER,
+            }:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+        unpublished = project.unpublish()
+        await self._project_repository.save(unpublished)
+        return ProjectDTO.from_entity(unpublished)

--- a/server/src/raggae/domain/entities/project.py
+++ b/server/src/raggae/domain/entities/project.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from raggae.domain.exceptions.project_exceptions import (
     ProjectAlreadyPublishedError,
+    ProjectNotPublishedError,
     ProjectReindexInProgressError,
 )
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
@@ -49,6 +50,12 @@ class Project:
         if self.is_published:
             raise ProjectAlreadyPublishedError()
         return replace(self, is_published=True)
+
+    def unpublish(self) -> "Project":
+        """Unpublish the project. Raises if not published."""
+        if not self.is_published:
+            raise ProjectNotPublishedError()
+        return replace(self, is_published=False)
 
     def update_prompt(self, new_prompt: str) -> "Project":
         """Return a new Project with an updated system prompt."""

--- a/server/src/raggae/domain/exceptions/project_exceptions.py
+++ b/server/src/raggae/domain/exceptions/project_exceptions.py
@@ -2,6 +2,10 @@ class ProjectAlreadyPublishedError(Exception):
     """Raised when trying to publish an already published project."""
 
 
+class ProjectNotPublishedError(Exception):
+    """Raised when trying to unpublish a project that is not published."""
+
+
 class ProjectNotFoundError(Exception):
     """Raised when a project cannot be found."""
 

--- a/server/src/raggae/domain/exceptions/project_exceptions.py
+++ b/server/src/raggae/domain/exceptions/project_exceptions.py
@@ -26,6 +26,14 @@ class InvalidProjectLLMBackendError(ValueError):
     """Raised when project LLM backend is unsupported."""
 
 
+class InvalidProjectLLMModelError(ValueError):
+    """Raised when project LLM model is not in the allowed list for its backend."""
+
+
+class InvalidProjectEmbeddingModelError(ValueError):
+    """Raised when project embedding model is not in the allowed list for its backend."""
+
+
 class InvalidProjectRetrievalStrategyError(ValueError):
     """Raised when project retrieval strategy is unsupported."""
 

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -90,12 +90,6 @@ from raggae.application.use_cases.document.list_document_chunks import ListDocum
 from raggae.application.use_cases.document.list_project_documents import ListProjectDocuments
 from raggae.application.use_cases.document.reindex_document import ReindexDocument
 from raggae.application.use_cases.document.upload_document import UploadDocument
-from raggae.application.use_cases.project.create_project import CreateProject
-from raggae.application.use_cases.project.delete_project import DeleteProject
-from raggae.application.use_cases.project.get_project import GetProject
-from raggae.application.use_cases.project.list_projects import ListProjects
-from raggae.application.use_cases.project.reindex_project import ReindexProject
-from raggae.application.use_cases.project.update_project import UpdateProject
 from raggae.application.use_cases.organization.accept_organization_invitation import (
     AcceptOrganizationInvitation,
 )
@@ -112,9 +106,6 @@ from raggae.application.use_cases.organization.leave_organization import LeaveOr
 from raggae.application.use_cases.organization.list_organization_invitations import (
     ListOrganizationInvitations,
 )
-from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
-    ListUserPendingOrganizationInvitations,
-)
 from raggae.application.use_cases.organization.list_organization_members import (
     ListOrganizationMembers,
 )
@@ -122,6 +113,9 @@ from raggae.application.use_cases.organization.list_organization_projects import
     ListOrganizationProjects,
 )
 from raggae.application.use_cases.organization.list_organizations import ListOrganizations
+from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
+    ListUserPendingOrganizationInvitations,
+)
 from raggae.application.use_cases.organization.remove_organization_member import (
     RemoveOrganizationMember,
 )
@@ -135,6 +129,14 @@ from raggae.application.use_cases.organization.update_organization import Update
 from raggae.application.use_cases.organization.update_organization_member_role import (
     UpdateOrganizationMemberRole,
 )
+from raggae.application.use_cases.project.create_project import CreateProject
+from raggae.application.use_cases.project.delete_project import DeleteProject
+from raggae.application.use_cases.project.get_project import GetProject
+from raggae.application.use_cases.project.list_projects import ListProjects
+from raggae.application.use_cases.project.publish_project import PublishProject
+from raggae.application.use_cases.project.reindex_project import ReindexProject
+from raggae.application.use_cases.project.unpublish_project import UnpublishProject
+from raggae.application.use_cases.project.update_project import UpdateProject
 from raggae.application.use_cases.provider_credentials.activate_provider_api_key import (
     ActivateProviderApiKey,
 )
@@ -153,9 +155,9 @@ from raggae.application.use_cases.provider_credentials.list_provider_api_keys im
 from raggae.application.use_cases.provider_credentials.save_provider_api_key import (
     SaveProviderApiKey,
 )
+from raggae.application.use_cases.user.get_current_user import GetCurrentUser
 from raggae.application.use_cases.user.login_user import LoginUser
 from raggae.application.use_cases.user.register_user import RegisterUser
-from raggae.application.use_cases.user.get_current_user import GetCurrentUser
 from raggae.application.use_cases.user.update_user_full_name import UpdateUserFullName
 from raggae.infrastructure.config.settings import settings
 from raggae.infrastructure.database.repositories.in_memory_conversation_repository import (
@@ -576,6 +578,20 @@ def get_update_project_use_case() -> UpdateProject:
     ).with_crypto_service(_provider_api_key_crypto_service)
 
 
+def get_publish_project_use_case() -> PublishProject:
+    return PublishProject(
+        project_repository=_project_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_unpublish_project_use_case() -> UnpublishProject:
+    return UnpublishProject(
+        project_repository=_project_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
 def get_reindex_project_use_case() -> ReindexProject:
     return ReindexProject(
         project_repository=_project_repository,
@@ -667,6 +683,7 @@ def get_send_message_use_case() -> SendMessage:
         provider_api_key_resolver=_provider_api_key_resolver,
         project_llm_service_resolver=_project_llm_service_resolver,
         project_reranker_service_resolver=_project_reranker_service_resolver,
+        organization_member_repository=_organization_member_repository,
         llm_provider=settings.default_llm_provider,
         default_chunk_limit=settings.retrieval_default_chunk_limit,
         history_window_size=settings.chat_history_window_size,
@@ -713,6 +730,7 @@ def get_list_conversations_use_case() -> ListConversations:
     return ListConversations(
         project_repository=_project_repository,
         conversation_repository=_conversation_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -723,6 +723,7 @@ def get_list_conversation_messages_use_case() -> ListConversationMessages:
         project_repository=_project_repository,
         conversation_repository=_conversation_repository,
         message_repository=_message_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 
@@ -738,6 +739,7 @@ def get_delete_conversation_use_case() -> DeleteConversation:
     return DeleteConversation(
         project_repository=_project_repository,
         conversation_repository=_conversation_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 
@@ -746,6 +748,7 @@ def get_get_conversation_use_case() -> GetConversation:
         project_repository=_project_repository,
         conversation_repository=_conversation_repository,
         message_repository=_message_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 
@@ -753,6 +756,7 @@ def get_update_conversation_use_case() -> UpdateConversation:
     return UpdateConversation(
         project_repository=_project_repository,
         conversation_repository=_conversation_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/v1/endpoints/model_catalog.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/model_catalog.py
@@ -59,14 +59,9 @@ async def get_model_catalog(
                 ModelEntry(id="gpt-4.1-nano", label="GPT-4.1 Nano (legacy)"),
             ],
             "gemini": [
-                ModelEntry(id="gemini-3-pro", label="Gemini 3 Pro"),
-                ModelEntry(id="gemini-3-flash-preview", label="Gemini 3 Flash (preview)"),
-                ModelEntry(id="gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview)"),
-                ModelEntry(id="gemini-2.5-pro", label="Gemini 2.5 Pro"),
-                ModelEntry(id="gemini-2.5-flash", label="Gemini 2.5 Flash"),
-                ModelEntry(id="gemini-2.5-flash-lite", label="Gemini 2.5 Flash Lite"),
-                ModelEntry(id="gemini-2.0-flash", label="Gemini 2.0 Flash (legacy)"),
-                ModelEntry(id="gemini-2.0-flash-lite", label="Gemini 2.0 Flash Lite (legacy)"),
+                ModelEntry(id="gemini-3.1-pro-preview", label="Gemini 3.1 Pro"),
+                ModelEntry(id="gemini-3-flash-preview", label="Gemini 3 Flash"),
+                ModelEntry(id="gemini-3-deep-think-preview", label="Deep Think"),
             ],
             "anthropic": [
                 ModelEntry(id="claude-opus-4-6-20260205", label="Claude Opus 4.6"),

--- a/server/tests/e2e/test_project_endpoints.py
+++ b/server/tests/e2e/test_project_endpoints.py
@@ -121,7 +121,7 @@ class TestProjectEndpoints:
                 "description": "A test project",
                 "system_prompt": "You are a helpful assistant",
                 "llm_backend": "openai",
-                "llm_model": "gpt-4o-mini",
+                "llm_model": "gpt-4.1-mini",
                 "llm_api_key": "sk-not-owned-1234",
             },
             headers=headers,
@@ -152,7 +152,7 @@ class TestProjectEndpoints:
                 "description": "A test project",
                 "system_prompt": "You are a helpful assistant",
                 "llm_backend": "openai",
-                "llm_model": "gpt-4o-mini",
+                "llm_model": "gpt-4.1-mini",
                 "llm_api_key": "sk-owned-1234",
             },
             headers=headers,
@@ -162,7 +162,7 @@ class TestProjectEndpoints:
         assert response.status_code == 201
         data = response.json()
         assert data["llm_backend"] == "openai"
-        assert data["llm_model"] == "gpt-4o-mini"
+        assert data["llm_model"] == "gpt-4.1-mini"
         assert data["llm_api_key_masked"] is not None
         assert data["llm_api_key_credential_id"] is None
 
@@ -187,7 +187,7 @@ class TestProjectEndpoints:
                 "description": "A test project",
                 "system_prompt": "You are a helpful assistant",
                 "llm_backend": "openai",
-                "llm_model": "gpt-4o-mini",
+                "llm_model": "gpt-4.1-mini",
                 "llm_api_key_credential_id": credential_id,
             },
             headers=headers,
@@ -197,7 +197,7 @@ class TestProjectEndpoints:
         assert response.status_code == 201
         data = response.json()
         assert data["llm_backend"] == "openai"
-        assert data["llm_model"] == "gpt-4o-mini"
+        assert data["llm_model"] == "gpt-4.1-mini"
         assert data["llm_api_key_masked"] is not None
 
     async def test_create_project_with_embedding_api_key_credential_id_returns_201(
@@ -221,7 +221,7 @@ class TestProjectEndpoints:
                 "description": "A test project",
                 "system_prompt": "You are a helpful assistant",
                 "embedding_backend": "gemini",
-                "embedding_model": "text-embedding-004",
+                "embedding_model": "gemini-embedding-001",
                 "embedding_api_key_credential_id": credential_id,
             },
             headers=headers,
@@ -231,7 +231,7 @@ class TestProjectEndpoints:
         assert response.status_code == 201
         data = response.json()
         assert data["embedding_backend"] == "gemini"
-        assert data["embedding_model"] == "text-embedding-004"
+        assert data["embedding_model"] == "gemini-embedding-001"
         assert data["embedding_api_key_masked"] is not None
 
     async def test_create_project_with_llm_api_key_and_credential_id_returns_422(
@@ -255,7 +255,7 @@ class TestProjectEndpoints:
                 "description": "A test project",
                 "system_prompt": "You are a helpful assistant",
                 "llm_backend": "openai",
-                "llm_model": "gpt-4o-mini",
+                "llm_model": "gpt-4.1-mini",
                 "llm_api_key": "sk-owned-by-id-5678",
                 "llm_api_key_credential_id": credential_id,
             },
@@ -535,7 +535,7 @@ class TestProjectEndpoints:
                 "description": "Updated description",
                 "system_prompt": "Updated prompt",
                 "llm_backend": "openai",
-                "llm_model": "gpt-4o-mini",
+                "llm_model": "gpt-4.1-mini",
                 "llm_api_key_credential_id": credential_id,
             },
             headers=headers,
@@ -572,7 +572,7 @@ class TestProjectEndpoints:
                 "description": "Updated description",
                 "system_prompt": "Updated prompt",
                 "embedding_backend": "gemini",
-                "embedding_model": "text-embedding-004",
+                "embedding_model": "gemini-embedding-001",
                 "embedding_api_key_credential_id": credential_id,
             },
             headers=headers,
@@ -609,7 +609,7 @@ class TestProjectEndpoints:
                 "description": "Updated description",
                 "system_prompt": "Updated prompt",
                 "embedding_backend": "gemini",
-                "embedding_model": "text-embedding-004",
+                "embedding_model": "gemini-embedding-001",
                 "embedding_api_key": "AIza-update-by-id-5678",
                 "embedding_api_key_credential_id": credential_id,
             },

--- a/server/tests/unit/application/use_cases/chat/test_delete_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_delete_conversation_org_access.py
@@ -1,0 +1,161 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.chat.delete_conversation import DeleteConversation
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_org_project(org_id: uuid4, is_published: bool = False) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=org_id,
+        name="Org project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_conversation(project_id: uuid4, user_id: uuid4) -> Conversation:
+    return Conversation(
+        id=uuid4(),
+        project_id=project_id,
+        user_id=user_id,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_org_member_repo(org_id: uuid4, user_id: uuid4, role: OrganizationMemberRole) -> AsyncMock:
+    member = OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+    repo = AsyncMock()
+    repo.find_by_organization_and_user.return_value = member
+    return repo
+
+
+class TestDeleteConversationOrgAccess:
+    async def test_owner_role_can_delete_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = DeleteConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        conversation_repo.delete.assert_awaited_once_with(conversation.id)
+
+    async def test_maker_role_can_delete_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = DeleteConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        conversation_repo.delete.assert_awaited_once_with(conversation.id)
+
+    async def test_user_role_published_project_can_delete_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=True)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = DeleteConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        conversation_repo.delete.assert_awaited_once_with(conversation.id)
+
+    async def test_user_role_unpublished_project_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=False)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        use_case = DeleteConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=user_id,
+            )
+
+    async def test_non_member_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_org_project(org_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        member_repo = AsyncMock(find_by_organization_and_user=AsyncMock(return_value=None))
+        use_case = DeleteConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=uuid4(),
+            )

--- a/server/tests/unit/application/use_cases/chat/test_get_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_get_conversation_org_access.py
@@ -1,0 +1,187 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.chat.get_conversation import GetConversation
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_org_project(org_id: uuid4) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=org_id,
+        name="Org project",
+        description="",
+        system_prompt="",
+        is_published=False,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_conversation(project_id: uuid4, user_id: uuid4) -> Conversation:
+    return Conversation(
+        id=uuid4(),
+        project_id=project_id,
+        user_id=user_id,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_org_member_repo(org_id: uuid4, user_id: uuid4, role: OrganizationMemberRole) -> AsyncMock:
+    member = OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+    repo = AsyncMock()
+    repo.find_by_organization_and_user.return_value = member
+    return repo
+
+
+class TestGetConversationOrgAccess:
+    async def test_owner_role_can_get_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(
+            count_by_conversation_id=AsyncMock(return_value=0),
+            find_latest_by_conversation_id=AsyncMock(return_value=None),
+        )
+        use_case = GetConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result.id == conversation.id
+
+    async def test_maker_role_can_get_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(
+            count_by_conversation_id=AsyncMock(return_value=0),
+            find_latest_by_conversation_id=AsyncMock(return_value=None),
+        )
+        use_case = GetConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result.id == conversation.id
+
+    async def test_user_role_published_project_can_get_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            organization_id=org_id,
+            name="Published",
+            description="",
+            system_prompt="",
+            is_published=True,
+            created_at=datetime.now(UTC),
+        )
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(
+            count_by_conversation_id=AsyncMock(return_value=0),
+            find_latest_by_conversation_id=AsyncMock(return_value=None),
+        )
+        use_case = GetConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result.id == conversation.id
+
+    async def test_user_role_unpublished_project_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)  # is_published=False
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        use_case = GetConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            message_repository=AsyncMock(),
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=user_id,
+            )
+
+    async def test_non_member_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_org_project(org_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        member_repo = AsyncMock(find_by_organization_and_user=AsyncMock(return_value=None))
+        use_case = GetConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            message_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=uuid4(),
+            )

--- a/server/tests/unit/application/use_cases/chat/test_list_conversation_messages_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversation_messages_org_access.py
@@ -1,0 +1,169 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.chat.list_conversation_messages import ListConversationMessages
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_org_project(org_id: uuid4, is_published: bool = False) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=org_id,
+        name="Org project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_conversation(project_id: uuid4, user_id: uuid4) -> Conversation:
+    return Conversation(
+        id=uuid4(),
+        project_id=project_id,
+        user_id=user_id,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_org_member_repo(org_id: uuid4, user_id: uuid4, role: OrganizationMemberRole) -> AsyncMock:
+    member = OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+    repo = AsyncMock()
+    repo.find_by_organization_and_user.return_value = member
+    return repo
+
+
+class TestListConversationMessagesOrgAccess:
+    async def test_owner_role_can_list_messages_of_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(find_by_conversation_id=AsyncMock(return_value=[]))
+        use_case = ListConversationMessages(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result == []
+
+    async def test_maker_role_can_list_messages_of_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(find_by_conversation_id=AsyncMock(return_value=[]))
+        use_case = ListConversationMessages(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result == []
+
+    async def test_user_role_published_project_can_list_messages(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=True)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        message_repo = AsyncMock(find_by_conversation_id=AsyncMock(return_value=[]))
+        use_case = ListConversationMessages(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            message_repository=message_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When
+        result = await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+        )
+
+        # Then
+        assert result == []
+
+    async def test_user_role_unpublished_project_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=False)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        use_case = ListConversationMessages(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            message_repository=AsyncMock(),
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=user_id,
+            )
+
+    async def test_non_member_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_org_project(org_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        member_repo = AsyncMock(find_by_organization_and_user=AsyncMock(return_value=None))
+        use_case = ListConversationMessages(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            message_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=uuid4(),
+            )

--- a/server/tests/unit/application/use_cases/chat/test_list_conversations_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversations_org_access.py
@@ -1,0 +1,130 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from raggae.application.use_cases.chat.list_conversations import ListConversations
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_project(user_id=None, organization_id=None, is_published=True) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=user_id or uuid4(),
+        name="Project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_member(org_id, user_id, role: OrganizationMemberRole) -> OrganizationMember:
+    return OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+
+
+class TestListConversationsOrgAccess:
+    async def test_list_conversations_as_org_user_on_published_project_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=True)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        conversation_repo = AsyncMock()
+        conversation_repo.find_by_project_and_user.return_value = [
+            Conversation(
+                id=uuid4(),
+                project_id=project.id,
+                user_id=user_id,
+                created_at=datetime.now(UTC),
+            )
+        ]
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = ListConversations(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert len(result) == 1
+
+    async def test_list_conversations_as_org_user_on_unpublished_project_raises_not_found(
+        self,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=False)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = ListConversations(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=org_member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, user_id=user_id)
+
+    async def test_list_conversations_as_org_maker_on_unpublished_project_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=False)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.MAKER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        conversation_repo = AsyncMock()
+        conversation_repo.find_by_project_and_user.return_value = []
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = ListConversations(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When / Then (no exception)
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+        assert result == []
+
+    async def test_list_conversations_non_member_raises_not_found(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=True)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = None
+        use_case = ListConversations(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=org_member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, user_id=user_id)

--- a/server/tests/unit/application/use_cases/chat/test_send_message_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message_org_access.py
@@ -1,0 +1,141 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from raggae.application.dto.query_relevant_chunks_result_dto import QueryRelevantChunksResultDTO
+from raggae.application.use_cases.chat.send_message import SendMessage
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_project(user_id=None, organization_id=None, is_published=True) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=user_id or uuid4(),
+        name="Project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_member(org_id, user_id, role: OrganizationMemberRole) -> OrganizationMember:
+    return OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+
+
+def _make_use_case(project: Project, org_member_repo=None) -> SendMessage:
+    query_use_case = AsyncMock()
+    query_use_case.execute.return_value = QueryRelevantChunksResultDTO(
+        chunks=[], strategy_used="hybrid", execution_time_ms=1.0
+    )
+    llm_service = AsyncMock()
+    llm_service.generate_answer.return_value = "answer"
+    conversation_repository = AsyncMock()
+    conversation_repository.find_by_project_and_user.return_value = []
+    conversation_repository.create.return_value = Conversation(
+        id=uuid4(),
+        project_id=project.id,
+        user_id=uuid4(),
+        created_at=datetime.now(UTC),
+    )
+    message_repository = AsyncMock()
+    message_repository.count_by_conversation_id.return_value = 0
+    message_repository.find_by_conversation_id.return_value = []
+    project_repository = AsyncMock()
+    project_repository.find_by_id.return_value = project
+    title_generator = AsyncMock()
+    title_generator.generate_title.return_value = "Title"
+    return SendMessage(
+        query_relevant_chunks_use_case=query_use_case,
+        llm_service=llm_service,
+        conversation_title_generator=title_generator,
+        project_repository=project_repository,
+        conversation_repository=conversation_repository,
+        message_repository=message_repository,
+        organization_member_repository=org_member_repo,
+    )
+
+
+class TestSendMessageOrgAccess:
+    async def test_send_message_as_org_user_on_published_project_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=True)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = _make_use_case(project, org_member_repo)
+
+        # When / Then (no exception)
+        result = await use_case.execute(
+            project_id=project.id,
+            user_id=user_id,
+            message="hello",
+        )
+        assert result is not None
+
+    async def test_send_message_as_org_user_on_unpublished_project_raises_not_found(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=False)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = _make_use_case(project, org_member_repo)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                user_id=user_id,
+                message="hello",
+            )
+
+    async def test_send_message_as_org_maker_on_unpublished_project_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=False)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.MAKER)
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = _make_use_case(project, org_member_repo)
+
+        # When / Then (no exception)
+        result = await use_case.execute(
+            project_id=project.id,
+            user_id=user_id,
+            message="hello",
+        )
+        assert result is not None
+
+    async def test_send_message_as_non_member_raises_not_found(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id, is_published=True)
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = None
+        use_case = _make_use_case(project, org_member_repo)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                user_id=user_id,
+                message="hello",
+            )

--- a/server/tests/unit/application/use_cases/chat/test_update_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_update_conversation_org_access.py
@@ -1,0 +1,167 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.chat.update_conversation import UpdateConversation
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_org_project(org_id: uuid4, is_published: bool = False) -> Project:
+    return Project(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=org_id,
+        name="Org project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+    )
+
+
+def _make_conversation(project_id: uuid4, user_id: uuid4) -> Conversation:
+    return Conversation(
+        id=uuid4(),
+        project_id=project_id,
+        user_id=user_id,
+        created_at=datetime.now(UTC),
+        title="Old title",
+    )
+
+
+def _make_org_member_repo(org_id: uuid4, user_id: uuid4, role: OrganizationMemberRole) -> AsyncMock:
+    member = OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+    repo = AsyncMock()
+    repo.find_by_organization_and_user.return_value = member
+    return repo
+
+
+class TestUpdateConversationOrgAccess:
+    async def test_owner_role_can_update_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = UpdateConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+            title="New title",
+        )
+
+        # Then
+        conversation_repo.update_title.assert_awaited_once_with(conversation.id, "New title")
+
+    async def test_maker_role_can_update_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = UpdateConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+            title="New title",
+        )
+
+        # Then
+        conversation_repo.update_title.assert_awaited_once_with(conversation.id, "New title")
+
+    async def test_user_role_published_project_can_update_own_conversation(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=True)
+        conversation = _make_conversation(project.id, user_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        conversation_repo = AsyncMock(find_by_id=AsyncMock(return_value=conversation))
+        use_case = UpdateConversation(
+            project_repository=project_repo,
+            conversation_repository=conversation_repo,
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project.id,
+            conversation_id=conversation.id,
+            user_id=user_id,
+            title="New title",
+        )
+
+        # Then
+        conversation_repo.update_title.assert_awaited_once_with(conversation.id, "New title")
+
+    async def test_user_role_unpublished_project_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_org_project(org_id, is_published=False)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        use_case = UpdateConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=user_id,
+                title="New title",
+            )
+
+    async def test_non_member_raises(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_org_project(org_id)
+        project_repo = AsyncMock(find_by_id=AsyncMock(return_value=project))
+        member_repo = AsyncMock(find_by_organization_and_user=AsyncMock(return_value=None))
+        use_case = UpdateConversation(
+            project_repository=project_repo,
+            conversation_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=project.id,
+                conversation_id=uuid4(),
+                user_id=uuid4(),
+                title="New title",
+            )

--- a/server/tests/unit/application/use_cases/organization/test_list_organization_projects.py
+++ b/server/tests/unit/application/use_cases/organization/test_list_organization_projects.py
@@ -75,6 +75,133 @@ class TestListOrganizationProjects:
         assert len(projects) == 1
         assert projects[0].organization_id == organization.id
 
+    async def test_list_projects_user_role_returns_only_published(self) -> None:
+        org_repo = InMemoryOrganizationRepository()
+        member_repo = InMemoryOrganizationMemberRepository()
+        project_repo = InMemoryProjectRepository()
+        use_case = ListOrganizationProjects(
+            organization_repository=org_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+        now = datetime.now(UTC)
+        user_id = uuid4()
+        organization = Organization(
+            id=uuid4(),
+            name="Acme",
+            slug=None,
+            description=None,
+            logo_url=None,
+            created_by_user_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        await org_repo.save(organization)
+        await member_repo.save(
+            OrganizationMember(
+                id=uuid4(),
+                organization_id=organization.id,
+                user_id=user_id,
+                role=OrganizationMemberRole.USER,
+                joined_at=now,
+            )
+        )
+        await project_repo.save(
+            Project(
+                id=uuid4(),
+                user_id=uuid4(),
+                organization_id=organization.id,
+                name="Published project",
+                description="",
+                system_prompt="",
+                is_published=True,
+                created_at=now,
+            )
+        )
+        await project_repo.save(
+            Project(
+                id=uuid4(),
+                user_id=uuid4(),
+                organization_id=organization.id,
+                name="Unpublished project",
+                description="",
+                system_prompt="",
+                is_published=False,
+                created_at=now,
+            )
+        )
+
+        # Given a USER role member
+        # When listing organization projects
+        projects = await use_case.execute(organization_id=organization.id, user_id=user_id)
+
+        # Then only published projects are returned
+        assert len(projects) == 1
+        assert projects[0].name == "Published project"
+
+    async def test_list_projects_maker_role_returns_all_projects(self) -> None:
+        org_repo = InMemoryOrganizationRepository()
+        member_repo = InMemoryOrganizationMemberRepository()
+        project_repo = InMemoryProjectRepository()
+        use_case = ListOrganizationProjects(
+            organization_repository=org_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+        now = datetime.now(UTC)
+        user_id = uuid4()
+        organization = Organization(
+            id=uuid4(),
+            name="Acme",
+            slug=None,
+            description=None,
+            logo_url=None,
+            created_by_user_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        await org_repo.save(organization)
+        await member_repo.save(
+            OrganizationMember(
+                id=uuid4(),
+                organization_id=organization.id,
+                user_id=user_id,
+                role=OrganizationMemberRole.MAKER,
+                joined_at=now,
+            )
+        )
+        await project_repo.save(
+            Project(
+                id=uuid4(),
+                user_id=uuid4(),
+                organization_id=organization.id,
+                name="Published project",
+                description="",
+                system_prompt="",
+                is_published=True,
+                created_at=now,
+            )
+        )
+        await project_repo.save(
+            Project(
+                id=uuid4(),
+                user_id=uuid4(),
+                organization_id=organization.id,
+                name="Unpublished project",
+                description="",
+                system_prompt="",
+                is_published=False,
+                created_at=now,
+            )
+        )
+
+        # Given a MAKER role member
+        # When listing organization projects
+        projects = await use_case.execute(organization_id=organization.id, user_id=user_id)
+
+        # Then all projects (published and unpublished) are returned
+        assert len(projects) == 2
+
     async def test_list_projects_for_non_member_raises(self) -> None:
         org_repo = InMemoryOrganizationRepository()
         member_repo = InMemoryOrganizationMemberRepository()

--- a/server/tests/unit/application/use_cases/project/test_publish_project.py
+++ b/server/tests/unit/application/use_cases/project/test_publish_project.py
@@ -1,0 +1,145 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from raggae.application.use_cases.project.publish_project import PublishProject
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import (
+    ProjectAlreadyPublishedError,
+    ProjectNotFoundError,
+)
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_project(
+    project_id=None,
+    user_id=None,
+    organization_id=None,
+    is_published=False,
+) -> Project:
+    return Project(
+        id=project_id or uuid4(),
+        user_id=user_id or uuid4(),
+        name="Test Project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_member(org_id, user_id, role: OrganizationMemberRole) -> OrganizationMember:
+    return OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+
+
+class TestPublishProject:
+    async def test_publish_project_as_creator_succeeds(self) -> None:
+        # Given
+        user_id = uuid4()
+        project = _make_project(user_id=user_id)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        use_case = PublishProject(project_repository=project_repo)
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is True
+        project_repo.save.assert_called_once()
+
+    async def test_publish_project_as_org_owner_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.OWNER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = PublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is True
+        project_repo.save.assert_called_once()
+
+    async def test_publish_project_as_org_maker_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.MAKER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = PublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is True
+        project_repo.save.assert_called_once()
+
+    async def test_publish_project_as_org_user_raises_not_found(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = PublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, user_id=user_id)
+        project_repo.save.assert_not_called()
+
+    async def test_publish_project_not_found_raises_error(self) -> None:
+        # Given
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = None
+        use_case = PublishProject(project_repository=project_repo)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=uuid4(), user_id=uuid4())
+
+    async def test_publish_already_published_project_raises_error(self) -> None:
+        # Given
+        user_id = uuid4()
+        project = _make_project(user_id=user_id, is_published=True)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        use_case = PublishProject(project_repository=project_repo)
+
+        # When / Then
+        with pytest.raises(ProjectAlreadyPublishedError):
+            await use_case.execute(project_id=project.id, user_id=user_id)
+        project_repo.save.assert_not_called()

--- a/server/tests/unit/application/use_cases/project/test_unpublish_project.py
+++ b/server/tests/unit/application/use_cases/project/test_unpublish_project.py
@@ -1,0 +1,145 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from raggae.application.use_cases.project.unpublish_project import UnpublishProject
+from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import (
+    ProjectNotFoundError,
+    ProjectNotPublishedError,
+)
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_project(
+    project_id=None,
+    user_id=None,
+    organization_id=None,
+    is_published=True,
+) -> Project:
+    return Project(
+        id=project_id or uuid4(),
+        user_id=user_id or uuid4(),
+        name="Test Project",
+        description="",
+        system_prompt="",
+        is_published=is_published,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_member(org_id, user_id, role: OrganizationMemberRole) -> OrganizationMember:
+    return OrganizationMember(
+        id=uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
+    )
+
+
+class TestUnpublishProject:
+    async def test_unpublish_project_as_creator_succeeds(self) -> None:
+        # Given
+        user_id = uuid4()
+        project = _make_project(user_id=user_id)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        use_case = UnpublishProject(project_repository=project_repo)
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is False
+        project_repo.save.assert_called_once()
+
+    async def test_unpublish_project_as_org_owner_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.OWNER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = UnpublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is False
+        project_repo.save.assert_called_once()
+
+    async def test_unpublish_project_as_org_maker_succeeds(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.MAKER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = UnpublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=user_id)
+
+        # Then
+        assert result.is_published is False
+        project_repo.save.assert_called_once()
+
+    async def test_unpublish_project_as_org_user_raises_not_found(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        member = _make_member(org_id, user_id, OrganizationMemberRole.USER)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        org_member_repo = AsyncMock()
+        org_member_repo.find_by_organization_and_user.return_value = member
+        use_case = UnpublishProject(
+            project_repository=project_repo,
+            organization_member_repository=org_member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, user_id=user_id)
+        project_repo.save.assert_not_called()
+
+    async def test_unpublish_project_not_found_raises_error(self) -> None:
+        # Given
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = None
+        use_case = UnpublishProject(project_repository=project_repo)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=uuid4(), user_id=uuid4())
+
+    async def test_unpublish_not_published_project_raises_error(self) -> None:
+        # Given
+        user_id = uuid4()
+        project = _make_project(user_id=user_id, is_published=False)
+        project_repo = AsyncMock()
+        project_repo.find_by_id.return_value = project
+        use_case = UnpublishProject(project_repository=project_repo)
+
+        # When / Then
+        with pytest.raises(ProjectNotPublishedError):
+            await use_case.execute(project_id=project.id, user_id=user_id)
+        project_repo.save.assert_not_called()


### PR DESCRIPTION
### 🍣 Problème

Il n'existait aucun mécanisme pour rendre un projet accessible publiquement au sein d'une organisation. De plus, plusieurs failles de contrôle d'accès avaient été identifiées :

  - Les membres avec le rôle USER pouvaient voir tous les projets d'une organisation, y compris ceux non publiés.
  - Les membres d'une organisation ne pouvaient pas accéder à leurs propres conversations sur les projets de l'org (blocage par la vérification project.user_id != user_id).
  - En cas d'échec de génération LLM, le message d'erreur affiché était générique et n'aidait pas au diagnostic.
  - Les modèles LLM/embedding saisis librement permettaient de configurer des identifiants inexistants (ex. gemini-3-pro), provoquant silencieusement des erreurs à l'exécution.

### 🚀 Solution

  - Ajout d'un cycle de vie publish / unpublish sur les projets, avec contrôle d'accès basé sur le rôle dans l'organisation.
  - Mise en place d'un onglet Publication dans les settings projet côté front-end.
  - Validation stricte des modèles LLM et embedding à la sauvegarde du projet.
  - Propagation du message d'erreur réel du provider LLM dans la réponse.

### 💡 Implémentation

#### Back-end (Clean Architecture)

  - domain : méthodes Project.publish() / Project.unpublish(), nouvelles exceptions ProjectAlreadyPublishedError, ProjectNotPublishedError, InvalidProjectLLMModelError,
  InvalidProjectEmbeddingModelError
  - application : use cases PublishProject, UnpublishProject ; contrôle d'accès org dans SendMessage, ListConversations, GetConversation, ListConversationMessages, DeleteConversation,
  UpdateConversation, ListOrganizationProjects ; constantes ALLOWED_LLM_MODELS / ALLOWED_EMBEDDING_MODELS ; validation dans UpdateProject
  - presentation : endpoints POST /projects/{id}/publish et POST /projects/{id}/unpublish ; mise à jour du catalogue de modèles Gemini
  - 40+ tests unitaires et e2e ajoutés ou mis à jour

#### Front-end

  - Fonctions API publishProject / unpublishProject et hooks usePublishProject / useUnpublishProject
  - Onglet "Publication" : badge de statut, URL publique copiable, boutons Publish/Unpublish avec dialog de confirmation et toasts sonner
  - Réorganisation des onglets de settings (Knowledge indexing avant Document ingestion)