### PR TITLE
feat(credentials): org-level API key management

### DIFF
--- a/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/hooks/use-projects";
 import { useModelCatalog } from "@/lib/hooks/use-model-catalog";
 import { useModelCredentials } from "@/lib/hooks/use-model-credentials";
+import { useOrgModelCredentials } from "@/lib/hooks/use-org-model-credentials";
 import type {
   ChunkingStrategy,
   ModelProvider,
@@ -66,7 +67,9 @@ export default function ProjectSettingsPage() {
   const { data: documents, isLoading: isDocumentsLoading } = useDocuments(params.projectId);
   const { data: modelCatalog } = useModelCatalog();
   const updateProject = useUpdateProject(params.projectId);
-  const { data: credentials } = useModelCredentials();
+  const { data: userCredentials } = useModelCredentials();
+  const { data: orgCredentials } = useOrgModelCredentials(project?.organization_id);
+  const credentials = project?.organization_id ? orgCredentials : userCredentials;
   const reindexProject = useReindexProject(params.projectId);
   const publishProject = usePublishProject(params.projectId);
   const unpublishProject = useUnpublishProject(params.projectId);

--- a/client/src/components/organizations/org-credentials-panel.tsx
+++ b/client/src/components/organizations/org-credentials-panel.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  useActivateOrgModelCredential,
+  useCreateOrgModelCredential,
+  useDeactivateOrgModelCredential,
+  useDeleteOrgModelCredential,
+  useOrgModelCredentials,
+} from "@/lib/hooks/use-org-model-credentials";
+import type { ModelProvider } from "@/lib/types/api";
+
+const PROVIDERS: Array<{ value: ModelProvider; label: string; placeholder: string }> = [
+  { value: "openai", label: "OpenAI", placeholder: "sk-..." },
+  { value: "gemini", label: "Gemini", placeholder: "AIza..." },
+  { value: "anthropic", label: "Anthropic", placeholder: "sk-ant-..." },
+];
+
+type OrgCredentialsPanelProps = {
+  organizationId: string;
+};
+
+export function OrgCredentialsPanel({ organizationId }: OrgCredentialsPanelProps) {
+  const { data: credentials, isLoading } = useOrgModelCredentials(organizationId);
+  const createCredential = useCreateOrgModelCredential(organizationId);
+  const activateCredential = useActivateOrgModelCredential(organizationId);
+  const deactivateCredential = useDeactivateOrgModelCredential(organizationId);
+  const deleteCredential = useDeleteOrgModelCredential(organizationId);
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalProvider, setModalProvider] = useState<ModelProvider>("openai");
+  const [modalApiKey, setModalApiKey] = useState("");
+
+  function handleModalOpenChange(open: boolean) {
+    setModalOpen(open);
+    if (!open) setModalApiKey("");
+  }
+
+  function handleSave() {
+    const apiKey = modalApiKey.trim();
+    if (!apiKey) return;
+    createCredential.mutate(
+      { provider: modalProvider, api_key: apiKey },
+      {
+        onSuccess: () => {
+          toast.success(`${modalProvider} API key saved`);
+          setModalOpen(false);
+          setModalApiKey("");
+        },
+        onError: (error) => {
+          toast.error((error as Error).message || "Failed to save API key");
+        },
+      },
+    );
+  }
+
+  function handleToggleActive(credentialId: string, currentlyActive: boolean) {
+    if (currentlyActive) {
+      deactivateCredential.mutate(credentialId, {
+        onSuccess: () => toast.success("API key deactivated"),
+        onError: (error) => toast.error((error as Error).message || "Failed to deactivate API key"),
+      });
+    } else {
+      activateCredential.mutate(credentialId, {
+        onSuccess: () => toast.success("API key activated"),
+        onError: () => toast.error("Failed to activate API key"),
+      });
+    }
+  }
+
+  function handleDelete(credentialId: string) {
+    deleteCredential.mutate(credentialId, {
+      onSuccess: () => toast.success("API key deleted"),
+      onError: () => toast.error("Failed to delete API key"),
+    });
+  }
+
+  const providerPlaceholder =
+    PROVIDERS.find((p) => p.value === modalProvider)?.placeholder ?? "";
+
+  return (
+    <Card className="space-y-4 p-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-medium">AI provider API keys</h2>
+          <p className="text-sm text-muted-foreground">
+            Add keys for OpenAI, Gemini, or Anthropic. Only one key per provider can be active at a time.
+          </p>
+        </div>
+        <Button
+          type="button"
+          className="shrink-0 cursor-pointer"
+          onClick={() => setModalOpen(true)}
+        >
+          Add a key
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-14 w-full" />
+      ) : credentials?.length ? (
+        <div className="space-y-2">
+          {credentials.map((item) => {
+            const providerLabel =
+              PROVIDERS.find((p) => p.value === item.provider)?.label ?? item.provider;
+            return (
+              <div
+                key={item.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium">
+                    {providerLabel}
+                  </span>
+                  <p className="text-sm font-medium">{item.masked_key}</p>
+                  <span className="text-xs text-muted-foreground">
+                    {new Date(item.created_at).toLocaleDateString()}
+                  </span>
+                  <span
+                    className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                      item.is_active
+                        ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                        : "bg-muted text-muted-foreground"
+                    }`}
+                  >
+                    {item.is_active ? "Active" : "Inactive"}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={item.is_active}
+                    disabled={activateCredential.isPending || deactivateCredential.isPending}
+                    onCheckedChange={() => handleToggleActive(item.id, item.is_active)}
+                  />
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="sm"
+                    className="cursor-pointer"
+                    disabled={deleteCredential.isPending}
+                    onClick={() => handleDelete(item.id)}
+                  >
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">No API key saved yet.</p>
+      )}
+
+      <Dialog open={modalOpen} onOpenChange={handleModalOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add an API key</DialogTitle>
+            <DialogDescription>
+              Select a provider then paste your API key.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="org-modal-provider">Provider</Label>
+              <select
+                id="org-modal-provider"
+                value={modalProvider}
+                onChange={(e) => setModalProvider(e.target.value as ModelProvider)}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+              >
+                {PROVIDERS.map((p) => (
+                  <option key={p.value} value={p.value}>
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="org-modal-api-key">API key</Label>
+              <Input
+                id="org-modal-api-key"
+                type="password"
+                placeholder={providerPlaceholder}
+                value={modalApiKey}
+                onChange={(e) => setModalApiKey(e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+
+          <DialogFooter showCloseButton>
+            <Button
+              type="button"
+              className="cursor-pointer"
+              disabled={!modalApiKey.trim() || createCredential.isPending}
+              onClick={handleSave}
+            >
+              Save key
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/client/src/lib/api/org-model-credentials.ts
+++ b/client/src/lib/api/org-model-credentials.ts
@@ -1,0 +1,59 @@
+import { apiFetch } from "@/lib/api/client";
+import type {
+  OrgModelCredentialResponse,
+  SaveModelCredentialRequest,
+} from "@/lib/types/api";
+
+export function listOrgModelCredentials(
+  token: string,
+  organizationId: string,
+): Promise<OrgModelCredentialResponse[]> {
+  return apiFetch<OrgModelCredentialResponse[]>(
+    `/organizations/${organizationId}/model-credentials`,
+    { token },
+  );
+}
+
+export function createOrgModelCredential(
+  token: string,
+  organizationId: string,
+  data: SaveModelCredentialRequest,
+): Promise<OrgModelCredentialResponse> {
+  return apiFetch<OrgModelCredentialResponse>(
+    `/organizations/${organizationId}/model-credentials`,
+    { method: "POST", token, body: JSON.stringify(data) },
+  );
+}
+
+export function activateOrgModelCredential(
+  token: string,
+  organizationId: string,
+  credentialId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/organizations/${organizationId}/model-credentials/${credentialId}/activate`,
+    { method: "PATCH", token },
+  );
+}
+
+export function deactivateOrgModelCredential(
+  token: string,
+  organizationId: string,
+  credentialId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/organizations/${organizationId}/model-credentials/${credentialId}/deactivate`,
+    { method: "PATCH", token },
+  );
+}
+
+export function deleteOrgModelCredential(
+  token: string,
+  organizationId: string,
+  credentialId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/organizations/${organizationId}/model-credentials/${credentialId}`,
+    { method: "DELETE", token },
+  );
+}

--- a/client/src/lib/hooks/use-org-model-credentials.ts
+++ b/client/src/lib/hooks/use-org-model-credentials.ts
@@ -11,13 +11,13 @@ import {
 import type { SaveModelCredentialRequest } from "@/lib/types/api";
 import { useAuth } from "./use-auth";
 
-export function useOrgModelCredentials(organizationId: string) {
+export function useOrgModelCredentials(organizationId: string | null | undefined) {
   const { token } = useAuth();
 
   return useQuery({
     queryKey: ["org-model-credentials", organizationId],
-    queryFn: () => listOrgModelCredentials(token!, organizationId),
-    enabled: !!token,
+    queryFn: () => listOrgModelCredentials(token!, organizationId!),
+    enabled: !!token && !!organizationId,
   });
 }
 

--- a/client/src/lib/hooks/use-org-model-credentials.ts
+++ b/client/src/lib/hooks/use-org-model-credentials.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  activateOrgModelCredential,
+  createOrgModelCredential,
+  deactivateOrgModelCredential,
+  deleteOrgModelCredential,
+  listOrgModelCredentials,
+} from "@/lib/api/org-model-credentials";
+import type { SaveModelCredentialRequest } from "@/lib/types/api";
+import { useAuth } from "./use-auth";
+
+export function useOrgModelCredentials(organizationId: string) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: ["org-model-credentials", organizationId],
+    queryFn: () => listOrgModelCredentials(token!, organizationId),
+    enabled: !!token,
+  });
+}
+
+export function useCreateOrgModelCredential(organizationId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: SaveModelCredentialRequest) =>
+      createOrgModelCredential(token!, organizationId, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-model-credentials", organizationId] });
+    },
+  });
+}
+
+export function useActivateOrgModelCredential(organizationId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (credentialId: string) =>
+      activateOrgModelCredential(token!, organizationId, credentialId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-model-credentials", organizationId] });
+    },
+  });
+}
+
+export function useDeactivateOrgModelCredential(organizationId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (credentialId: string) =>
+      deactivateOrgModelCredential(token!, organizationId, credentialId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-model-credentials", organizationId] });
+    },
+  });
+}
+
+export function useDeleteOrgModelCredential(organizationId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (credentialId: string) =>
+      deleteOrgModelCredential(token!, organizationId, credentialId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["org-model-credentials", organizationId] });
+    },
+  });
+}

