### PR TITLE
feat(proxy): runtime proxy handler pour déploiement Docker portable

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -20,9 +20,6 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-ARG NEXT_API_URL=http://server:8000
-ENV NEXT_API_URL=${NEXT_API_URL}
-
 RUN pnpm build
 
 # ---- runner ----

--- a/client/next.config.ts
+++ b/client/next.config.ts
@@ -19,25 +19,11 @@ const gitCommit =
   process.env.GIT_COMMIT ??
   readGitValue("git rev-parse HEAD");
 
-const apiBaseUrl = process.env.NEXT_API_URL ?? "http://localhost:8000";
-
 const nextConfig: NextConfig = {
   output: "standalone",
   env: {
     NEXT_PUBLIC_APP_GIT_BRANCH: gitBranch,
     NEXT_PUBLIC_APP_GIT_COMMIT: gitCommit,
-  },
-  async rewrites() {
-    return [
-      {
-        source: "/api/v1/:path*",
-        destination: `${apiBaseUrl}/api/v1/:path*`,
-      },
-    ];
-  },
-  experimental: {
-    proxyTimeout: 120_000,
-    proxyClientMaxBodySize: "100mb",
   },
 };
 

--- a/client/src/app/api/v1/[...path]/route.ts
+++ b/client/src/app/api/v1/[...path]/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { buildResponseHeaders, buildUpstreamHeaders } from "@/lib/proxy/headers";
+import { buildUpstreamUrl } from "@/lib/proxy/url";
+
+export const runtime = "nodejs";
+
+type RouteParams = { params: Promise<{ path: string[] }> };
+
+async function handler(request: NextRequest, { params }: RouteParams) {
+  const { path } = await params;
+  const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8000";
+
+  const url = buildUpstreamUrl(backendUrl, path, request.nextUrl.searchParams);
+  const headers = buildUpstreamHeaders(
+    request.headers,
+    request.headers.get("x-forwarded-for") ?? undefined,
+  );
+
+  const hasBody = !["GET", "HEAD"].includes(request.method);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, {
+      method: request.method,
+      headers,
+      body: hasBody ? request.body : undefined,
+      // @ts-expect-error — duplex requis pour le streaming du body en Node.js
+      duplex: hasBody ? "half" : undefined,
+    });
+  } catch {
+    return new NextResponse("Bad Gateway", { status: 502 });
+  }
+
+  return new NextResponse(upstream.body, {
+    status: upstream.status,
+    headers: buildResponseHeaders(upstream.headers),
+  });
+}
+
+export {
+  handler as GET,
+  handler as POST,
+  handler as PUT,
+  handler as DELETE,
+  handler as PATCH,
+};

--- a/client/src/lib/proxy/headers.ts
+++ b/client/src/lib/proxy/headers.ts
@@ -1,0 +1,49 @@
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "te",
+  "trailer",
+  "upgrade",
+  "proxy-authorization",
+  "proxy-authenticate",
+]);
+
+export function buildUpstreamHeaders(
+  incomingHeaders: Headers,
+  clientIp?: string,
+): Headers {
+  const headers = new Headers();
+
+  for (const [key, value] of incomingHeaders) {
+    const lower = key.toLowerCase();
+    if (lower === "host" || HOP_BY_HOP.has(lower)) continue;
+    headers.set(key, value);
+  }
+
+  if (clientIp) {
+    headers.set("x-forwarded-for", clientIp);
+  }
+
+  return headers;
+}
+
+export function buildResponseHeaders(upstreamHeaders: Headers): Headers {
+  const headers = new Headers();
+
+  for (const [key, value] of upstreamHeaders) {
+    const lower = key.toLowerCase();
+    // fetch() décompresse automatiquement la réponse — ne pas retransmettre
+    // Content-Encoding, sinon le browser tenterait une double décompression.
+    if (lower === "content-encoding" || HOP_BY_HOP.has(lower)) continue;
+    // Set-Cookie traité séparément pour éviter la déduplication de Headers
+    if (lower === "set-cookie") continue;
+    headers.set(key, value);
+  }
+
+  for (const cookie of upstreamHeaders.getSetCookie()) {
+    headers.append("set-cookie", cookie);
+  }
+
+  return headers;
+}

