### PR TITLE
fix(chat): allow org OWNER/MAKER members to query relevant chunks

### DIFF
--- a/server/src/raggae/application/use_cases/chat/query_relevant_chunks.py
+++ b/server/src/raggae/application/use_cases/chat/query_relevant_chunks.py
@@ -11,6 +11,9 @@ from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
 from raggae.application.interfaces.repositories.document_chunk_repository import (
     DocumentChunkRepository,
 )
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.application.interfaces.services.chunk_retrieval_service import ChunkRetrievalService
 from raggae.application.interfaces.services.embedding_service import EmbeddingService
@@ -19,6 +22,7 @@ from raggae.application.interfaces.services.project_embedding_service_resolver i
 )
 from raggae.application.interfaces.services.reranker_service import RerankerService
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class QueryRelevantChunks:
@@ -35,6 +39,7 @@ class QueryRelevantChunks:
         reranker_candidate_multiplier: int = 3,
         document_chunk_repository: DocumentChunkRepository | None = None,
         context_window_size: int = 0,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._embedding_service = embedding_service
@@ -45,6 +50,7 @@ class QueryRelevantChunks:
         self._reranker_candidate_multiplier = reranker_candidate_multiplier
         self._document_chunk_repository = document_chunk_repository
         self._context_window_size = context_window_size
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -61,8 +67,20 @@ class QueryRelevantChunks:
     ) -> QueryRelevantChunksResultDTO:
         started_at = perf_counter()
         project = await self._project_repository.find_by_id(project_id)
-        if project is None or project.user_id != user_id:
+        if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None or member.role not in {
+                OrganizationMemberRole.OWNER,
+                OrganizationMemberRole.MAKER,
+            }:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
 
         embedding_service = (
             self._project_embedding_service_resolver.resolve(project)

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -716,6 +716,7 @@ def get_query_relevant_chunks_use_case() -> QueryRelevantChunks:
         reranker_candidate_multiplier=settings.reranker_candidate_multiplier,
         document_chunk_repository=_document_chunk_repository,
         context_window_size=settings.retrieval_context_window_size,
+        organization_member_repository=_organization_member_repository,
     )
 
 

--- a/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
+++ b/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
@@ -1,18 +1,20 @@
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
 from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
 from raggae.application.use_cases.chat.query_relevant_chunks import QueryRelevantChunks
 from raggae.domain.entities.document_chunk import DocumentChunk
