### PR TITLE
chore(lint): apply ruff format and remove unused imports

### DIFF
--- a/server/src/raggae/application/use_cases/organization/__init__.py
+++ b/server/src/raggae/application/use_cases/organization/__init__.py
@@ -7,22 +7,22 @@ from raggae.application.use_cases.organization.accept_user_organization_invitati
 from raggae.application.use_cases.organization.create_organization import CreateOrganization
 from raggae.application.use_cases.organization.delete_organization import DeleteOrganization
 from raggae.application.use_cases.organization.get_organization import GetOrganization
-from raggae.application.use_cases.organization.leave_organization import LeaveOrganization
 from raggae.application.use_cases.organization.invite_organization_member import (
     InviteOrganizationMember,
 )
+from raggae.application.use_cases.organization.leave_organization import LeaveOrganization
 from raggae.application.use_cases.organization.list_organization_invitations import (
     ListOrganizationInvitations,
 )
-from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
-    ListUserPendingOrganizationInvitations,
-)
-from raggae.application.use_cases.organization.list_organizations import ListOrganizations
 from raggae.application.use_cases.organization.list_organization_members import (
     ListOrganizationMembers,
 )
 from raggae.application.use_cases.organization.list_organization_projects import (
     ListOrganizationProjects,
+)
+from raggae.application.use_cases.organization.list_organizations import ListOrganizations
+from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
+    ListUserPendingOrganizationInvitations,
 )
 from raggae.application.use_cases.organization.remove_organization_member import (
     RemoveOrganizationMember,

--- a/server/src/raggae/application/use_cases/organization/create_organization.py
+++ b/server/src/raggae/application/use_cases/organization/create_organization.py
@@ -1,5 +1,5 @@
-from datetime import UTC, datetime
 import random
+from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
 from raggae.application.dto.organization_dto import OrganizationDTO

--- a/server/src/raggae/application/use_cases/organization/delete_organization.py
+++ b/server/src/raggae/application/use_cases/organization/delete_organization.py
@@ -1,10 +1,10 @@
 from uuid import UUID
 
-from raggae.application.interfaces.repositories.organization_member_repository import (
-    OrganizationMemberRepository,
-)
 from raggae.application.interfaces.repositories.organization_invitation_repository import (
     OrganizationInvitationRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
 )
 from raggae.application.interfaces.repositories.organization_repository import (
     OrganizationRepository,

--- a/server/src/raggae/application/use_cases/organization/resend_organization_invitation.py
+++ b/server/src/raggae/application/use_cases/organization/resend_organization_invitation.py
@@ -16,9 +16,6 @@ from raggae.domain.exceptions.organization_exceptions import (
     OrganizationInvitationInvalidError,
     OrganizationNotFoundError,
 )
-from raggae.domain.value_objects.organization_invitation_status import (
-    OrganizationInvitationStatus,
-)
 from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 

--- a/server/src/raggae/application/use_cases/project/create_project.py
+++ b/server/src/raggae/application/use_cases/project/create_project.py
@@ -4,27 +4,27 @@ from uuid import UUID, uuid4
 from raggae.application.constants import (
     DEFAULT_PROJECT_CHAT_HISTORY_MAX_CHARS,
     DEFAULT_PROJECT_CHAT_HISTORY_WINDOW_SIZE,
-    DEFAULT_PROJECT_RETRIEVAL_MIN_SCORE,
     DEFAULT_PROJECT_RERANKER_CANDIDATE_MULTIPLIER,
+    DEFAULT_PROJECT_RETRIEVAL_MIN_SCORE,
     DEFAULT_PROJECT_RETRIEVAL_TOP_K,
     MAX_PROJECT_CHAT_HISTORY_MAX_CHARS,
     MAX_PROJECT_CHAT_HISTORY_WINDOW_SIZE,
-    MAX_PROJECT_RETRIEVAL_MIN_SCORE,
     MAX_PROJECT_RERANKER_CANDIDATE_MULTIPLIER,
+    MAX_PROJECT_RETRIEVAL_MIN_SCORE,
     MAX_PROJECT_RETRIEVAL_TOP_K,
     MAX_PROJECT_SYSTEM_PROMPT_LENGTH,
     MIN_PROJECT_CHAT_HISTORY_MAX_CHARS,
     MIN_PROJECT_CHAT_HISTORY_WINDOW_SIZE,
-    MIN_PROJECT_RETRIEVAL_MIN_SCORE,
     MIN_PROJECT_RERANKER_CANDIDATE_MULTIPLIER,
+    MIN_PROJECT_RETRIEVAL_MIN_SCORE,
     MIN_PROJECT_RETRIEVAL_TOP_K,
 )
 from raggae.application.dto.project_dto import ProjectDTO
-from raggae.application.interfaces.repositories.project_repository import (
-    ProjectRepository,
-)
 from raggae.application.interfaces.repositories.organization_member_repository import (
     OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import (
+    ProjectRepository,
 )
 from raggae.application.interfaces.repositories.provider_credential_repository import (
     ProviderCredentialRepository,
@@ -33,10 +33,11 @@ from raggae.application.interfaces.services.provider_api_key_crypto_service impo
     ProviderApiKeyCryptoService,
 )
 from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
 from raggae.domain.exceptions.project_exceptions import (
-    InvalidProjectEmbeddingBackendError,
     InvalidProjectChatHistoryMaxCharsError,
     InvalidProjectChatHistoryWindowSizeError,
+    InvalidProjectEmbeddingBackendError,
     InvalidProjectLLMBackendError,
     InvalidProjectRerankerBackendError,
     InvalidProjectRerankerCandidateMultiplierError,
@@ -46,7 +47,6 @@ from raggae.domain.exceptions.project_exceptions import (
     ProjectAPIKeyNotOwnedError,
     ProjectSystemPromptTooLongError,
 )
-from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
 from raggae.domain.value_objects.model_provider import ModelProvider
 

--- a/server/src/raggae/presentation/api/v1/endpoints/auth.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/auth.py
@@ -3,9 +3,9 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
+from raggae.application.use_cases.user.get_current_user import GetCurrentUser
 from raggae.application.use_cases.user.login_user import LoginUser
 from raggae.application.use_cases.user.register_user import RegisterUser
-from raggae.application.use_cases.user.get_current_user import GetCurrentUser
 from raggae.application.use_cases.user.update_user_full_name import UpdateUserFullName
 from raggae.domain.exceptions.user_exceptions import (
     InvalidCredentialsError,

--- a/server/src/raggae/presentation/api/v1/endpoints/organizations.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/organizations.py
@@ -20,9 +20,6 @@ from raggae.application.use_cases.organization.leave_organization import LeaveOr
 from raggae.application.use_cases.organization.list_organization_invitations import (
     ListOrganizationInvitations,
 )
-from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
-    ListUserPendingOrganizationInvitations,
-)
 from raggae.application.use_cases.organization.list_organization_members import (
     ListOrganizationMembers,
 )
@@ -30,6 +27,9 @@ from raggae.application.use_cases.organization.list_organization_projects import
     ListOrganizationProjects,
 )
 from raggae.application.use_cases.organization.list_organizations import ListOrganizations
+from raggae.application.use_cases.organization.list_user_pending_organization_invitations import (
+    ListUserPendingOrganizationInvitations,
+)
 from raggae.application.use_cases.organization.remove_organization_member import (
     RemoveOrganizationMember,
 )
@@ -59,10 +59,10 @@ from raggae.presentation.api.dependencies import (
     get_invite_organization_member_use_case,
     get_leave_organization_use_case,
     get_list_organization_invitations_use_case,
-    get_list_user_pending_organization_invitations_use_case,
     get_list_organization_members_use_case,
     get_list_organization_projects_use_case,
     get_list_organizations_use_case,
+    get_list_user_pending_organization_invitations_use_case,
     get_remove_organization_member_use_case,
     get_resend_organization_invitation_use_case,
     get_revoke_organization_invitation_use_case,
@@ -76,9 +76,9 @@ from raggae.presentation.api.v1.schemas.organization_schemas import (
     OrganizationInvitationResponse,
     OrganizationMemberResponse,
     OrganizationResponse,
-    UserPendingOrganizationInvitationResponse,
     UpdateOrganizationMemberRoleRequest,
     UpdateOrganizationRequest,
+    UserPendingOrganizationInvitationResponse,
 )
 from raggae.presentation.api.v1.schemas.project_schemas import ProjectResponse
 

--- a/server/src/raggae/presentation/main.py
+++ b/server/src/raggae/presentation/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from raggae.presentation.api.dependencies import get_query_relevant_chunks_use_case
 from raggae.presentation.api.v1.endpoints.auth import router as auth_router
 from raggae.presentation.api.v1.endpoints.chat import router as chat_router
 from raggae.presentation.api.v1.endpoints.documents import router as documents_router
@@ -15,7 +16,6 @@ from raggae.presentation.api.v1.endpoints.org_model_credentials import (
 )
 from raggae.presentation.api.v1.endpoints.organizations import router as organizations_router
 from raggae.presentation.api.v1.endpoints.projects import router as projects_router
-from raggae.presentation.api.dependencies import get_query_relevant_chunks_use_case
 
 
 @asynccontextmanager

--- a/server/tests/e2e/test_chat_endpoints.py
+++ b/server/tests/e2e/test_chat_endpoints.py
@@ -2,6 +2,7 @@ import json
 from uuid import uuid4
 
 from httpx import AsyncClient
+
 from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
 

--- a/server/tests/e2e/test_document_processing_error_endpoints.py
+++ b/server/tests/e2e/test_document_processing_error_endpoints.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+
 from raggae.domain.exceptions.document_exceptions import EmbeddingGenerationError
 
 

--- a/server/tests/integration/test_document_processing_flow.py
+++ b/server/tests/integration/test_document_processing_flow.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.services.document_indexing_service import DocumentIndexingService
 from raggae.application.use_cases.document.delete_document import DeleteDocument
 from raggae.application.use_cases.document.upload_document import UploadDocument

--- a/server/tests/integration/test_document_processing_with_postgres.py
+++ b/server/tests/integration/test_document_processing_with_postgres.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.application.use_cases.document.upload_document import UploadDocument
 from raggae.domain.entities.project import Project
 from raggae.infrastructure.database.models import Base
@@ -32,7 +34,6 @@ from raggae.infrastructure.services.simple_text_chunker_service import (
 from raggae.infrastructure.services.simple_text_sanitizer_service import (
     SimpleTextSanitizerService,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestDocumentProcessingWithPostgres:

--- a/server/tests/integration/test_minio_file_storage_service.py
+++ b/server/tests/integration/test_minio_file_storage_service.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import pytest
+
 from raggae.infrastructure.services.minio_file_storage_service import MinioFileStorageService
 
 

--- a/server/tests/integration/test_openai_embedding_service.py
+++ b/server/tests/integration/test_openai_embedding_service.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+
 from raggae.infrastructure.services.openai_embedding_service import OpenAIEmbeddingService
 
 

--- a/server/tests/integration/test_sqlalchemy_chunk_retrieval_service.py
+++ b/server/tests/integration/test_sqlalchemy_chunk_retrieval_service.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.document_chunk import DocumentChunk
 from raggae.infrastructure.database.models import Base
@@ -14,7 +16,6 @@ from raggae.infrastructure.database.repositories.sqlalchemy_document_repository 
 from raggae.infrastructure.services.sqlalchemy_chunk_retrieval_service import (
     SQLAlchemyChunkRetrievalService,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyChunkRetrievalService:

--- a/server/tests/integration/test_sqlalchemy_conversation_and_message_repositories.py
+++ b/server/tests/integration/test_sqlalchemy_conversation_and_message_repositories.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.message import Message
 from raggae.domain.entities.project import Project
 from raggae.domain.entities.user import User
@@ -19,7 +21,6 @@ from raggae.infrastructure.database.repositories.sqlalchemy_project_repository i
 from raggae.infrastructure.database.repositories.sqlalchemy_user_repository import (
     SQLAlchemyUserRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyConversationAndMessageRepositories:

--- a/server/tests/integration/test_sqlalchemy_document_chunk_repository.py
+++ b/server/tests/integration/test_sqlalchemy_document_chunk_repository.py
@@ -2,12 +2,13 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.document_chunk import DocumentChunk
 from raggae.infrastructure.database.models import Base
 from raggae.infrastructure.database.repositories.sqlalchemy_document_chunk_repository import (
     SQLAlchemyDocumentChunkRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyDocumentChunkRepository:

--- a/server/tests/integration/test_sqlalchemy_document_repository.py
+++ b/server/tests/integration/test_sqlalchemy_document_repository.py
@@ -2,13 +2,14 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.document import Document
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
 from raggae.infrastructure.database.models import Base
 from raggae.infrastructure.database.repositories.sqlalchemy_document_repository import (
     SQLAlchemyDocumentRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyDocumentRepository:

--- a/server/tests/integration/test_sqlalchemy_organization_repositories.py
+++ b/server/tests/integration/test_sqlalchemy_organization_repositories.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.organization import Organization
 from raggae.domain.entities.organization_invitation import OrganizationInvitation
 from raggae.domain.entities.organization_member import OrganizationMember
@@ -20,7 +22,6 @@ from raggae.infrastructure.database.repositories.sqlalchemy_organization_member_
 from raggae.infrastructure.database.repositories.sqlalchemy_organization_repository import (
     SQLAlchemyOrganizationRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyOrganizationRepositories:

--- a/server/tests/integration/test_sqlalchemy_project_repository.py
+++ b/server/tests/integration/test_sqlalchemy_project_repository.py
@@ -2,13 +2,14 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.project import Project
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
 from raggae.infrastructure.database.models import Base
 from raggae.infrastructure.database.repositories.sqlalchemy_project_repository import (
     SQLAlchemyProjectRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyProjectRepository:

--- a/server/tests/integration/test_sqlalchemy_provider_credential_repository.py
+++ b/server/tests/integration/test_sqlalchemy_provider_credential_repository.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.user import User
 from raggae.domain.entities.user_model_provider_credential import UserModelProviderCredential
 from raggae.domain.value_objects.model_provider import ModelProvider
@@ -12,7 +14,6 @@ from raggae.infrastructure.database.repositories.sqlalchemy_provider_credential_
 from raggae.infrastructure.database.repositories.sqlalchemy_user_repository import (
     SQLAlchemyUserRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyProviderCredentialRepository:

--- a/server/tests/integration/test_sqlalchemy_user_repository.py
+++ b/server/tests/integration/test_sqlalchemy_user_repository.py
@@ -2,12 +2,13 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
 from raggae.domain.entities.user import User
 from raggae.infrastructure.database.models import Base
 from raggae.infrastructure.database.repositories.sqlalchemy_user_repository import (
     SQLAlchemyUserRepository,
 )
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 
 class TestSQLAlchemyUserRepository:

--- a/server/tests/unit/application/services/test_document_indexing_service.py
+++ b/server/tests/unit/application/services/test_document_indexing_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.dto.document_structure_analysis_dto import DocumentStructureAnalysisDTO
 from raggae.application.interfaces.services.file_metadata_extractor import FileMetadata
 from raggae.application.services.document_indexing_service import DocumentIndexingService

--- a/server/tests/unit/application/use_cases/chat/test_delete_conversation.py
+++ b/server/tests/unit/application/use_cases/chat/test_delete_conversation.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.delete_conversation import DeleteConversation
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/chat/test_get_conversation.py
+++ b/server/tests/unit/application/use_cases/chat/test_get_conversation.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.get_conversation import GetConversation
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.message import Message

--- a/server/tests/unit/application/use_cases/chat/test_list_conversation_messages.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversation_messages.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.list_conversation_messages import (
     ListConversationMessages,
 )

--- a/server/tests/unit/application/use_cases/chat/test_list_conversations.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversations.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.list_conversations import ListConversations
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/chat/test_list_conversations_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_conversations_org_access.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.list_conversations import ListConversations
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.organization_member import OrganizationMember

--- a/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
+++ b/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
 from raggae.application.use_cases.chat.query_relevant_chunks import QueryRelevantChunks
 from raggae.domain.entities.document_chunk import DocumentChunk

--- a/server/tests/unit/application/use_cases/chat/test_send_message.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, AsyncMock, Mock
 from uuid import UUID, uuid4
 
 import pytest
+
 from raggae.application.dto.query_relevant_chunks_result_dto import (
     QueryRelevantChunksResultDTO,
 )

--- a/server/tests/unit/application/use_cases/chat/test_send_message_org_access.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message_org_access.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.dto.query_relevant_chunks_result_dto import QueryRelevantChunksResultDTO
 from raggae.application.use_cases.chat.send_message import SendMessage
 from raggae.domain.entities.conversation import Conversation

--- a/server/tests/unit/application/use_cases/chat/test_send_message_persistence.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message_persistence.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.dto.query_relevant_chunks_result_dto import (
     QueryRelevantChunksResultDTO,
 )

--- a/server/tests/unit/application/use_cases/chat/test_send_message_stream.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message_stream.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
+
 from raggae.application.dto.chat_stream_event import ChatStreamDone, ChatStreamToken
 from raggae.application.dto.query_relevant_chunks_result_dto import (
     QueryRelevantChunksResultDTO,

--- a/server/tests/unit/application/use_cases/chat/test_update_conversation.py
+++ b/server/tests/unit/application/use_cases/chat/test_update_conversation.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.chat.update_conversation import UpdateConversation
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_delete_document.py
+++ b/server/tests/unit/application/use_cases/document/test_delete_document.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.delete_document import DeleteDocument
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_get_document_file.py
+++ b/server/tests/unit/application/use_cases/document/test_get_document_file.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.get_document_file import GetDocumentFile
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_list_document_chunks.py
+++ b/server/tests/unit/application/use_cases/document/test_list_document_chunks.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.list_document_chunks import ListDocumentChunks
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.document_chunk import DocumentChunk

--- a/server/tests/unit/application/use_cases/document/test_list_project_documents.py
+++ b/server/tests/unit/application/use_cases/document/test_list_project_documents.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.list_project_documents import ListProjectDocuments
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_reindex_document.py
+++ b/server/tests/unit/application/use_cases/document/test_reindex_document.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.reindex_document import ReindexDocument
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_upload_document.py
+++ b/server/tests/unit/application/use_cases/document/test_upload_document.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.upload_document import UploadDocument
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/document/test_upload_document_processing.py
+++ b/server/tests/unit/application/use_cases/document/test_upload_document_processing.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.dto.document_structure_analysis_dto import DocumentStructureAnalysisDTO
 from raggae.application.services.document_indexing_service import DocumentIndexingService
 from raggae.application.use_cases.document.upload_document import UploadDocument

--- a/server/tests/unit/application/use_cases/document/test_upload_documents.py
+++ b/server/tests/unit/application/use_cases/document/test_upload_documents.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.document.upload_document import (
     UploadDocument,
     UploadDocumentItem,

--- a/server/tests/unit/application/use_cases/organization/test_organization_invitation_use_cases.py
+++ b/server/tests/unit/application/use_cases/organization/test_organization_invitation_use_cases.py
@@ -27,6 +27,7 @@ from raggae.application.use_cases.organization.revoke_organization_invitation im
 from raggae.domain.entities.organization import Organization
 from raggae.domain.entities.organization_invitation import OrganizationInvitation
 from raggae.domain.entities.organization_member import OrganizationMember
+from raggae.domain.entities.user import User
 from raggae.domain.exceptions.organization_exceptions import (
     OrganizationInvitationInvalidError,
 )
@@ -46,7 +47,6 @@ from raggae.infrastructure.database.repositories.in_memory_organization_reposito
 from raggae.infrastructure.database.repositories.in_memory_user_repository import (
     InMemoryUserRepository,
 )
-from raggae.domain.entities.user import User
 
 
 class TestOrganizationInvitationUseCases:

--- a/server/tests/unit/application/use_cases/organization/test_organization_use_cases.py
+++ b/server/tests/unit/application/use_cases/organization/test_organization_use_cases.py
@@ -15,10 +15,10 @@ from raggae.domain.exceptions.organization_exceptions import (
     OrganizationAccessDeniedError,
     OrganizationNotFoundError,
 )
-from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 from raggae.domain.value_objects.organization_invitation_status import (
     OrganizationInvitationStatus,
 )
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 from raggae.infrastructure.database.repositories.in_memory_organization_invitation_repository import (
     InMemoryOrganizationInvitationRepository,
 )

--- a/server/tests/unit/application/use_cases/project/test_create_project.py
+++ b/server/tests/unit/application/use_cases/project/test_create_project.py
@@ -3,8 +3,10 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.create_project import CreateProject
 from raggae.domain.entities.user_model_provider_credential import UserModelProviderCredential
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
 from raggae.domain.exceptions.project_exceptions import (
     InvalidProjectChatHistoryMaxCharsError,
     InvalidProjectChatHistoryWindowSizeError,
@@ -16,7 +18,6 @@ from raggae.domain.exceptions.project_exceptions import (
     ProjectAPIKeyNotOwnedError,
     ProjectSystemPromptTooLongError,
 )
-from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
 from raggae.domain.value_objects.model_provider import ModelProvider
 

--- a/server/tests/unit/application/use_cases/project/test_delete_project.py
+++ b/server/tests/unit/application/use_cases/project/test_delete_project.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.delete_project import DeleteProject
 from raggae.domain.entities.project import Project
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError

--- a/server/tests/unit/application/use_cases/project/test_get_project.py
+++ b/server/tests/unit/application/use_cases/project/test_get_project.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.get_project import GetProject
 from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/project/test_list_projects.py
+++ b/server/tests/unit/application/use_cases/project/test_list_projects.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.list_projects import ListProjects
 from raggae.domain.entities.project import Project
 

--- a/server/tests/unit/application/use_cases/project/test_publish_project.py
+++ b/server/tests/unit/application/use_cases/project/test_publish_project.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.publish_project import PublishProject
 from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/project/test_reindex_project.py
+++ b/server/tests/unit/application/use_cases/project/test_reindex_project.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.reindex_project import ReindexProject
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/project/test_unpublish_project.py
+++ b/server/tests/unit/application/use_cases/project/test_unpublish_project.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.unpublish_project import UnpublishProject
 from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/project/test_update_project.py
+++ b/server/tests/unit/application/use_cases/project/test_update_project.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.project.update_project import UpdateProject
 from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project

--- a/server/tests/unit/application/use_cases/user/test_login_user.py
+++ b/server/tests/unit/application/use_cases/user/test_login_user.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.user.login_user import LoginUser
 from raggae.domain.entities.user import User
 from raggae.domain.exceptions.user_exceptions import InvalidCredentialsError

--- a/server/tests/unit/application/use_cases/user/test_register_user.py
+++ b/server/tests/unit/application/use_cases/user/test_register_user.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.user.register_user import RegisterUser
 from raggae.domain.entities.user import User
 from raggae.domain.exceptions.user_exceptions import UserAlreadyExistsError

--- a/server/tests/unit/application/use_cases/user/test_update_user_full_name.py
+++ b/server/tests/unit/application/use_cases/user/test_update_user_full_name.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+
 from raggae.application.use_cases.user.update_user_full_name import UpdateUserFullName
 from raggae.domain.entities.user import User
 from raggae.domain.exceptions.user_exceptions import UserNotFoundError

--- a/server/tests/unit/domain/entities/test_document.py
+++ b/server/tests/unit/domain/entities/test_document.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+
 from raggae.domain.entities.document import Document
 from raggae.domain.exceptions.document_exceptions import (
     InvalidDocumentStatusTransitionError,

--- a/server/tests/unit/domain/entities/test_message.py
+++ b/server/tests/unit/domain/entities/test_message.py
@@ -2,6 +2,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+
 from raggae.domain.entities.message import Message
 
 

--- a/server/tests/unit/domain/entities/test_project.py
+++ b/server/tests/unit/domain/entities/test_project.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+
 from raggae.domain.entities.project import Project
 from raggae.domain.exceptions.project_exceptions import (
     ProjectAlreadyPublishedError,

--- a/server/tests/unit/domain/entities/test_user.py
+++ b/server/tests/unit/domain/entities/test_user.py
@@ -3,6 +3,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+
 from raggae.domain.entities.user import User
 from raggae.domain.exceptions.user_exceptions import UserAlreadyInactiveError
 

--- a/server/tests/unit/domain/value_objects/test_chunk_level.py
+++ b/server/tests/unit/domain/value_objects/test_chunk_level.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.value_objects.chunk_level import ChunkLevel
 
 

--- a/server/tests/unit/domain/value_objects/test_document_status.py
+++ b/server/tests/unit/domain/value_objects/test_document_status.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.value_objects.document_status import DocumentStatus
 
 

--- a/server/tests/unit/domain/value_objects/test_email.py
+++ b/server/tests/unit/domain/value_objects/test_email.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.exceptions.validation_errors import InvalidEmailError
 from raggae.domain.value_objects.email import Email
 

--- a/server/tests/unit/domain/value_objects/test_model_provider.py
+++ b/server/tests/unit/domain/value_objects/test_model_provider.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.exceptions.validation_errors import InvalidModelProviderError
 from raggae.domain.value_objects.model_provider import ModelProvider
 

--- a/server/tests/unit/domain/value_objects/test_password.py
+++ b/server/tests/unit/domain/value_objects/test_password.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.exceptions.validation_errors import WeakPasswordError
 from raggae.domain.value_objects.password import Password
 

--- a/server/tests/unit/infrastructure/services/test_cross_encoder_reranker_service.py
+++ b/server/tests/unit/infrastructure/services/test_cross_encoder_reranker_service.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 import numpy as np
 import pytest
+
 from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
 from raggae.infrastructure.services.cross_encoder_reranker_service import (
     CrossEncoderRerankerService,

--- a/server/tests/unit/infrastructure/services/test_in_memory_file_storage_service.py
+++ b/server/tests/unit/infrastructure/services/test_in_memory_file_storage_service.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.infrastructure.services.in_memory_file_storage_service import (
     InMemoryFileStorageService,
 )

--- a/server/tests/unit/infrastructure/services/test_ollama_embedding_service.py
+++ b/server/tests/unit/infrastructure/services/test_ollama_embedding_service.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import EmbeddingGenerationError
 from raggae.infrastructure.services.ollama_embedding_service import OllamaEmbeddingService
 

--- a/server/tests/unit/infrastructure/test_gemini_embedding_service.py
+++ b/server/tests/unit/infrastructure/test_gemini_embedding_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import EmbeddingGenerationError
 from raggae.infrastructure.services.gemini_embedding_service import GeminiEmbeddingService
 

--- a/server/tests/unit/infrastructure/test_gemini_llm_service.py
+++ b/server/tests/unit/infrastructure/test_gemini_llm_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
 from raggae.infrastructure.services.gemini_llm_service import GeminiLLMService
 

--- a/server/tests/unit/infrastructure/test_langdetect_language_detector.py
+++ b/server/tests/unit/infrastructure/test_langdetect_language_detector.py
@@ -2,6 +2,7 @@ import sys
 import types
 
 import pytest
+
 from raggae.infrastructure.services.langdetect_language_detector import (
     LangdetectLanguageDetector,
 )

--- a/server/tests/unit/infrastructure/test_llamaindex_text_chunker_service.py
+++ b/server/tests/unit/infrastructure/test_llamaindex_text_chunker_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from raggae.infrastructure.services.llamaindex_text_chunker_service import (
     LlamaIndexTextChunkerService,
 )

--- a/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
+++ b/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
@@ -4,6 +4,7 @@ from io import BytesIO
 
 import pytest
 from docx import Document as DocxDocument
+
 from raggae.domain.exceptions.document_exceptions import DocumentExtractionError
 from raggae.infrastructure.services.multiformat_document_text_extractor import (
     MultiFormatDocumentTextExtractor,

--- a/server/tests/unit/infrastructure/test_ollama_llm_service.py
+++ b/server/tests/unit/infrastructure/test_ollama_llm_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
 from raggae.infrastructure.services.ollama_llm_service import OllamaLLMService
 

--- a/server/tests/unit/infrastructure/test_openai_embedding_service.py
+++ b/server/tests/unit/infrastructure/test_openai_embedding_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import EmbeddingGenerationError
 from raggae.infrastructure.services.openai_embedding_service import OpenAIEmbeddingService
 

--- a/server/tests/unit/infrastructure/test_openai_llm_service.py
+++ b/server/tests/unit/infrastructure/test_openai_llm_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
 from raggae.infrastructure.services.openai_llm_service import OpenAILLMService
 

--- a/server/tests/unit/infrastructure/test_pdf_docx_file_metadata_extractor.py
+++ b/server/tests/unit/infrastructure/test_pdf_docx_file_metadata_extractor.py
@@ -5,6 +5,7 @@ from io import BytesIO
 
 import pytest
 from docx import Document as DocxDocument
+
 from raggae.application.interfaces.services.file_metadata_extractor import FileMetadata
 from raggae.infrastructure.services.pdf_docx_file_metadata_extractor import (
     PdfDocxFileMetadataExtractor,

--- a/server/tests/unit/infrastructure/test_resolve_strategy.py
+++ b/server/tests/unit/infrastructure/test_resolve_strategy.py
@@ -1,6 +1,7 @@
 """Tests for _resolve_strategy across all three copies."""
 
 import pytest
+
 from raggae.application.use_cases.chat.query_relevant_chunks import (
     _resolve_strategy as resolve_strategy_use_case,
 )

--- a/server/tests/unit/infrastructure/test_simple_provider_api_key_validator.py
+++ b/server/tests/unit/infrastructure/test_simple_provider_api_key_validator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from raggae.domain.exceptions.validation_errors import InvalidProviderApiKeyError
 from raggae.domain.value_objects.model_provider import ModelProvider
 from raggae.infrastructure.services.simple_provider_api_key_validator import (


### PR DESCRIPTION
## Summary

- Réordonnancement des imports selon l'ordre alphabétique (ruff)
- Correction des imports third-party placés après les imports locaux
- Suppression des imports inutilisés (`OrganizationInvitationStatus`, `ANY`)
- Correction d'indentation et de longueur de ligne

## Test plan

- [ ] Vérifier que `ruff format src/ tests/` ne produit aucun changement
- [ ] Vérifier que `ruff check src/ tests/` ne remonte que les E501 préexistants (lignes trop longues non auto-fixables)
- [ ] Les tests existants passent sans modification