--- a/client/src/lib/types/api.ts
+++ b/client/src/lib/types/api.ts
@@ -345,6 +345,16 @@ export interface ModelCredentialResponse {
   updated_at: string;
 }
 
+export interface OrgModelCredentialResponse {
+  id: string;
+  organization_id: string;
+  provider: ModelProvider;
+  masked_key: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface ModelEntry {
   id: string;
   label: string;

--- a/server/alembic/versions/20260301_34_drop_unique_active_user_credential_per_provider.py
+++ b/server/alembic/versions/20260301_34_drop_unique_active_user_credential_per_provider.py
@@ -18,11 +18,8 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.drop_index(
-        "uq_user_provider_active_credential",
-        table_name="user_model_provider_credentials",
-        postgresql_where=sa.text("is_active = true"),
-    )
+    # Index already dropped in migration 20260224_24 — no-op
+    pass
 
 
 def downgrade() -> None:

--- a/server/alembic/versions/20260301_34_drop_unique_active_user_credential_per_provider.py
+++ b/server/alembic/versions/20260301_34_drop_unique_active_user_credential_per_provider.py
@@ -1,0 +1,35 @@
+"""drop unique active user credential per provider
+
+Revision ID: 20260301_34
+Revises: 20260226_33
+Create Date: 2026-03-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260301_34"
+down_revision: str | None = "20260226_33"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        "uq_user_provider_active_credential",
+        table_name="user_model_provider_credentials",
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+
+def downgrade() -> None:
+    op.create_index(
+        "uq_user_provider_active_credential",
+        "user_model_provider_credentials",
+        ["user_id", "provider"],
+        unique=True,
+        postgresql_where=sa.text("is_active = true"),
+    )

--- a/server/alembic/versions/20260301_35_add_org_model_provider_credentials.py
+++ b/server/alembic/versions/20260301_35_add_org_model_provider_credentials.py
@@ -1,0 +1,64 @@
+"""add org model provider credentials
+
+Revision ID: 20260301_35
+Revises: 20260301_34
+Create Date: 2026-03-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260301_35"
+down_revision: str | None = "20260301_34"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_model_provider_credentials",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("encrypted_api_key", sa.Text(), nullable=False),
+        sa.Column("key_fingerprint", sa.String(length=128), nullable=False),
+        sa.Column("key_suffix", sa.String(length=16), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_org_model_provider_credentials_organization_id",
+        "org_model_provider_credentials",
+        ["organization_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_org_model_provider_credentials_provider",
+        "org_model_provider_credentials",
+        ["provider"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_org_model_provider_credentials_provider",
+        table_name="org_model_provider_credentials",
+    )
+    op.drop_index(
+        "ix_org_model_provider_credentials_organization_id",
+        table_name="org_model_provider_credentials",
+    )
+    op.drop_table("org_model_provider_credentials")

--- a/server/alembic/versions/20260301_36_add_org_credential_ids_to_projects.py
+++ b/server/alembic/versions/20260301_36_add_org_credential_ids_to_projects.py
@@ -1,0 +1,60 @@
+"""add org credential ids to projects
+
+Revision ID: 20260301_36
+Revises: 20260301_35
+Create Date: 2026-03-01
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260301_36"
+down_revision: str | None = "20260301_35"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "projects",
+        sa.Column(
+            "org_embedding_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "projects",
+        sa.Column(
+            "org_llm_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_projects_org_embedding_credential",
+        "projects",
+        "org_model_provider_credentials",
+        ["org_embedding_api_key_credential_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_projects_org_llm_credential",
+        "projects",
+        "org_model_provider_credentials",
+        ["org_llm_api_key_credential_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_projects_org_llm_credential", "projects", type_="foreignkey")
+    op.drop_constraint("fk_projects_org_embedding_credential", "projects", type_="foreignkey")
+    op.drop_column("projects", "org_llm_api_key_credential_id")
+    op.drop_column("projects", "org_embedding_api_key_credential_id")

--- a/server/src/raggae/application/constants.py
+++ b/server/src/raggae/application/constants.py
@@ -1,31 +1,63 @@
 ALLOWED_LLM_MODELS: dict[str, frozenset[str]] = {
-    "openai": frozenset({
-        "gpt-5.2", "gpt-5.2-pro", "gpt-5.1", "gpt-5", "gpt-5-mini", "gpt-5-nano",
-        "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano",
-    }),
-    "gemini": frozenset({
-        "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3-deep-think-preview",
-    }),
-    "anthropic": frozenset({
-        "claude-opus-4-6-20260205", "claude-opus-4-5-20251101",
-        "claude-sonnet-4-6-20260217", "claude-sonnet-4-20250514",
-        "claude-haiku-4-5-20251001",
-    }),
-    "inmemory": frozenset({
-        "inmemory-chat-accurate", "inmemory-chat-balanced", "inmemory-chat-fast",
-    }),
+    "openai": frozenset(
+        {
+            "gpt-5.2",
+            "gpt-5.2-pro",
+            "gpt-5.1",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.1-nano",
+        }
+    ),
+    "gemini": frozenset(
+        {
+            "gemini-3.1-pro-preview",
+            "gemini-3-flash-preview",
+            "gemini-3-deep-think-preview",
+        }
+    ),
+    "anthropic": frozenset(
+        {
+            "claude-opus-4-6-20260205",
+            "claude-opus-4-5-20251101",
+            "claude-sonnet-4-6-20260217",
+            "claude-sonnet-4-20250514",
+            "claude-haiku-4-5-20251001",
+        }
+    ),
+    "inmemory": frozenset(
+        {
+            "inmemory-chat-accurate",
+            "inmemory-chat-balanced",
+            "inmemory-chat-fast",
+        }
+    ),
 }
 
 ALLOWED_EMBEDDING_MODELS: dict[str, frozenset[str]] = {
-    "openai": frozenset({
-        "text-embedding-3-large", "text-embedding-3-small", "text-embedding-ada-002",
-    }),
-    "gemini": frozenset({
-        "gemini-embedding-001", "text-multilingual-embedding-002",
-    }),
-    "inmemory": frozenset({
-        "inmemory-embed-accurate", "inmemory-embed-balanced", "inmemory-embed-fast",
-    }),
+    "openai": frozenset(
+        {
+            "text-embedding-3-large",
+            "text-embedding-3-small",
+            "text-embedding-ada-002",
+        }
+    ),
+    "gemini": frozenset(
+        {
+            "gemini-embedding-001",
+            "text-multilingual-embedding-002",
+        }
+    ),
+    "inmemory": frozenset(
+        {
+            "inmemory-embed-accurate",
+            "inmemory-embed-balanced",
+            "inmemory-embed-fast",
+        }
+    ),
 }
 
 MAX_PROJECT_SYSTEM_PROMPT_LENGTH = 8000

--- a/server/src/raggae/application/dto/org_provider_credential_dto.py
+++ b/server/src/raggae/application/dto/org_provider_credential_dto.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass
+class OrgProviderCredentialDTO:
+    id: UUID
+    organization_id: UUID
+    provider: str
+    masked_key: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime

--- a/server/src/raggae/application/interfaces/repositories/org_provider_credential_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/org_provider_credential_repository.py
@@ -1,0 +1,25 @@
+from typing import Protocol
+from uuid import UUID
+
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.value_objects.model_provider import ModelProvider
+
+
+class OrgProviderCredentialRepository(Protocol):
+    """Interface for organization model provider credential persistence."""
+
+    async def save(self, credential: OrgModelProviderCredential) -> None: ...
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgModelProviderCredential]: ...
+
+    async def list_by_org_id_and_provider(
+        self,
+        organization_id: UUID,
+        provider: ModelProvider,
+    ) -> list[OrgModelProviderCredential]: ...
+
+    async def set_active(self, credential_id: UUID, organization_id: UUID) -> None: ...
+
+    async def set_inactive(self, credential_id: UUID, organization_id: UUID) -> None: ...
+
+    async def delete(self, credential_id: UUID, organization_id: UUID) -> None: ...

--- a/server/src/raggae/application/use_cases/org_credentials/activate_org_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/org_credentials/activate_org_provider_api_key.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import OrgCredentialNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class ActivateOrgProviderApiKey:
+    """Use case to activate one organization provider API key."""
+
+    def __init__(
+        self,
+        org_credential_repository: OrgProviderCredentialRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._org_credential_repository = org_credential_repository
+        self._organization_member_repository = organization_member_repository
+
+    async def execute(self, credential_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage credentials for organization {organization_id}"
+            )
+        credentials = await self._org_credential_repository.list_by_org_id(organization_id)
+        if not any(c.id == credential_id for c in credentials):
+            raise OrgCredentialNotFoundError()
+        await self._org_credential_repository.set_active(credential_id, organization_id)

--- a/server/src/raggae/application/use_cases/org_credentials/deactivate_org_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/org_credentials/deactivate_org_provider_api_key.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import (
+    OrgCredentialInUseError,
+    OrgCredentialNotFoundError,
+)
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class DeactivateOrgProviderApiKey:
+    """Use case to deactivate one organization provider API key."""
+
+    def __init__(
+        self,
+        org_credential_repository: OrgProviderCredentialRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        project_repository: ProjectRepository,
+    ) -> None:
+        self._org_credential_repository = org_credential_repository
+        self._organization_member_repository = organization_member_repository
+        self._project_repository = project_repository
+
+    async def execute(self, credential_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage credentials for organization {organization_id}"
+            )
+        credentials = await self._org_credential_repository.list_by_org_id(organization_id)
+        if not any(c.id == credential_id for c in credentials):
+            raise OrgCredentialNotFoundError()
+        projects = await self._project_repository.find_by_organization_id(organization_id)
+        if any(
+            p.org_embedding_api_key_credential_id == credential_id
+            or p.org_llm_api_key_credential_id == credential_id
+            for p in projects
+        ):
+            raise OrgCredentialInUseError()
+        await self._org_credential_repository.set_inactive(credential_id, organization_id)

--- a/server/src/raggae/application/use_cases/org_credentials/delete_org_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/org_credentials/delete_org_provider_api_key.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import (
+    OrgCredentialInUseError,
+    OrgCredentialNotFoundError,
+)
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class DeleteOrgProviderApiKey:
+    """Use case to delete one organization provider API key."""
+
+    def __init__(
+        self,
+        org_credential_repository: OrgProviderCredentialRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        project_repository: ProjectRepository,
+    ) -> None:
+        self._org_credential_repository = org_credential_repository
+        self._organization_member_repository = organization_member_repository
+        self._project_repository = project_repository
+
+    async def execute(self, credential_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage credentials for organization {organization_id}"
+            )
+        credentials = await self._org_credential_repository.list_by_org_id(organization_id)
+        if not any(c.id == credential_id for c in credentials):
+            raise OrgCredentialNotFoundError()
+        projects = await self._project_repository.find_by_organization_id(organization_id)
+        if any(
+            p.org_embedding_api_key_credential_id == credential_id
+            or p.org_llm_api_key_credential_id == credential_id
+            for p in projects
+        ):
+            raise OrgCredentialInUseError()
+        await self._org_credential_repository.delete(credential_id, organization_id)

--- a/server/src/raggae/application/use_cases/org_credentials/list_org_provider_api_keys.py
+++ b/server/src/raggae/application/use_cases/org_credentials/list_org_provider_api_keys.py
@@ -1,0 +1,45 @@
+from uuid import UUID
+
+from raggae.application.dto.org_provider_credential_dto import OrgProviderCredentialDTO
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+
+
+class ListOrgProviderApiKeys:
+    """Use case to list all provider API keys for an organization."""
+
+    def __init__(
+        self,
+        org_credential_repository: OrgProviderCredentialRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._org_credential_repository = org_credential_repository
+        self._organization_member_repository = organization_member_repository
+
+    async def execute(self, organization_id: UUID, user_id: UUID) -> list[OrgProviderCredentialDTO]:
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} is not a member of organization {organization_id}"
+            )
+        credentials = await self._org_credential_repository.list_by_org_id(organization_id)
+        return [
+            OrgProviderCredentialDTO(
+                id=c.id,
+                organization_id=c.organization_id,
+                provider=c.provider.value,
+                masked_key=c.masked_key,
+                is_active=c.is_active,
+                created_at=c.created_at,
+                updated_at=c.updated_at,
+            )
+            for c in credentials
+        ]

--- a/server/src/raggae/application/use_cases/org_credentials/save_org_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/org_credentials/save_org_provider_api_key.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from raggae.application.dto.org_provider_credential_dto import OrgProviderCredentialDTO
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.services.provider_api_key_crypto_service import (
+    ProviderApiKeyCryptoService,
+)
+from raggae.application.interfaces.services.provider_api_key_validator import (
+    ProviderApiKeyValidator,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import OrgDuplicateCredentialError
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class SaveOrgProviderApiKey:
+    """Use case to persist an organization provider API key securely."""
+
+    def __init__(
+        self,
+        org_credential_repository: OrgProviderCredentialRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        provider_api_key_validator: ProviderApiKeyValidator,
+        provider_api_key_crypto_service: ProviderApiKeyCryptoService,
+    ) -> None:
+        self._org_credential_repository = org_credential_repository
+        self._organization_member_repository = organization_member_repository
+        self._provider_api_key_validator = provider_api_key_validator
+        self._provider_api_key_crypto_service = provider_api_key_crypto_service
+
+    async def execute(
+        self, organization_id: UUID, user_id: UUID, provider: str, api_key: str
+    ) -> OrgProviderCredentialDTO:
+        model_provider = ModelProvider(provider)
+        member = await self._organization_member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage credentials for organization {organization_id}"
+            )
+        self._provider_api_key_validator.validate(model_provider, api_key)
+        fingerprint = self._provider_api_key_crypto_service.fingerprint(api_key)
+        existing = await self._org_credential_repository.list_by_org_id_and_provider(
+            organization_id, model_provider
+        )
+        if any(c.key_fingerprint == fingerprint for c in existing):
+            raise OrgDuplicateCredentialError()
+        now = datetime.now(UTC)
+        credential = OrgModelProviderCredential(
+            id=uuid4(),
+            organization_id=organization_id,
+            provider=model_provider,
+            encrypted_api_key=self._provider_api_key_crypto_service.encrypt(api_key),
+            key_fingerprint=fingerprint,
+            key_suffix=api_key[-4:],
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+        await self._org_credential_repository.save(credential)
+        return OrgProviderCredentialDTO(
+            id=credential.id,
+            organization_id=credential.organization_id,
+            provider=credential.provider.value,
+            masked_key=credential.masked_key,
+            is_active=credential.is_active,
+            created_at=credential.created_at,
+            updated_at=credential.updated_at,
+        )

--- a/server/src/raggae/application/use_cases/provider_credentials/activate_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/provider_credentials/activate_provider_api_key.py
@@ -19,7 +19,4 @@ class ActivateProviderApiKey:
         target = next((c for c in credentials if c.id == credential_id), None)
         if target is None:
             raise ProviderCredentialNotFoundError()
-        for credential in credentials:
-            if credential.provider == target.provider and credential.id != credential_id:
-                await self._provider_credential_repository.set_inactive(credential.id, user_id)
         await self._provider_credential_repository.set_active(credential_id, user_id)

--- a/server/src/raggae/application/use_cases/provider_credentials/save_provider_api_key.py
+++ b/server/src/raggae/application/use_cases/provider_credentials/save_provider_api_key.py
@@ -40,10 +40,6 @@ class SaveProviderApiKey:
         )
         if any(c.key_fingerprint == fingerprint for c in existing):
             raise DuplicateProviderCredentialError()
-        for credential in existing:
-            await self._provider_credential_repository.set_inactive(
-                credential_id=credential.id, user_id=user_id
-            )
         now = datetime.now(UTC)
         credential = UserModelProviderCredential(
             id=uuid4(),

--- a/server/src/raggae/domain/entities/org_model_provider_credential.py
+++ b/server/src/raggae/domain/entities/org_model_provider_credential.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from raggae.domain.value_objects.model_provider import ModelProvider
+
+
+@dataclass(frozen=True)
+class OrgModelProviderCredential:
+    """Organization API credential for a model provider."""
+
+    id: UUID
+    organization_id: UUID
+    provider: ModelProvider
+    encrypted_api_key: str
+    key_fingerprint: str
+    key_suffix: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    @property
+    def masked_key(self) -> str:
+        return f"...{self.key_suffix}"

--- a/server/src/raggae/domain/entities/project.py
+++ b/server/src/raggae/domain/entities/project.py
@@ -44,6 +44,8 @@ class Project:
     reranker_model: str | None = None
     reranker_candidate_multiplier: int = 3
     organization_id: UUID | None = None
+    org_embedding_api_key_credential_id: UUID | None = None
+    org_llm_api_key_credential_id: UUID | None = None
 
     def publish(self) -> "Project":
         """Publish the project. Raises if already published."""

--- a/server/src/raggae/domain/exceptions/provider_credential_exceptions.py
+++ b/server/src/raggae/domain/exceptions/provider_credential_exceptions.py
@@ -8,3 +8,15 @@ class DuplicateProviderCredentialError(ValueError):
 
 class CredentialInUseError(ValueError):
     """Raised when a credential cannot be deactivated because a project is using it."""
+
+
+class OrgCredentialNotFoundError(ValueError):
+    """Raised when an org provider credential does not exist."""
+
+
+class OrgDuplicateCredentialError(ValueError):
+    """Raised when a credential with the same API key already exists for an org and provider."""
+
+
+class OrgCredentialInUseError(ValueError):
+    """Raised when an org credential cannot be deactivated because a project is using it."""

--- a/server/src/raggae/infrastructure/database/models/org_model_provider_credential_model.py
+++ b/server/src/raggae/infrastructure/database/models/org_model_provider_credential_model.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from raggae.infrastructure.database.models.base import Base
+
+
+class OrgModelProviderCredentialModel(Base):
+    __tablename__ = "org_model_provider_credentials"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    organization_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    provider: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    encrypted_api_key: Mapped[str] = mapped_column(Text(), nullable=False)
+    key_fingerprint: Mapped[str] = mapped_column(String(128), nullable=False)
+    key_suffix: Mapped[str] = mapped_column(String(16), nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/server/src/raggae/infrastructure/database/models/project_model.py
+++ b/server/src/raggae/infrastructure/database/models/project_model.py
@@ -78,4 +78,14 @@ class ProjectModel(Base):
     reranker_candidate_multiplier: Mapped[int] = mapped_column(
         Integer(), nullable=False, default=3, server_default="3"
     )
+    org_embedding_api_key_credential_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("org_model_provider_credentials.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    org_llm_api_key_credential_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("org_model_provider_credentials.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_org_provider_credential_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_org_provider_credential_repository.py
@@ -1,0 +1,47 @@
+from dataclasses import replace
+from uuid import UUID
+
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.value_objects.model_provider import ModelProvider
+
+
+class InMemoryOrgProviderCredentialRepository:
+    """In-memory org provider credential repository for testing."""
+
+    def __init__(self) -> None:
+        self._credentials: dict[UUID, OrgModelProviderCredential] = {}
+
+    async def save(self, credential: OrgModelProviderCredential) -> None:
+        self._credentials[credential.id] = credential
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgModelProviderCredential]:
+        return [c for c in self._credentials.values() if c.organization_id == organization_id]
+
+    async def list_by_org_id_and_provider(
+        self,
+        organization_id: UUID,
+        provider: ModelProvider,
+    ) -> list[OrgModelProviderCredential]:
+        return [
+            c
+            for c in self._credentials.values()
+            if c.organization_id == organization_id and c.provider == provider
+        ]
+
+    async def set_active(self, credential_id: UUID, organization_id: UUID) -> None:
+        target = self._credentials.get(credential_id)
+        if target is None or target.organization_id != organization_id:
+            return
+        self._credentials[credential_id] = replace(target, is_active=True)
+
+    async def set_inactive(self, credential_id: UUID, organization_id: UUID) -> None:
+        target = self._credentials.get(credential_id)
+        if target is None or target.organization_id != organization_id:
+            return
+        self._credentials[credential_id] = replace(target, is_active=False)
+
+    async def delete(self, credential_id: UUID, organization_id: UUID) -> None:
+        credential = self._credentials.get(credential_id)
+        if credential is None or credential.organization_id != organization_id:
+            return
+        del self._credentials[credential_id]

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_org_provider_credential_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_org_provider_credential_repository.py
@@ -1,0 +1,113 @@
+from uuid import UUID
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.infrastructure.database.models.org_model_provider_credential_model import (
+    OrgModelProviderCredentialModel,
+)
+
+
+class SQLAlchemyOrgProviderCredentialRepository:
+    """PostgreSQL org provider credential repository using SQLAlchemy async sessions."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def save(self, credential: OrgModelProviderCredential) -> None:
+        async with self._session_factory() as session:
+            model = await session.get(OrgModelProviderCredentialModel, credential.id)
+            if model is None:
+                model = OrgModelProviderCredentialModel(
+                    id=credential.id,
+                    organization_id=credential.organization_id,
+                    provider=credential.provider.value,
+                    encrypted_api_key=credential.encrypted_api_key,
+                    key_fingerprint=credential.key_fingerprint,
+                    key_suffix=credential.key_suffix,
+                    is_active=credential.is_active,
+                    created_at=credential.created_at,
+                    updated_at=credential.updated_at,
+                )
+                session.add(model)
+            else:
+                model.encrypted_api_key = credential.encrypted_api_key
+                model.key_fingerprint = credential.key_fingerprint
+                model.key_suffix = credential.key_suffix
+                model.is_active = credential.is_active
+                model.updated_at = credential.updated_at
+            await session.commit()
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgModelProviderCredential]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OrgModelProviderCredentialModel).where(
+                    OrgModelProviderCredentialModel.organization_id == organization_id
+                )
+            )
+            return [self._to_domain(m) for m in result.scalars().all()]
+
+    async def list_by_org_id_and_provider(
+        self,
+        organization_id: UUID,
+        provider: ModelProvider,
+    ) -> list[OrgModelProviderCredential]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OrgModelProviderCredentialModel).where(
+                    OrgModelProviderCredentialModel.organization_id == organization_id,
+                    OrgModelProviderCredentialModel.provider == provider.value,
+                )
+            )
+            return [self._to_domain(m) for m in result.scalars().all()]
+
+    async def set_active(self, credential_id: UUID, organization_id: UUID) -> None:
+        async with self._session_factory() as session:
+            target = await session.get(OrgModelProviderCredentialModel, credential_id)
+            if target is None or target.organization_id != organization_id:
+                await session.commit()
+                return
+            await session.execute(
+                update(OrgModelProviderCredentialModel)
+                .where(OrgModelProviderCredentialModel.id == credential_id)
+                .values(is_active=True)
+            )
+            await session.commit()
+
+    async def set_inactive(self, credential_id: UUID, organization_id: UUID) -> None:
+        async with self._session_factory() as session:
+            target = await session.get(OrgModelProviderCredentialModel, credential_id)
+            if target is None or target.organization_id != organization_id:
+                await session.commit()
+                return
+            await session.execute(
+                update(OrgModelProviderCredentialModel)
+                .where(OrgModelProviderCredentialModel.id == credential_id)
+                .values(is_active=False)
+            )
+            await session.commit()
+
+    async def delete(self, credential_id: UUID, organization_id: UUID) -> None:
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(OrgModelProviderCredentialModel).where(
+                    OrgModelProviderCredentialModel.id == credential_id,
+                    OrgModelProviderCredentialModel.organization_id == organization_id,
+                )
+            )
+            await session.commit()
+
+    def _to_domain(self, model: OrgModelProviderCredentialModel) -> OrgModelProviderCredential:
+        return OrgModelProviderCredential(
+            id=model.id,
+            organization_id=model.organization_id,
+            provider=ModelProvider(model.provider),
+            encrypted_api_key=model.encrypted_api_key,
+            key_fingerprint=model.key_fingerprint,
+            key_suffix=model.key_suffix,
+            is_active=model.is_active,
+            created_at=model.created_at,
+            updated_at=model.updated_at,
+        )

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_repository.py
@@ -48,6 +48,8 @@ class SQLAlchemyProjectRepository:
                     reranker_backend=project.reranker_backend,
                     reranker_model=project.reranker_model,
                     reranker_candidate_multiplier=project.reranker_candidate_multiplier,
