### PR TITLE
feat(docker): production Docker setup and CI/CD image publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,51 @@
+# =============================================================================
+# RAGGAE — Environment variables template
+# Copy this file to .env and fill in the values.
+# =============================================================================
+
+# --- PostgreSQL ---
+POSTGRES_USER=raggae
+POSTGRES_PASSWORD=change_me
+POSTGRES_DB=raggae
+
+# --- MinIO (S3-compatible storage) ---
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=change_me
+S3_ENDPOINT_URL=http://minio:9000
+S3_ACCESS_KEY=minioadmin
+S3_SECRET_KEY=change_me
+S3_BUCKET_NAME=raggae-documents
+S3_REGION=us-east-1
+S3_SECURE=false
+
+# --- Security ---
+# Generate with: openssl rand -hex 32
+SECRET_KEY=change_me
+# Generate with: openssl rand -base64 32
+CREDENTIALS_ENCRYPTION_KEY=change_me
+
+# --- CORS ---
+# Comma-separated list of allowed origins
+ALLOWED_ORIGINS=http://localhost:3000
+
+# --- Backends ---
+STORAGE_BACKEND=s3
+PERSISTENCE_BACKEND=postgres
+PROCESSING_MODE=async
+
+# --- LLM provider (openai | gemini | ollama | inmemory) ---
+DEFAULT_LLM_PROVIDER=openai
+DEFAULT_LLM_API_KEY=
+DEFAULT_LLM_MODEL=gpt-4o-mini
+
+# --- Embedding provider (openai | gemini | ollama | inmemory) ---
+DEFAULT_EMBEDDING_PROVIDER=openai
+DEFAULT_EMBEDDING_API_KEY=
+DEFAULT_EMBEDDING_MODEL=text-embedding-3-small
+
+# --- Server ---
+SERVER_PORT=8000
+UVICORN_WORKERS=2
+
+# --- Client ---
+CLIENT_PORT=3000

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,103 @@
+name: Build & Publish Docker images
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+
+env:
+  REGISTRY: ghcr.io
+  OWNER: ${{ github.repository_owner }}
+
+jobs:
+  build-server:
+    name: Build & push server image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/raggae-server
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          dockerfile: ./server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+
+  build-client:
+    name: Build & push client image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.OWNER }}/raggae-client
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./client
+          dockerfile: ./client/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=client
+          cache-to: type=gha,mode=max,scope=client
+          build-args: |
+            NEXT_API_URL=http://server:8000

--- a/client/.dockerignore
+++ b/client/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+.env
+.env.*
+!.env.example
+tests/
+*.test.*
+*.spec.*

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,49 @@
+# syntax=docker/dockerfile:1
+
+# ---- deps ----
+FROM node:24-alpine AS deps
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# ---- builder ----
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ARG NEXT_API_URL=http://server:8000
+ENV NEXT_API_URL=${NEXT_API_URL}
+
+RUN pnpm build
+
+# ---- runner ----
+FROM node:24-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+CMD ["node", "server.js"]

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -19,7 +19,10 @@ const gitCommit =
   process.env.GIT_COMMIT ??
   readGitValue("git rev-parse HEAD");
 
+const apiBaseUrl = process.env.NEXT_API_URL ?? "http://localhost:8000";
+
 const nextConfig: NextConfig = {
+  output: "standalone",
   env: {
     NEXT_PUBLIC_APP_GIT_BRANCH: gitBranch,
     NEXT_PUBLIC_APP_GIT_COMMIT: gitCommit,
@@ -28,7 +31,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: "/api/v1/:path*",
-        destination: "http://localhost:8000/api/v1/:path*",
+        destination: `${apiBaseUrl}/api/v1/:path*`,
       },
     ];
   },

