### PR TITLE
fix(docker): rename services to raggae-server and raggae-client

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -100,4 +100,4 @@ jobs:
           cache-from: type=gha,scope=client
           cache-to: type=gha,mode=max,scope=client
           build-args: |
-            NEXT_API_URL=http://server:8000
+            NEXT_API_URL=http://raggae-server:8000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -29,7 +29,7 @@ services:
       timeout: 5s
       retries: 5
 
-  server:
+  raggae-server:
     build:
       context: ./server
       dockerfile: Dockerfile
@@ -63,17 +63,17 @@ services:
       minio:
         condition: service_healthy
 
-  client:
+  raggae-client:
     build:
       context: ./client
       dockerfile: Dockerfile
       args:
-        NEXT_API_URL: http://server:8000
+        NEXT_API_URL: http://raggae-server:8000
     restart: unless-stopped
     ports:
       - "${CLIENT_PORT:-3000}:3000"
     depends_on:
-      - server
+      - raggae-server
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Problème

L'image client était buildée avec `NEXT_API_URL=http://server:8000` en dur.
Or le projet de déploiement utilise les noms de service `raggae-server` et `raggae-client`,
rendant le proxy Next.js non fonctionnel sur le VPS.

## Changements

- `docker-compose.prod.yml` : renommage `server` → `raggae-server`, `client` → `raggae-client`
- `docker-publish.yml` : mise à jour du `build-arg` `NEXT_API_URL=http://raggae-server:8000`

## Impact

Le CI va rebuilder et republier l'image client avec la bonne URL backend.