+                    org_embedding_api_key_credential_id=project.org_embedding_api_key_credential_id,
+                    org_llm_api_key_credential_id=project.org_llm_api_key_credential_id,
                     created_at=project.created_at,
                 )
                 session.add(model)
@@ -71,6 +73,10 @@ class SQLAlchemyProjectRepository:
                 model.llm_model = project.llm_model
                 model.llm_api_key_encrypted = project.llm_api_key_encrypted
                 model.llm_api_key_credential_id = project.llm_api_key_credential_id
+                model.org_embedding_api_key_credential_id = (
+                    project.org_embedding_api_key_credential_id
+                )
+                model.org_llm_api_key_credential_id = project.org_llm_api_key_credential_id
                 model.retrieval_strategy = project.retrieval_strategy
                 model.retrieval_top_k = project.retrieval_top_k
                 model.retrieval_min_score = project.retrieval_min_score
@@ -117,6 +123,8 @@ class SQLAlchemyProjectRepository:
                 reranker_backend=model.reranker_backend,
                 reranker_model=model.reranker_model,
                 reranker_candidate_multiplier=model.reranker_candidate_multiplier,
+                org_embedding_api_key_credential_id=model.org_embedding_api_key_credential_id,
+                org_llm_api_key_credential_id=model.org_llm_api_key_credential_id,
                 created_at=model.created_at,
             )
 
