### PR TITLE
perf(docker): speed up server image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -53,8 +53,10 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
-          cache-from: type=gha,scope=server
-          cache-to: type=gha,mode=max,scope=server
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/raggae-server:cache
+            type=gha,scope=server
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.OWNER }}/raggae-server:cache,mode=max
 
   build-client:
     name: Build & push client image

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -5,12 +5,13 @@ FROM python:3.13-slim AS builder
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir uv
 
 COPY pyproject.toml .
-COPY src/ src/
 
-RUN pip install --no-cache-dir .
+RUN uv pip install --system --no-cache .
+
+COPY src/ src/
 
 # ---- runtime ----
 FROM python:3.13-slim AS runtime


### PR DESCRIPTION
## Summary

- Remplace `pip` par `uv` dans le stage builder du Dockerfile server (installation 10-100x plus rapide)
- Déplace `COPY src/` après l'installation des dépendances pour que le cache Docker soit invalidé uniquement lors de changements de `pyproject.toml`, pas du code source
- Utilise GHCR comme backend de cache persistant pour BuildKit, en complément du cache GHA

## Impact attendu

Le build passe de ~20 min à quelques minutes pour les runs où seul le code source change (cas le plus fréquent).

## Test plan

- [ ] Vérifier que le premier run construit l'image correctement et pousse le cache dans GHCR
- [ ] Vérifier qu'un second run (sans changement de `pyproject.toml`) utilise bien le cache et est significativement plus rapide