--- a/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -242,7 +242,7 @@ export default function ProjectSettingsPage() {
 
   function handleSave() {
     const parentChildChanged =
-      effectiveParentChildChunking !== project.parent_child_chunking;
+      effectiveParentChildChunking !== project?.parent_child_chunking;
     if (parentChildChanged) {
       setPendingData(payload);
       setReindexWarningOpen(true);

--- a/client/src/components/documents/document-row.tsx
+++ b/client/src/components/documents/document-row.tsx
@@ -219,18 +219,18 @@ export function DocumentRow({
             {!previewLoading && !previewError && previewUrl && previewType === "application/pdf" && (
               <iframe src={previewUrl} title={document.file_name} className="h-[84vh] w-full rounded-md border" />
             )}
-            {!previewLoading && !previewError && previewUrl && previewType.startsWith("image/") && (
+            {!previewLoading && !previewError && previewUrl && previewType?.startsWith("image/") && (
               <img src={previewUrl} alt={document.file_name} className="mx-auto max-h-[84vh] object-contain" />
             )}
-            {!previewLoading && !previewError && previewUrl && previewType.startsWith("text/") && (
+            {!previewLoading && !previewError && previewUrl && previewType?.startsWith("text/") && (
               <iframe src={previewUrl} title={document.file_name} className="h-[84vh] w-full rounded-md border bg-background" />
             )}
             {!previewLoading &&
               !previewError &&
               previewUrl &&
-              !previewType.startsWith("image/") &&
+              !previewType?.startsWith("image/") &&
               previewType !== "application/pdf" &&
-              !previewType.startsWith("text/") && (
+              !previewType?.startsWith("text/") && (
                 <div className="space-y-3">
                   <p className="text-sm text-muted-foreground">
                     Preview is not available for this file type.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,80 @@
+services:
+  postgres:
+    image: pgvector/pgvector:pg18
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
+    command: server /data --console-address ":9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  server:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "${SERVER_PORT:-8000}:8000"
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
+      SECRET_KEY: ${SECRET_KEY}
+      CREDENTIALS_ENCRYPTION_KEY: ${CREDENTIALS_ENCRYPTION_KEY}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS}
+      STORAGE_BACKEND: ${STORAGE_BACKEND:-s3}
+      PERSISTENCE_BACKEND: ${PERSISTENCE_BACKEND:-postgres}
+      PROCESSING_MODE: ${PROCESSING_MODE:-async}
+      S3_ENDPOINT_URL: ${S3_ENDPOINT_URL:-http://minio:9000}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY}
+      S3_SECRET_KEY: ${S3_SECRET_KEY}
+      S3_BUCKET_NAME: ${S3_BUCKET_NAME:-raggae-documents}
+      S3_REGION: ${S3_REGION:-us-east-1}
+      S3_SECURE: ${S3_SECURE:-false}
+      DEFAULT_LLM_PROVIDER: ${DEFAULT_LLM_PROVIDER:-openai}
+      DEFAULT_LLM_API_KEY: ${DEFAULT_LLM_API_KEY:-}
+      DEFAULT_LLM_MODEL: ${DEFAULT_LLM_MODEL:-}
+      DEFAULT_EMBEDDING_PROVIDER: ${DEFAULT_EMBEDDING_PROVIDER:-openai}
+      DEFAULT_EMBEDDING_API_KEY: ${DEFAULT_EMBEDDING_API_KEY:-}
+      DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-}
+      UVICORN_WORKERS: ${UVICORN_WORKERS:-2}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+
+  client:
+    build:
+      context: ./client
+      dockerfile: Dockerfile
+      args:
+        NEXT_API_URL: http://server:8000
+    restart: unless-stopped
+    ports:
+      - "${CLIENT_PORT:-3000}:3000"
+    depends_on:
+      - server
+
+volumes:
+  postgres_data:
+  minio_data:

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,14 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+.coverage
+tests/
+.env
+.env.*
+!.env.example

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder ----
+FROM python:3.13-slim AS builder
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY pyproject.toml .
+COPY src/ src/
+
+RUN pip install --no-cache-dir .
+
+# ---- runtime ----
+FROM python:3.13-slim AS runtime
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+COPY src/ src/
+COPY alembic/ alembic/
+COPY alembic.ini alembic.ini
+COPY entrypoint.sh entrypoint.sh
+
+RUN chmod +x entrypoint.sh
+
+EXPOSE 8000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+alembic upgrade head
+
+echo "Starting server..."
+exec uvicorn src.raggae.presentation.main:app \
+  --host 0.0.0.0 \
+  --port 8000 \
+  --workers "${UVICORN_WORKERS:-2}"


### PR DESCRIPTION
## Summary

- Ajout du `Dockerfile` server (Python 3.13-slim, multi-stage, migrations Alembic au démarrage)
- Ajout du `Dockerfile` client (Node 24-alpine, multi-stage, Next.js standalone)
- Activation du mode `output: standalone` Next.js et URL API configurable via `NEXT_API_URL`
- Ajout du `docker-compose.prod.yml` générique (postgres/pgvector pg18, minio, server, client)
- Ajout du `.env.example` documentant toutes les variables nécessaires
- Ajout du workflow GitHub Actions (`docker-publish.yml`) pour builder et pousser les images sur GHCR

## Images publiées

Sur push `main` ou tag `v*` :
- `ghcr.io/<owner>/raggae-server`
- `ghcr.io/<owner>/raggae-client`

Tags générés : `main`, `sha-<commit>`, `1.2.3` / `1.2` (sur tag semver).

## Test plan

- [x] `docker build -f server/Dockerfile ./server` se termine sans erreur
- [x] `docker build -f client/Dockerfile ./client` se termine sans erreur
- [ ] `docker compose -f docker-compose.prod.yml up` démarre la stack complète
- [ ] Le workflow CI se déclenche sur push `main` et pousse les images sur GHCR