@@ -157,6 +165,8 @@ class SQLAlchemyProjectRepository:
                     reranker_backend=model.reranker_backend,
                     reranker_model=model.reranker_model,
                     reranker_candidate_multiplier=model.reranker_candidate_multiplier,
+                    org_embedding_api_key_credential_id=model.org_embedding_api_key_credential_id,
+                    org_llm_api_key_credential_id=model.org_llm_api_key_credential_id,
                     created_at=model.created_at,
                 )
                 for model in models
@@ -199,6 +209,8 @@ class SQLAlchemyProjectRepository:
                     reranker_backend=model.reranker_backend,
                     reranker_model=model.reranker_model,
                     reranker_candidate_multiplier=model.reranker_candidate_multiplier,
+                    org_embedding_api_key_credential_id=model.org_embedding_api_key_credential_id,
+                    org_llm_api_key_credential_id=model.org_llm_api_key_credential_id,
                     created_at=model.created_at,
                 )
                 for model in models

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -14,6 +14,9 @@ from raggae.application.interfaces.repositories.document_repository import (
     DocumentRepository,
 )
 from raggae.application.interfaces.repositories.message_repository import MessageRepository
+from raggae.application.interfaces.repositories.org_provider_credential_repository import (
+    OrgProviderCredentialRepository,
+)
 from raggae.application.interfaces.repositories.organization_invitation_repository import (
     OrganizationInvitationRepository,
 )
