### PR TITLE
fix(docker): create src stub before uv install

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -9,6 +9,7 @@ RUN pip install --no-cache-dir uv
 
 COPY pyproject.toml .
 
+RUN mkdir -p src/raggae && touch src/raggae/__init__.py
 RUN uv pip install --system --no-cache .
 
 COPY src/ src/


### PR DESCRIPTION
## Problème

Le build Docker échouait avec :

```
error: error in 'egg_base' option: 'src' does not exist or is not a directory
```

`uv pip install .` tente de résoudre le répertoire source du package (`egg_base=src`) défini dans `pyproject.toml`, mais `src/` n'existe pas encore — seul `pyproject.toml` a été copié à ce stade.

## Fix

Création d'un stub minimal `src/raggae/__init__.py` avant l'installation, ce qui satisfait `pyproject.toml` et permet à `uv` d'installer les dépendances. Le vrai code source est copié ensuite via `COPY src/ src/`, écrasant le stub.

Le cache Docker reste efficace : la couche `uv pip install` n'est invalidée que si `pyproject.toml` change, pas si le code source change.