+from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.value_objects.chunk_level import ChunkLevel
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
-def _make_project(project_id=None, user_id=None):
+def _make_project(project_id=None, user_id=None, organization_id=None):
     return Project(
         id=project_id or uuid4(),
         user_id=user_id or uuid4(),
@@ -21,6 +23,17 @@ def _make_project(project_id=None, user_id=None):
         system_prompt="",
         is_published=False,
         created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_member(organization_id: UUID, user_id: UUID, role: OrganizationMemberRole) -> OrganizationMember:
+    return OrganizationMember(
+        id=uuid4(),
+        organization_id=organization_id,
+        user_id=user_id,
+        role=role,
+        joined_at=datetime.now(UTC),
     )
 
 
@@ -979,3 +992,131 @@ class TestQueryRelevantChunks:
         assert result.chunks[1].content == "standard chunk"
         # Parent fetched only once
         mock_chunk_repo.find_by_id.assert_awaited_once_with(parent_id)
+
+
+class TestQueryRelevantChunksOrgAccess:
+    @pytest.fixture
+    def mock_project_repository(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_embedding_service(self) -> AsyncMock:
+        svc = AsyncMock()
+        svc.embed_texts.return_value = [[0.1, 0.2, 0.3]]
+        return svc
+
+    @pytest.fixture
+    def mock_chunk_retrieval_service(self) -> AsyncMock:
+        svc = AsyncMock()
+        svc.retrieve_chunks.return_value = []
+        return svc
+
+    @pytest.fixture
+    def mock_org_member_repository(self) -> AsyncMock:
+        return AsyncMock()
+
+    def _make_use_case(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> QueryRelevantChunks:
+        return QueryRelevantChunks(
+            project_repository=mock_project_repository,
+            embedding_service=mock_embedding_service,
+            chunk_retrieval_service=mock_chunk_retrieval_service,
+            organization_member_repository=mock_org_member_repository,
+        )
+
+    async def test_query_org_maker_can_access_project(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = _make_project(
+            project_id, organization_id=org_id
+        )
+        mock_org_member_repository.find_by_organization_and_user.return_value = _make_member(
+            org_id, user_id, OrganizationMemberRole.MAKER
+        )
+        use_case = self._make_use_case(
+            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+        )
+
+        # When / Then — no exception raised
+        await use_case.execute(project_id=project_id, user_id=user_id, query="hello")
+
+    async def test_query_org_owner_can_access_project(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = _make_project(
+            project_id, organization_id=org_id
+        )
+        mock_org_member_repository.find_by_organization_and_user.return_value = _make_member(
+            org_id, user_id, OrganizationMemberRole.OWNER
+        )
+        use_case = self._make_use_case(
+            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+        )
+
+        # When / Then — no exception raised
+        await use_case.execute(project_id=project_id, user_id=user_id, query="hello")
+
+    async def test_query_non_member_raises_error(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = _make_project(
+            project_id, organization_id=org_id
+        )
+        mock_org_member_repository.find_by_organization_and_user.return_value = None
+        use_case = self._make_use_case(
+            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project_id, user_id=uuid4(), query="hello")
+
+    async def test_query_without_org_member_repo_raises_error_for_non_owner(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = _make_project(
+            project_id, organization_id=org_id
+        )
+        use_case = QueryRelevantChunks(
+            project_repository=mock_project_repository,
+            embedding_service=mock_embedding_service,
+            chunk_retrieval_service=mock_chunk_retrieval_service,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project_id, user_id=uuid4(), query="hello")

--- a/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
+++ b/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
@@ -27,7 +27,9 @@ def _make_project(project_id=None, user_id=None, organization_id=None):
     )
 
 
-def _make_member(organization_id: UUID, user_id: UUID, role: OrganizationMemberRole) -> OrganizationMember:
+def _make_member(
+    organization_id: UUID, user_id: UUID, role: OrganizationMemberRole
+) -> OrganizationMember:
     return OrganizationMember(
         id=uuid4(),
         organization_id=organization_id,
@@ -1047,7 +1049,10 @@ class TestQueryRelevantChunksOrgAccess:
             org_id, user_id, OrganizationMemberRole.MAKER
         )
         use_case = self._make_use_case(
-            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+            mock_project_repository,
+            mock_embedding_service,
+            mock_chunk_retrieval_service,
+            mock_org_member_repository,
         )
 
         # When / Then — no exception raised
@@ -1071,7 +1076,10 @@ class TestQueryRelevantChunksOrgAccess:
             org_id, user_id, OrganizationMemberRole.OWNER
         )
         use_case = self._make_use_case(
-            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+            mock_project_repository,
+            mock_embedding_service,
+            mock_chunk_retrieval_service,
+            mock_org_member_repository,
         )
 
         # When / Then — no exception raised
@@ -1092,7 +1100,10 @@ class TestQueryRelevantChunksOrgAccess:
         )
         mock_org_member_repository.find_by_organization_and_user.return_value = None
         use_case = self._make_use_case(
-            mock_project_repository, mock_embedding_service, mock_chunk_retrieval_service, mock_org_member_repository
+            mock_project_repository,
+            mock_embedding_service,
+            mock_chunk_retrieval_service,
+            mock_org_member_repository,
         )
 
         # When / Then


### PR DESCRIPTION
## Problème

En tant que Maker ou Owner d'une organisation, envoyer un message dans un projet d'org ne produisait aucune réponse.

## Cause racine

`QueryRelevantChunks` (appelé par `SendMessage` pour récupérer les chunks RAG) vérifiait uniquement que l'utilisateur était propriétaire du projet :

\`\`\`python
# Avant — trop restrictif
if project is None or project.user_id != user_id:
    raise ProjectNotFoundError(...)
\`\`\`

Tous les autres use cases (document, chat) avaient déjà été mis à jour pour accepter les membres org OWNER/MAKER, mais `QueryRelevantChunks` avait été oublié.

## Fix

Ajout du paramètre `organization_member_repository` et de la vérification d'accès org, identique au pattern utilisé partout ailleurs.

## Tests

4 nouveaux tests unitaires couvrant :
- MAKER peut accéder → succès
- OWNER peut accéder → succès
- Non-membre → `ProjectNotFoundError`
- Sans repo org injecté → `ProjectNotFoundError`