@@ -90,6 +93,21 @@ from raggae.application.use_cases.document.list_document_chunks import ListDocum
 from raggae.application.use_cases.document.list_project_documents import ListProjectDocuments
 from raggae.application.use_cases.document.reindex_document import ReindexDocument
 from raggae.application.use_cases.document.upload_document import UploadDocument
+from raggae.application.use_cases.org_credentials.activate_org_provider_api_key import (
+    ActivateOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.deactivate_org_provider_api_key import (
+    DeactivateOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.delete_org_provider_api_key import (
+    DeleteOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.list_org_provider_api_keys import (
+    ListOrgProviderApiKeys,
+)
+from raggae.application.use_cases.org_credentials.save_org_provider_api_key import (
+    SaveOrgProviderApiKey,
+)
 from raggae.application.use_cases.organization.accept_organization_invitation import (
     AcceptOrganizationInvitation,
 )
@@ -172,6 +190,9 @@ from raggae.infrastructure.database.repositories.in_memory_document_repository i
 from raggae.infrastructure.database.repositories.in_memory_message_repository import (
     InMemoryMessageRepository,
 )
+from raggae.infrastructure.database.repositories.in_memory_org_provider_credential_repository import (
+    InMemoryOrgProviderCredentialRepository,
+)
 from raggae.infrastructure.database.repositories.in_memory_organization_invitation_repository import (
     InMemoryOrganizationInvitationRepository,
 )
@@ -201,6 +222,9 @@ from raggae.infrastructure.database.repositories.sqlalchemy_document_repository 
 )
 from raggae.infrastructure.database.repositories.sqlalchemy_message_repository import (
     SQLAlchemyMessageRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_org_provider_credential_repository import (
+    SQLAlchemyOrgProviderCredentialRepository,
 )
 from raggae.infrastructure.database.repositories.sqlalchemy_organization_invitation_repository import (
     SQLAlchemyOrganizationInvitationRepository,
@@ -355,6 +379,9 @@ if settings.persistence_backend == "postgres":
     _provider_credential_repository: ProviderCredentialRepository = (
         SQLAlchemyProviderCredentialRepository(session_factory=SessionFactory)
     )
+    _org_credential_repository: OrgProviderCredentialRepository = (
+        SQLAlchemyOrgProviderCredentialRepository(session_factory=SessionFactory)
+    )
     _organization_repository: OrganizationRepository = SQLAlchemyOrganizationRepository(
         session_factory=SessionFactory
     )
@@ -379,6 +406,7 @@ else:
     _conversation_repository = InMemoryConversationRepository()
     _message_repository = InMemoryMessageRepository()
     _provider_credential_repository = InMemoryProviderCredentialRepository()
+    _org_credential_repository = InMemoryOrgProviderCredentialRepository()
     _organization_repository = InMemoryOrganizationRepository()
     _organization_member_repository = InMemoryOrganizationMemberRepository()
     _organization_invitation_repository = InMemoryOrganizationInvitationRepository()
@@ -889,6 +917,45 @@ def get_accept_user_organization_invitation_use_case() -> AcceptUserOrganization
         organization_repository=_organization_repository,
         organization_member_repository=_organization_member_repository,
         organization_invitation_repository=_organization_invitation_repository,
+    )
+
+
+def get_save_org_provider_api_key_use_case() -> SaveOrgProviderApiKey:
+    return SaveOrgProviderApiKey(
+        org_credential_repository=_org_credential_repository,
+        organization_member_repository=_organization_member_repository,
+        provider_api_key_validator=_provider_api_key_validator,
+        provider_api_key_crypto_service=_provider_api_key_crypto_service,
+    )
+
+
+def get_list_org_provider_api_keys_use_case() -> ListOrgProviderApiKeys:
+    return ListOrgProviderApiKeys(
+        org_credential_repository=_org_credential_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_activate_org_provider_api_key_use_case() -> ActivateOrgProviderApiKey:
+    return ActivateOrgProviderApiKey(
+        org_credential_repository=_org_credential_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_deactivate_org_provider_api_key_use_case() -> DeactivateOrgProviderApiKey:
+    return DeactivateOrgProviderApiKey(
+        org_credential_repository=_org_credential_repository,
+        organization_member_repository=_organization_member_repository,
+        project_repository=_project_repository,
+    )
+
+
+def get_delete_org_provider_api_key_use_case() -> DeleteOrgProviderApiKey:
+    return DeleteOrgProviderApiKey(
+        org_credential_repository=_org_credential_repository,
+        organization_member_repository=_organization_member_repository,
+        project_repository=_project_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/v1/endpoints/org_model_credentials.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/org_model_credentials.py
@@ -1,0 +1,238 @@
+import logging
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from raggae.application.use_cases.org_credentials.activate_org_provider_api_key import (
+    ActivateOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.deactivate_org_provider_api_key import (
+    DeactivateOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.delete_org_provider_api_key import (
+    DeleteOrgProviderApiKey,
+)
+from raggae.application.use_cases.org_credentials.list_org_provider_api_keys import (
+    ListOrgProviderApiKeys,
+)
+from raggae.application.use_cases.org_credentials.save_org_provider_api_key import (
+    SaveOrgProviderApiKey,
+)
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import (
+    OrgCredentialInUseError,
+    OrgCredentialNotFoundError,
+    OrgDuplicateCredentialError,
+)
+from raggae.domain.exceptions.validation_errors import (
+    InvalidModelProviderError,
+    InvalidProviderApiKeyError,
+)
+from raggae.presentation.api.dependencies import (
+    get_activate_org_provider_api_key_use_case,
+    get_current_user_id,
+    get_deactivate_org_provider_api_key_use_case,
+    get_delete_org_provider_api_key_use_case,
+    get_list_org_provider_api_keys_use_case,
+    get_save_org_provider_api_key_use_case,
+)
+from raggae.presentation.api.v1.schemas.org_model_credential_schemas import (
+    OrgModelCredentialResponse,
+    SaveOrgModelCredentialRequest,
+)
+
+router = APIRouter(
+    prefix="/organizations/{organization_id}/model-credentials",
+    tags=["org-model-credentials"],
+    dependencies=[Depends(get_current_user_id)],
+)
+logger = logging.getLogger(__name__)
+
+
+@router.post("", status_code=status.HTTP_201_CREATED)
+async def save_org_model_credential(
+    organization_id: UUID,
+    data: SaveOrgModelCredentialRequest,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[SaveOrgProviderApiKey, Depends(get_save_org_provider_api_key_use_case)],
+) -> OrgModelCredentialResponse:
+    try:
+        credential = await use_case.execute(
+            organization_id=organization_id,
+            user_id=user_id,
+            provider=data.provider,
+            api_key=data.api_key,
+        )
+    except OrganizationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+    except InvalidModelProviderError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from None
+    except InvalidProviderApiKeyError:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="Invalid API key format",
+        ) from None
+    except OrgDuplicateCredentialError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This API key is already saved for this provider",
+        ) from None
+    logger.info(
+        "org_provider_credential_saved",
+        extra={
+            "organization_id": str(organization_id),
+            "user_id": str(user_id),
+            "provider": credential.provider,
+            "credential_id": str(credential.id),
+        },
+    )
+    return OrgModelCredentialResponse(
+        id=credential.id,
+        organization_id=credential.organization_id,
+        provider=credential.provider,
+        masked_key=credential.masked_key,
+        is_active=credential.is_active,
+        created_at=credential.created_at,
+        updated_at=credential.updated_at,
+    )
+
+
+@router.get("")
+async def list_org_model_credentials(
+    organization_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ListOrgProviderApiKeys, Depends(get_list_org_provider_api_keys_use_case)],
+) -> list[OrgModelCredentialResponse]:
+    try:
+        credentials = await use_case.execute(organization_id=organization_id, user_id=user_id)
+    except OrganizationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+    return [
+        OrgModelCredentialResponse(
+            id=item.id,
+            organization_id=item.organization_id,
+            provider=item.provider,
+            masked_key=item.masked_key,
+            is_active=item.is_active,
+            created_at=item.created_at,
+            updated_at=item.updated_at,
+        )
+        for item in credentials
+    ]
+
+
+@router.patch("/{credential_id}/activate", status_code=status.HTTP_204_NO_CONTENT)
+async def activate_org_model_credential(
+    organization_id: UUID,
+    credential_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[
+        ActivateOrgProviderApiKey, Depends(get_activate_org_provider_api_key_use_case)
+    ],
+) -> None:
+    try:
+        await use_case.execute(
+            credential_id=credential_id, organization_id=organization_id, user_id=user_id
+        )
+    except OrganizationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+    except OrgCredentialNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Org provider credential not found",
+        ) from None
+    logger.info(
+        "org_provider_credential_activated",
+        extra={
+            "organization_id": str(organization_id),
+            "user_id": str(user_id),
+            "credential_id": str(credential_id),
+        },
+    )
+
+
+@router.patch("/{credential_id}/deactivate", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_org_model_credential(
+    organization_id: UUID,
+    credential_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[
+        DeactivateOrgProviderApiKey, Depends(get_deactivate_org_provider_api_key_use_case)
+    ],
+) -> None:
+    try:
+        await use_case.execute(
+            credential_id=credential_id, organization_id=organization_id, user_id=user_id
+        )
+    except OrganizationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+    except OrgCredentialNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Org provider credential not found",
+        ) from None
+    except OrgCredentialInUseError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This API key is used by one or more projects and cannot be deactivated",
+        ) from None
+    logger.info(
+        "org_provider_credential_deactivated",
+        extra={
+            "organization_id": str(organization_id),
+            "user_id": str(user_id),
+            "credential_id": str(credential_id),
+        },
+    )
+
+
+@router.delete("/{credential_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_org_model_credential(
+    organization_id: UUID,
+    credential_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[DeleteOrgProviderApiKey, Depends(get_delete_org_provider_api_key_use_case)],
+) -> None:
+    try:
+        await use_case.execute(
+            credential_id=credential_id, organization_id=organization_id, user_id=user_id
+        )
+    except OrganizationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+    except OrgCredentialNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Org provider credential not found",
+        ) from None
+    except OrgCredentialInUseError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This API key is used by one or more projects and cannot be deleted",
+        ) from None
+    logger.info(
+        "org_provider_credential_deleted",
+        extra={
+            "organization_id": str(organization_id),
+            "user_id": str(user_id),
+            "credential_id": str(credential_id),
+        },
+    )

--- a/server/src/raggae/presentation/api/v1/schemas/org_model_credential_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/org_model_credential_schemas.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class SaveOrgModelCredentialRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=32)
+    api_key: str = Field(min_length=4, max_length=512)
+
+
+class OrgModelCredentialResponse(BaseModel):
+    id: UUID
+    organization_id: UUID
+    provider: str
+    masked_key: str
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime

--- a/server/src/raggae/presentation/main.py
+++ b/server/src/raggae/presentation/main.py
@@ -10,6 +10,9 @@ from raggae.presentation.api.v1.endpoints.model_catalog import router as model_c
 from raggae.presentation.api.v1.endpoints.model_credentials import (
     router as model_credentials_router,
 )
+from raggae.presentation.api.v1.endpoints.org_model_credentials import (
+    router as org_model_credentials_router,
+)
 from raggae.presentation.api.v1.endpoints.organizations import router as organizations_router
 from raggae.presentation.api.v1.endpoints.projects import router as projects_router
 from raggae.presentation.api.dependencies import get_query_relevant_chunks_use_case
@@ -36,6 +39,7 @@ app.include_router(documents_router, prefix="/api/v1")
 app.include_router(chat_router, prefix="/api/v1")
 app.include_router(model_catalog_router, prefix="/api/v1")
 app.include_router(model_credentials_router, prefix="/api/v1")
+app.include_router(org_model_credentials_router, prefix="/api/v1")
 
 
 @app.get("/health")

--- a/server/tests/unit/application/use_cases/chat/test_delete_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_delete_conversation_org_access.py
@@ -59,7 +59,9 @@ class TestDeleteConversationOrgAccess:
         use_case = DeleteConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.OWNER
+            ),
         )
 
         # When
@@ -83,7 +85,9 @@ class TestDeleteConversationOrgAccess:
         use_case = DeleteConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.MAKER
+            ),
         )
 
         # When
@@ -107,7 +111,9 @@ class TestDeleteConversationOrgAccess:
         use_case = DeleteConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When
@@ -129,7 +135,9 @@ class TestDeleteConversationOrgAccess:
         use_case = DeleteConversation(
             project_repository=project_repo,
             conversation_repository=AsyncMock(),
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When / Then

--- a/server/tests/unit/application/use_cases/chat/test_get_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_get_conversation_org_access.py
@@ -64,7 +64,9 @@ class TestGetConversationOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.OWNER
+            ),
         )
 
         # When
@@ -93,7 +95,9 @@ class TestGetConversationOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.MAKER
+            ),
         )
 
         # When
@@ -131,7 +135,9 @@ class TestGetConversationOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When
@@ -154,7 +160,9 @@ class TestGetConversationOrgAccess:
             project_repository=project_repo,
             conversation_repository=AsyncMock(),
             message_repository=AsyncMock(),
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When / Then

--- a/server/tests/unit/application/use_cases/chat/test_list_conversation_messages_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversation_messages_org_access.py
@@ -61,7 +61,9 @@ class TestListConversationMessagesOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.OWNER
+            ),
         )
 
         # When
@@ -87,7 +89,9 @@ class TestListConversationMessagesOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.MAKER
+            ),
         )
 
         # When
@@ -113,7 +117,9 @@ class TestListConversationMessagesOrgAccess:
             project_repository=project_repo,
             conversation_repository=conversation_repo,
             message_repository=message_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When
@@ -136,7 +142,9 @@ class TestListConversationMessagesOrgAccess:
             project_repository=project_repo,
             conversation_repository=AsyncMock(),
             message_repository=AsyncMock(),
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When / Then

--- a/server/tests/unit/application/use_cases/chat/test_update_conversation_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_update_conversation_org_access.py
@@ -60,7 +60,9 @@ class TestUpdateConversationOrgAccess:
         use_case = UpdateConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.OWNER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.OWNER
+            ),
         )
 
         # When
@@ -85,7 +87,9 @@ class TestUpdateConversationOrgAccess:
         use_case = UpdateConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.MAKER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.MAKER
+            ),
         )
 
         # When
