### PR TITLE
fix(client): corriger les tests composants désynchronisés

### DIFF
--- a/client/tests/components/documents/document-row.test.tsx
+++ b/client/tests/components/documents/document-row.test.tsx
@@ -18,45 +18,31 @@ const mockDoc = {
   processing_strategy: null,
   status: "indexed" as const,
   error_message: null,
+  last_indexed_at: null,
+};
+
+const defaultProps = {
+  chunkingStrategy: "auto" as const,
+  parentChildChunking: false,
+  onDelete: vi.fn(),
+  isDeleting: false,
+  onReindex: vi.fn(),
+  reindexingId: null,
 };
 
 describe("DocumentRow", () => {
   it("should display file name", () => {
-    renderWithProviders(
-      <DocumentRow
-        document={mockDoc}
-        onDelete={vi.fn()}
-        isDeleting={false}
-        onReindex={vi.fn()}
-        reindexingId={null}
-      />,
-    );
+    renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
     expect(screen.getByText("report.pdf")).toBeInTheDocument();
   });
 
   it("should display file size formatted", () => {
-    renderWithProviders(
-      <DocumentRow
-        document={mockDoc}
-        onDelete={vi.fn()}
-        isDeleting={false}
-        onReindex={vi.fn()}
-        reindexingId={null}
-      />,
-    );
+    renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
     expect(screen.getByText("2.0 KB")).toBeInTheDocument();
   });
 
   it("should display created date", () => {
-    renderWithProviders(
-      <DocumentRow
-        document={mockDoc}
-        onDelete={vi.fn()}
-        isDeleting={false}
-        onReindex={vi.fn()}
-        reindexingId={null}
-      />,
-    );
+    renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
     expect(screen.getByText(/Jan 15, 2026/)).toBeInTheDocument();
   });
 
@@ -64,13 +50,7 @@ describe("DocumentRow", () => {
     const onDelete = vi.fn();
     const user = userEvent.setup();
     renderWithProviders(
-      <DocumentRow
-        document={mockDoc}
-        onDelete={onDelete}
-        isDeleting={false}
-        onReindex={vi.fn()}
-        reindexingId={null}
-      />,
+      <DocumentRow document={mockDoc} {...defaultProps} onDelete={onDelete} />,
     );
 
     await user.click(screen.getByRole("button", { name: /delete/i }));

--- a/client/tests/components/layout/sidebar.test.tsx
+++ b/client/tests/components/layout/sidebar.test.tsx
@@ -24,13 +24,13 @@ describe("Sidebar", () => {
 
     expect(
       screen.getByRole("link", { name: /project one/i }),
-    ).toHaveAttribute("href", "/projects/proj-1");
+    ).toHaveAttribute("href", "/projects/proj-1/chat");
     expect(
       screen.getByRole("link", { name: /project two/i }),
-    ).toHaveAttribute("href", "/projects/proj-2");
+    ).toHaveAttribute("href", "/projects/proj-2/chat");
   });
 
-  it("should open project contextual menu with chat/documents/settings links", async () => {
+  it("should open project contextual menu with chat and settings links", async () => {
     const user = userEvent.setup();
     renderWithProviders(<Sidebar />);
 
@@ -39,10 +39,6 @@ describe("Sidebar", () => {
     expect(screen.getByRole("menuitem", { name: /^chat$/i })).toHaveAttribute(
       "href",
       "/projects/proj-1/chat",
-    );
-    expect(screen.getByRole("menuitem", { name: /^documents$/i })).toHaveAttribute(
-      "href",
-      "/projects/proj-1/documents",
     );
     expect(screen.getByRole("menuitem", { name: /^settings$/i })).toHaveAttribute(
       "href",

--- a/client/tests/components/projects/project-card.test.tsx
+++ b/client/tests/components/projects/project-card.test.tsx
@@ -37,7 +37,7 @@ describe("ProjectCard", () => {
   it("should link to project detail", () => {
     renderWithProviders(<ProjectCard project={mockProject} />);
     const link = screen.getByRole("link");
-    expect(link).toHaveAttribute("href", "/projects/proj-1");
+    expect(link).toHaveAttribute("href", "/projects/proj-1/chat");
   });
 
   it("should show 'No description' when empty", () => {

--- a/client/tests/components/projects/project-form.test.tsx
+++ b/client/tests/components/projects/project-form.test.tsx
@@ -10,7 +10,21 @@ vi.mock("next/navigation", () => ({
 
 describe("ProjectForm", () => {
   it("should render name, description, and system prompt fields", () => {
-    renderWithProviders(<ProjectForm onSubmit={vi.fn()} />);
+    const initialData = {
+      id: "proj-1",
+      user_id: "user-1",
+      name: "",
+      description: "",
+      system_prompt: "",
+      is_published: false,
+      created_at: "2026-01-01T00:00:00Z",
+      chunking_strategy: "auto" as const,
+      parent_child_chunking: false,
+      reindex_status: "idle",
+      reindex_progress: 0,
+      reindex_total: 0,
+    };
+    renderWithProviders(<ProjectForm initialData={initialData} onSubmit={vi.fn()} submitLabel="Save" />);
 
     expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
@@ -46,9 +60,6 @@ describe("ProjectForm", () => {
     expect(onSubmit).toHaveBeenCalledWith({
       name: "My Project",
       description: "A description",
-      system_prompt: "",
-      chunking_strategy: "auto",
-      parent_child_chunking: false,
     });
   });
 


### PR DESCRIPTION
## Summary

- **DocumentRow** : props `chunkingStrategy` et `parentChildChunking` manquantes dans les renders de test
- **ProjectCard** : href attendu mis à jour vers `/projects/:id/chat` (le composant a évolué)
- **ProjectForm** : tests alignés sur le comportement réel — mode création (payload `name`+`description` uniquement) vs mode édition (system prompt visible)
- **Sidebar** : href `/chat` et suppression de l'assertion sur l'item `Documents` qui n'existe plus dans le dropdown

## Test plan

- [ ] `npm test -- --run` passe en 106/106