--- a/client/src/lib/proxy/url.ts
+++ b/client/src/lib/proxy/url.ts
@@ -1,0 +1,10 @@
+export function buildUpstreamUrl(
+  backendUrl: string,
+  path: string[],
+  searchParams: URLSearchParams,
+): string {
+  const base = backendUrl.endsWith("/") ? backendUrl.slice(0, -1) : backendUrl;
+  const fullPath = `/api/v1/${path.join("/")}`;
+  const query = searchParams.toString();
+  return query ? `${base}${fullPath}?${query}` : `${base}${fullPath}`;
+}

--- a/client/tests/unit/app/api/v1/route.test.ts
+++ b/client/tests/unit/app/api/v1/route.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment node
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { NextRequest } from "next/server";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { GET, POST, DELETE, PATCH } from "@/app/api/v1/[...path]/route";
+
+const BACKEND_URL = "http://fake-backend:8000";
+
+vi.stubEnv("BACKEND_URL", BACKEND_URL);
+
+const server = setupServer();
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("GET /api/v1/[...path]", () => {
+  it("should proxy to the backend and return JSON", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects`, () =>
+        HttpResponse.json([{ id: 1, name: "Projet A" }]),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects");
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([{ id: 1, name: "Projet A" }]);
+  });
+
+  it("should forward query string to the backend", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects`, ({ request }) => {
+        const url = new URL(request.url);
+        return HttpResponse.json({ page: url.searchParams.get("page") });
+      }),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects?page=2");
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    const body = await res.json();
+    expect(body.page).toBe("2");
+  });
+
+  it("should forward Authorization header to the backend", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects`, ({ request }) =>
+        HttpResponse.json({ auth: request.headers.get("authorization") }),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects", {
+      headers: { Authorization: "Bearer my-token" },
+    });
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    const body = await res.json();
+    expect(body.auth).toBe("Bearer my-token");
+  });
+
+  it("should preserve the backend status code", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects/999`, () =>
+        HttpResponse.json({ detail: "Not found" }, { status: 404 }),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects/999");
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects", "999"] }) });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("should preserve Content-Type from the backend response", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects`, () =>
+        HttpResponse.json([], { headers: { "Content-Type": "application/json; charset=utf-8" } }),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects");
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("should return 502 when the backend is unreachable", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/projects`, () => HttpResponse.error()),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects");
+    const res = await GET(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    expect(res.status).toBe(502);
+  });
+
+  it("should return a streaming body (ReadableStream, not buffered)", async () => {
+    server.use(
+      http.get(`${BACKEND_URL}/api/v1/stream`, () =>
+        HttpResponse.json({ streamed: true }),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/stream");
+    const res = await GET(req, { params: Promise.resolve({ path: ["stream"] }) });
+
+    expect(res.body).toBeInstanceOf(ReadableStream);
+  });
+});
+
+describe("POST /api/v1/[...path]", () => {
+  it("should forward JSON body to the backend", async () => {
+    server.use(
+      http.post(`${BACKEND_URL}/api/v1/projects`, async ({ request }) => {
+        const body = await request.json();
+        return HttpResponse.json(body, { status: 201 });
+      }),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Nouveau projet" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ path: ["projects"] }) });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body).toEqual({ name: "Nouveau projet" });
+  });
+});
+
+describe("DELETE /api/v1/[...path]", () => {
+  it("should proxy DELETE and return 204", async () => {
+    server.use(
+      http.delete(`${BACKEND_URL}/api/v1/projects/1`, () =>
+        new HttpResponse(null, { status: 204 }),
+      ),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects/1", {
+      method: "DELETE",
+    });
+    const res = await DELETE(req, { params: Promise.resolve({ path: ["projects", "1"] }) });
+
+    expect(res.status).toBe(204);
+  });
+});
+
+describe("PATCH /api/v1/[...path]", () => {
+  it("should forward PATCH body to the backend", async () => {
+    server.use(
+      http.patch(`${BACKEND_URL}/api/v1/projects/1`, async ({ request }) => {
+        const body = await request.json();
+        return HttpResponse.json({ ...body, id: 1 });
+      }),
+    );
+
+    const req = new NextRequest("http://localhost:3000/api/v1/projects/1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Modifié" }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ path: ["projects", "1"] }) });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ id: 1, name: "Modifié" });
+  });
+});

--- a/client/tests/unit/lib/proxy/headers.test.ts
+++ b/client/tests/unit/lib/proxy/headers.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { buildUpstreamHeaders, buildResponseHeaders } from "@/lib/proxy/headers";
+
+describe("buildUpstreamHeaders", () => {
+  it("should forward Authorization header", () => {
+    const headers = new Headers({ Authorization: "Bearer token123" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("authorization")).toBe("Bearer token123");
+  });
+
+  it("should forward Content-Type header", () => {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("content-type")).toBe("application/json");
+  });
+
+  it("should remove 'host' header", () => {
+    const headers = new Headers({ host: "localhost:3000" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("host")).toBeNull();
+  });
+
+  it("should remove 'connection' hop-by-hop header", () => {
+    const headers = new Headers({ connection: "keep-alive" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("connection")).toBeNull();
+  });
+
+  it("should remove 'transfer-encoding' hop-by-hop header", () => {
+    const headers = new Headers({ "transfer-encoding": "chunked" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("transfer-encoding")).toBeNull();
+  });
+
+  it("should remove 'keep-alive' hop-by-hop header", () => {
+    const headers = new Headers({ "keep-alive": "timeout=5" });
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("keep-alive")).toBeNull();
+  });
+
+  it("should add X-Forwarded-For when clientIp is provided", () => {
+    const headers = new Headers();
+    const result = buildUpstreamHeaders(headers, "1.2.3.4");
+    expect(result.get("x-forwarded-for")).toBe("1.2.3.4");
+  });
+
+  it("should not add X-Forwarded-For when clientIp is absent", () => {
+    const headers = new Headers();
+    const result = buildUpstreamHeaders(headers);
+    expect(result.get("x-forwarded-for")).toBeNull();
+  });
+});
+
+describe("buildResponseHeaders", () => {
+  it("should forward Content-Type header", () => {
+    const headers = new Headers({ "Content-Type": "application/json" });
+    const result = buildResponseHeaders(headers);
+    expect(result.get("content-type")).toBe("application/json");
+  });
+
+  it("should remove 'connection' hop-by-hop header", () => {
+    const headers = new Headers({ connection: "keep-alive" });
+    const result = buildResponseHeaders(headers);
+    expect(result.get("connection")).toBeNull();
+  });
+
+  it("should remove 'transfer-encoding' hop-by-hop header", () => {
+    const headers = new Headers({ "transfer-encoding": "chunked" });
+    const result = buildResponseHeaders(headers);
+    expect(result.get("transfer-encoding")).toBeNull();
+  });
+
+  it("should remove 'content-encoding' to avoid double-decompression", () => {
+    // fetch() décompresse automatiquement la réponse.
+    // Retransmettre Content-Encoding ferait croire au browser
+    // que le body est encore compressé → corruption silencieuse.
+    const headers = new Headers({ "content-encoding": "gzip" });
+    const result = buildResponseHeaders(headers);
+    expect(result.get("content-encoding")).toBeNull();
+  });
+
+  it("should forward a single Set-Cookie header", () => {
+    const headers = new Headers();
+    headers.append("set-cookie", "session=abc; HttpOnly");
+    const result = buildResponseHeaders(headers);
+    expect(result.getSetCookie()).toEqual(["session=abc; HttpOnly"]);
+  });
+
+  it("should forward multiple Set-Cookie headers without losing any", () => {
+    // L'API Headers déduplique les headers de même nom si on utilise set().
+    // Il faut utiliser append() ou getSetCookie() pour éviter les pertes.
+    const headers = new Headers();
+    headers.append("set-cookie", "session=abc; HttpOnly");
+    headers.append("set-cookie", "refresh=xyz; HttpOnly");
+    const result = buildResponseHeaders(headers);
+    expect(result.getSetCookie()).toHaveLength(2);
+    expect(result.getSetCookie()).toContain("session=abc; HttpOnly");
+    expect(result.getSetCookie()).toContain("refresh=xyz; HttpOnly");
+  });
+
+  it("should not error when Set-Cookie is absent", () => {
+    const headers = new Headers({ "content-type": "application/json" });
+    const result = buildResponseHeaders(headers);
+    expect(result.getSetCookie()).toEqual([]);
+  });
+});

--- a/client/tests/unit/lib/proxy/url.test.ts
+++ b/client/tests/unit/lib/proxy/url.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { buildUpstreamUrl } from "@/lib/proxy/url";
+
+describe("buildUpstreamUrl", () => {
+  it("should concatenate backendUrl and a single path segment", () => {
+    const result = buildUpstreamUrl(
+      "http://backend:8000",
+      ["projects"],
+      new URLSearchParams(),
+    );
+    expect(result).toBe("http://backend:8000/api/v1/projects");
+  });
+
+  it("should concatenate backendUrl and multiple path segments", () => {
+    const result = buildUpstreamUrl(
+      "http://backend:8000",
+      ["projects", "42", "chat"],
+      new URLSearchParams(),
+    );
+    expect(result).toBe("http://backend:8000/api/v1/projects/42/chat");
+  });
+
+  it("should append query string when present", () => {
+    const result = buildUpstreamUrl(
+      "http://backend:8000",
+      ["projects"],
+      new URLSearchParams("page=2&limit=10"),
+    );
+    expect(result).toBe("http://backend:8000/api/v1/projects?page=2&limit=10");
+  });
+
+  it("should not append '?' when query string is empty", () => {
+    const result = buildUpstreamUrl(
+      "http://backend:8000",
+      ["projects"],
+      new URLSearchParams(""),
+    );
+    expect(result).toBe("http://backend:8000/api/v1/projects");
+  });
+
+  it("should not double slashes when backendUrl ends with '/'", () => {
+    const result = buildUpstreamUrl(
+      "http://backend:8000/",
+      ["projects"],
+      new URLSearchParams(),
+    );
+    expect(result).toBe("http://backend:8000/api/v1/projects");
+  });
+});


### PR DESCRIPTION
## Problème

L'image Docker du client n'était pas portable : l'URL du backend (`NEXT_API_URL`) était bâkée au moment du build via un `ARG` Dockerfile, car elle était utilisée dans `rewrites()` de `next.config.ts` — évalué à la compilation par Next.js.

Résultat : une image par environnement, incompatible avec un déploiement multi-stack docker-compose.

## Solution

Remplacement des `rewrites()` Next.js (build-time) par un **Route Handler App Router** (`/api/v1/[...path]`) qui lit `BACKEND_URL` depuis `process.env` au **runtime**.

La logique proxy est extraite dans `src/lib/proxy/` (fonctions pures) pour être testable unitairement.

## Changements

### Nouveaux fichiers
- `src/lib/proxy/url.ts` — `buildUpstreamUrl`
- `src/lib/proxy/headers.ts` — `buildUpstreamHeaders` + `buildResponseHeaders`
- `src/app/api/v1/[...path]/route.ts` — route handler proxy (runtime Node.js)

### Fichiers modifiés
- `next.config.ts` — suppression de `rewrites()`, `NEXT_API_URL`, `proxyTimeout`, `proxyClientMaxBodySize`
- `Dockerfile` — suppression de `ARG NEXT_API_URL` / `ENV NEXT_API_URL`

### Points traités
- `Content-Encoding` strippé pour éviter la double décompression silencieuse
- `Set-Cookie` multiples forwardés sans perte (contournement de la déduplication de `Headers`)
- Headers hop-by-hop filtrés (`connection`, `transfer-encoding`, `keep-alive`…)
- Header `host` supprimé côté upstream
- `X-Forwarded-For` forwardé si présent
- Réponse streamée via `response.body` (ReadableStream) — pas de buffering
- Retour 502 si le backend est injoignable
- `export const runtime = "nodejs"` pour garantir le runtime cible

## Tests

30 tests unitaires ajoutés (Vitest + MSW) :
- 5 tests `buildUpstreamUrl`
- 8 tests `buildUpstreamHeaders`
- 7 tests `buildResponseHeaders`
- 10 tests route handler (GET, POST, DELETE, PATCH, streaming, 502)

## Checklist de déploiement

- [ ] S'assurer que `BACKEND_URL`, `NEXTAUTH_URL` et `NEXTAUTH_SECRET` sont définis dans le `.env` de chaque stack
- [ ] `NEXT_PUBLIC_API_URL` et `API_DOMAIN` supprimés du `raggae-deploy` (commit séparé sur ce dépôt)