@@ -110,7 +114,9 @@ class TestUpdateConversationOrgAccess:
         use_case = UpdateConversation(
             project_repository=project_repo,
             conversation_repository=conversation_repo,
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When
@@ -133,7 +139,9 @@ class TestUpdateConversationOrgAccess:
         use_case = UpdateConversation(
             project_repository=project_repo,
             conversation_repository=AsyncMock(),
-            organization_member_repository=_make_org_member_repo(org_id, user_id, OrganizationMemberRole.USER),
+            organization_member_repository=_make_org_member_repo(
+                org_id, user_id, OrganizationMemberRole.USER
+            ),
         )
 
         # When / Then

--- a/server/tests/unit/application/use_cases/org_credentials/test_activate_org_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/org_credentials/test_activate_org_provider_api_key.py
@@ -1,0 +1,125 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_credentials.activate_org_provider_api_key import (
+    ActivateOrgProviderApiKey,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import OrgCredentialNotFoundError
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_member(role: OrganizationMemberRole) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def _make_credential(org_id: object, credential_id: object) -> OrgModelProviderCredential:
+    now = datetime.now(UTC)
+    return OrgModelProviderCredential(
+        id=credential_id,
+        organization_id=org_id,
+        provider=ModelProvider("openai"),
+        encrypted_api_key="enc",
+        key_fingerprint="fp",
+        key_suffix="1234",
+        is_active=False,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestActivateOrgProviderApiKey:
+    async def test_activate_org_provider_api_key_success(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        use_case = ActivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        await use_case.execute(credential_id=credential_id, organization_id=org_id, user_id=uuid4())
+
+        # Then
+        cred_repo.set_active.assert_awaited_once_with(credential_id, org_id)
+
+    async def test_activate_org_provider_api_key_does_not_deactivate_others(self) -> None:
+        # Given — deux credentials pour le même provider
+        org_id = uuid4()
+        credential_id = uuid4()
+        other_id = uuid4()
+        now = datetime.now(UTC)
+        other = OrgModelProviderCredential(
+            id=other_id,
+            organization_id=org_id,
+            provider=ModelProvider("openai"),
+            encrypted_api_key="enc2",
+            key_fingerprint="fp2",
+            key_suffix="5678",
+            is_active=True,
+            created_at=now,
+            updated_at=now,
+        )
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(
+            return_value=[_make_credential(org_id, credential_id), other]
+        )
+        use_case = ActivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        await use_case.execute(credential_id=credential_id, organization_id=org_id, user_id=uuid4())
+
+        # Then — les autres ne sont PAS désactivées
+        cred_repo.set_active.assert_awaited_once_with(credential_id, org_id)
+        cred_repo.set_inactive.assert_not_awaited()
+
+    async def test_activate_org_provider_api_key_not_found_raises_error(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[])
+        use_case = ActivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialNotFoundError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_activate_org_provider_api_key_access_denied(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.USER)
+        )
+        use_case = ActivateOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())

--- a/server/tests/unit/application/use_cases/org_credentials/test_deactivate_org_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/org_credentials/test_deactivate_org_provider_api_key.py
@@ -1,0 +1,160 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_credentials.deactivate_org_provider_api_key import (
+    DeactivateOrgProviderApiKey,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import (
+    OrgCredentialInUseError,
+    OrgCredentialNotFoundError,
+)
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_member(role: OrganizationMemberRole) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def _make_credential(org_id: object, credential_id: object) -> OrgModelProviderCredential:
+    now = datetime.now(UTC)
+    return OrgModelProviderCredential(
+        id=credential_id,
+        organization_id=org_id,
+        provider=ModelProvider("openai"),
+        encrypted_api_key="enc",
+        key_fingerprint="fp",
+        key_suffix="1234",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestDeactivateOrgProviderApiKey:
+    async def test_deactivate_org_provider_api_key_success(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[])
+        use_case = DeactivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When
+        await use_case.execute(credential_id=credential_id, organization_id=org_id, user_id=uuid4())
+
+        # Then
+        cred_repo.set_inactive.assert_awaited_once_with(credential_id, org_id)
+
+    async def test_deactivate_org_provider_api_key_not_found_raises_error(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[])
+        use_case = DeactivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=AsyncMock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialNotFoundError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_deactivate_org_provider_api_key_access_denied(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.USER)
+        )
+        use_case = DeactivateOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+            project_repository=AsyncMock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_deactivate_org_provider_api_key_in_use_by_embedding_raises_error(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project = type(
+            "P",
+            (),
+            {
+                "org_embedding_api_key_credential_id": credential_id,
+                "org_llm_api_key_credential_id": None,
+            },
+        )()
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[project])
+        use_case = DeactivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialInUseError):
+            await use_case.execute(
+                credential_id=credential_id, organization_id=org_id, user_id=uuid4()
+            )
+
+    async def test_deactivate_org_provider_api_key_in_use_by_llm_raises_error(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project = type(
+            "P",
+            (),
+            {
+                "org_embedding_api_key_credential_id": None,
+                "org_llm_api_key_credential_id": credential_id,
+            },
+        )()
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[project])
+        use_case = DeactivateOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialInUseError):
+            await use_case.execute(
+                credential_id=credential_id, organization_id=org_id, user_id=uuid4()
+            )

--- a/server/tests/unit/application/use_cases/org_credentials/test_delete_org_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/org_credentials/test_delete_org_provider_api_key.py
@@ -1,0 +1,160 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_credentials.delete_org_provider_api_key import (
+    DeleteOrgProviderApiKey,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import (
+    OrgCredentialInUseError,
+    OrgCredentialNotFoundError,
+)
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_member(role: OrganizationMemberRole) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def _make_credential(org_id: object, credential_id: object) -> OrgModelProviderCredential:
+    now = datetime.now(UTC)
+    return OrgModelProviderCredential(
+        id=credential_id,
+        organization_id=org_id,
+        provider=ModelProvider("openai"),
+        encrypted_api_key="enc",
+        key_fingerprint="fp",
+        key_suffix="1234",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestDeleteOrgProviderApiKey:
+    async def test_delete_org_provider_api_key_success(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[])
+        use_case = DeleteOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When
+        await use_case.execute(credential_id=credential_id, organization_id=org_id, user_id=uuid4())
+
+        # Then
+        cred_repo.delete.assert_awaited_once_with(credential_id, org_id)
+
+    async def test_delete_org_provider_api_key_not_found_raises_error(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[])
+        use_case = DeleteOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=AsyncMock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialNotFoundError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_delete_org_provider_api_key_access_denied(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.USER)
+        )
+        use_case = DeleteOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+            project_repository=AsyncMock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(credential_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_delete_org_provider_api_key_in_use_by_embedding_raises_error(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project = type(
+            "P",
+            (),
+            {
+                "org_embedding_api_key_credential_id": credential_id,
+                "org_llm_api_key_credential_id": None,
+            },
+        )()
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[project])
+        use_case = DeleteOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialInUseError):
+            await use_case.execute(
+                credential_id=credential_id, organization_id=org_id, user_id=uuid4()
+            )
+
+    async def test_delete_org_provider_api_key_in_use_by_llm_raises_error(self) -> None:
+        # Given
+        org_id = uuid4()
+        credential_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id, credential_id)])
+        project = type(
+            "P",
+            (),
+            {
+                "org_embedding_api_key_credential_id": None,
+                "org_llm_api_key_credential_id": credential_id,
+            },
+        )()
+        project_repo = AsyncMock()
+        project_repo.find_by_organization_id = AsyncMock(return_value=[project])
+        use_case = DeleteOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            project_repository=project_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrgCredentialInUseError):
+            await use_case.execute(
+                credential_id=credential_id, organization_id=org_id, user_id=uuid4()
+            )

--- a/server/tests/unit/application/use_cases/org_credentials/test_list_org_provider_api_keys.py
+++ b/server/tests/unit/application/use_cases/org_credentials/test_list_org_provider_api_keys.py
@@ -1,0 +1,107 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_credentials.list_org_provider_api_keys import (
+    ListOrgProviderApiKeys,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_member(role: OrganizationMemberRole) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def _make_credential(org_id: object) -> OrgModelProviderCredential:
+    now = datetime.now(UTC)
+    return OrgModelProviderCredential(
+        id=uuid4(),
+        organization_id=org_id,
+        provider=ModelProvider("openai"),
+        encrypted_api_key="enc",
+        key_fingerprint="fp",
+        key_suffix="abcd",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestListOrgProviderApiKeys:
+    async def test_list_org_provider_api_keys_returns_masked_credentials(self) -> None:
+        # Given
+        org_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[_make_credential(org_id)])
+        use_case = ListOrgProviderApiKeys(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        result = await use_case.execute(organization_id=org_id, user_id=uuid4())
+
+        # Then
+        assert len(result) == 1
+        assert result[0].masked_key == "...abcd"
+        assert result[0].provider == "openai"
+
+    async def test_list_org_provider_api_keys_accessible_by_maker(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.MAKER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[])
+        use_case = ListOrgProviderApiKeys(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        result = await use_case.execute(organization_id=uuid4(), user_id=uuid4())
+
+        # Then
+        assert result == []
+
+    async def test_list_org_provider_api_keys_accessible_by_user_role(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.USER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id = AsyncMock(return_value=[])
+        use_case = ListOrgProviderApiKeys(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        result = await use_case.execute(organization_id=uuid4(), user_id=uuid4())
+
+        # Then
+        assert result == []
+
+    async def test_list_org_provider_api_keys_access_denied_for_non_member(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(return_value=None)
+        use_case = ListOrgProviderApiKeys(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(organization_id=uuid4(), user_id=uuid4())

--- a/server/tests/unit/application/use_cases/org_credentials/test_save_org_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/org_credentials/test_save_org_provider_api_key.py
@@ -1,0 +1,197 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_credentials.save_org_provider_api_key import (
+    SaveOrgProviderApiKey,
+)
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.exceptions.provider_credential_exceptions import OrgDuplicateCredentialError
+from raggae.domain.exceptions.validation_errors import InvalidModelProviderError
+from raggae.domain.value_objects.model_provider import ModelProvider
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+def _make_member(role: OrganizationMemberRole) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def _make_existing_credential(org_id: object, fingerprint: str) -> OrgModelProviderCredential:
+    now = datetime.now(UTC)
+    return OrgModelProviderCredential(
+        id=uuid4(),
+        organization_id=org_id,
+        provider=ModelProvider("openai"),
+        encrypted_api_key="enc",
+        key_fingerprint=fingerprint,
+        key_suffix="1111",
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestSaveOrgProviderApiKey:
+    async def test_save_org_provider_api_key_success_as_owner(self) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id_and_provider = AsyncMock(return_value=[])
+        crypto = Mock()
+        crypto.fingerprint.return_value = "fp-new"
+        crypto.encrypt.return_value = "encrypted"
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=crypto,
+        )
+
+        # When
+        result = await use_case.execute(
+            organization_id=org_id, user_id=user_id, provider="openai", api_key="sk-test-abcd"
+        )
+
+        # Then
+        assert result.provider == "openai"
+        assert result.masked_key == "...abcd"
+        assert result.is_active is True
+        cred_repo.save.assert_awaited_once()
+
+    async def test_save_org_provider_api_key_success_as_maker(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.MAKER)
+        )
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id_and_provider = AsyncMock(return_value=[])
+        crypto = Mock()
+        crypto.fingerprint.return_value = "fp-new"
+        crypto.encrypt.return_value = "encrypted"
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=crypto,
+        )
+
+        # When
+        result = await use_case.execute(
+            organization_id=uuid4(), user_id=uuid4(), provider="gemini", api_key="AIza-test-1234"
+        )
+
+        # Then
+        assert result.is_active is True
+
+    async def test_save_org_provider_api_key_access_denied_for_user_role(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.USER)
+        )
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=Mock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                organization_id=uuid4(), user_id=uuid4(), provider="openai", api_key="sk-test"
+            )
+
+    async def test_save_org_provider_api_key_access_denied_for_non_member(self) -> None:
+        # Given
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(return_value=None)
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=Mock(),
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                organization_id=uuid4(), user_id=uuid4(), provider="openai", api_key="sk-test"
+            )
+
+    async def test_save_org_provider_api_key_duplicate_fingerprint_raises_error(self) -> None:
+        # Given
+        org_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        existing = _make_existing_credential(org_id, fingerprint="same-fp")
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id_and_provider = AsyncMock(return_value=[existing])
+        crypto = Mock()
+        crypto.fingerprint.return_value = "same-fp"
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=crypto,
+        )
+
+        # When / Then
+        with pytest.raises(OrgDuplicateCredentialError):
+            await use_case.execute(
+                organization_id=org_id, user_id=uuid4(), provider="openai", api_key="sk-test-xxxx"
+            )
+
+    async def test_save_org_provider_api_key_does_not_deactivate_existing(self) -> None:
+        # Given
+        org_id = uuid4()
+        member_repo = AsyncMock()
+        member_repo.find_by_organization_and_user = AsyncMock(
+            return_value=_make_member(OrganizationMemberRole.OWNER)
+        )
+        existing = _make_existing_credential(org_id, fingerprint="other-fp")
+        cred_repo = AsyncMock()
+        cred_repo.list_by_org_id_and_provider = AsyncMock(return_value=[existing])
+        crypto = Mock()
+        crypto.fingerprint.return_value = "new-fp"
+        crypto.encrypt.return_value = "encrypted"
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=cred_repo,
+            organization_member_repository=member_repo,
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=crypto,
+        )
+
+        # When
+        await use_case.execute(
+            organization_id=org_id, user_id=uuid4(), provider="openai", api_key="sk-test-xxxx"
+        )
+
+        # Then — les credentials existantes ne sont PAS désactivées
+        cred_repo.set_inactive.assert_not_awaited()
+
+    async def test_save_org_provider_api_key_invalid_provider_raises_error(self) -> None:
+        # Given
+        use_case = SaveOrgProviderApiKey(
+            org_credential_repository=AsyncMock(),
+            organization_member_repository=AsyncMock(),
+            provider_api_key_validator=Mock(),
+            provider_api_key_crypto_service=Mock(),
+        )
+
+        # When / Then
+        with pytest.raises(InvalidModelProviderError):
+            await use_case.execute(
+                organization_id=uuid4(), user_id=uuid4(), provider="mistral", api_key="invalid"
+            )

--- a/server/tests/unit/application/use_cases/provider_credentials/test_activate_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/provider_credentials/test_activate_provider_api_key.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.provider_credentials.activate_provider_api_key import (
     ActivateProviderApiKey,
 )
@@ -40,6 +41,48 @@ class TestActivateProviderApiKey:
 
         # Then
         repository.set_active.assert_awaited_once_with(credential_id, user_id)
+
+    async def test_activate_provider_api_key_does_not_deactivate_other_credentials_of_same_provider(
+        self,
+    ) -> None:
+        # Given — deux credentials pour le même provider, l'une inactive, l'autre active
+        credential_id = uuid4()
+        other_credential_id = uuid4()
+        user_id = uuid4()
+        now = datetime.now(UTC)
+        repository = AsyncMock()
+        repository.list_by_user_id.return_value = [
+            UserModelProviderCredential(
+                id=credential_id,
+                user_id=user_id,
+                provider=ModelProvider("openai"),
+                encrypted_api_key="enc",
+                key_fingerprint="fp1",
+                key_suffix="1111",
+                is_active=False,
+                created_at=now,
+                updated_at=now,
+            ),
+            UserModelProviderCredential(
+                id=other_credential_id,
+                user_id=user_id,
+                provider=ModelProvider("openai"),
+                encrypted_api_key="enc2",
+                key_fingerprint="fp2",
+                key_suffix="2222",
+                is_active=True,
+                created_at=now,
+                updated_at=now,
+            ),
+        ]
+        use_case = ActivateProviderApiKey(provider_credential_repository=repository)
+
+        # When
+        await use_case.execute(credential_id=credential_id, user_id=user_id)
+
+        # Then — la clé est activée mais l'autre n'est PAS désactivée
+        repository.set_active.assert_awaited_once_with(credential_id, user_id)
+        repository.set_inactive.assert_not_awaited()
 
     async def test_activate_provider_api_key_not_owned_by_user_raises_error(self) -> None:
         # Given

--- a/server/tests/unit/application/use_cases/provider_credentials/test_deactivate_provider_api_key.py
+++ b/server/tests/unit/application/use_cases/provider_credentials/test_deactivate_provider_api_key.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.provider_credentials.deactivate_provider_api_key import (
     DeactivateProviderApiKey,
 )

--- a/server/tests/unit/domain/entities/test_org_model_provider_credential.py
+++ b/server/tests/unit/domain/entities/test_org_model_provider_credential.py
@@ -1,0 +1,26 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from raggae.domain.entities.org_model_provider_credential import OrgModelProviderCredential
+from raggae.domain.value_objects.model_provider import ModelProvider
+
+
+def test_masked_key_with_last_four_should_return_masked_value() -> None:
+    # Given
+    credential = OrgModelProviderCredential(
+        id=uuid4(),
+        organization_id=uuid4(),
+        provider=ModelProvider("openai"),
+        encrypted_api_key="encrypted-value",
+        key_fingerprint="f0f1f2f3",
+        key_suffix="abcd",
+        is_active=True,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+    # When
+    masked_key = credential.masked_key
+
+    # Then
+    assert masked_key == "...abcd"


### PR DESCRIPTION
## Summary

### Backend
- Allow multiple active credentials per provider for both users and organizations (removes unique partial index per user+provider)
- Add `OrgModelProviderCredential` domain entity and org-specific credential exceptions
- Add 5 use cases for org credential management (Save, List, Activate, Deactivate, Delete) with OWNER/MAKER role enforcement
- Add `org_model_provider_credentials` table and FK columns on `projects` (`org_embedding_api_key_credential_id`, `org_llm_api_key_credential_id`)
- Expose REST endpoints at `POST|GET|PATCH|DELETE /api/v1/organizations/{org_id}/model-credentials`

### Frontend
- Add `OrgModelCredentialResponse` type
- Add API client and React Query hooks for org credentials endpoints
- Add `OrgCredentialsPanel` component in organization settings
- Split organization settings page into tabs: General / Members / API Keys
- Fix: project settings now loads org credentials for org projects (instead of user personal keys)

## Design decisions

- An organization can hold **multiple active credentials per provider** (unlike users, which previously allowed only one — now also relaxed)
- For **personal projects**: credentials are chosen from the user's active keys
- For **org projects**: credentials are chosen from the organization's active keys (no mixing)
- Projects store explicit credential IDs (`org_embedding_api_key_credential_id`, `org_llm_api_key_credential_id`)

## Test plan

- [x] Unit tests for all 5 org credential use cases (25 new tests)
- [x] Unit tests for updated user credential behavior (2 new tests, existing passing)
- [x] Domain entity test for `OrgModelProviderCredential`
- [ ] Run migrations against a local Postgres instance: `alembic upgrade head`
- [ ] Manual API smoke test via the new endpoints
- [ ] Navigate to an organization settings page → verify General / Members / API Keys tabs
- [ ] Add an org API key → verify it appears only in settings of projects belonging to that org