### PR TITLE
fix(auth): allow org USER members to access published projects

### DIFF
--- a/server/src/raggae/application/use_cases/chat/query_relevant_chunks.py
+++ b/server/src/raggae/application/use_cases/chat/query_relevant_chunks.py
@@ -76,11 +76,11 @@ class QueryRelevantChunks:
                 organization_id=project.organization_id,
                 user_id=user_id,
             )
-            if member is None or member.role not in {
-                OrganizationMemberRole.OWNER,
-                OrganizationMemberRole.MAKER,
-            }:
+            if member is None:
                 raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         embedding_service = (
             self._project_embedding_service_resolver.resolve(project)

--- a/server/src/raggae/application/use_cases/project/get_project.py
+++ b/server/src/raggae/application/use_cases/project/get_project.py
@@ -34,10 +34,10 @@ class GetProject:
             organization_id=project.organization_id,
             user_id=user_id,
         )
-        if member is None or member.role not in {
-            OrganizationMemberRole.OWNER,
-            OrganizationMemberRole.MAKER,
-        }:
+        if member is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+        if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+            if not project.is_published:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
 
         return ProjectDTO.from_entity(project)

--- a/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
+++ b/server/tests/unit/application/use_cases/chat/test_query_relevant_chunks.py
@@ -1085,6 +1085,68 @@ class TestQueryRelevantChunksOrgAccess:
         # When / Then — no exception raised
         await use_case.execute(project_id=project_id, user_id=user_id, query="hello")
 
+    async def test_query_org_user_can_access_published_project(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = Project(
+            id=project_id,
+            user_id=uuid4(),
+            name="Project",
+            description="",
+            system_prompt="",
+            is_published=True,
+            created_at=datetime.now(UTC),
+            organization_id=org_id,
+        )
+        mock_org_member_repository.find_by_organization_and_user.return_value = _make_member(
+            org_id, user_id, OrganizationMemberRole.USER
+        )
+        use_case = self._make_use_case(
+            mock_project_repository,
+            mock_embedding_service,
+            mock_chunk_retrieval_service,
+            mock_org_member_repository,
+        )
+
+        # When / Then — no exception raised
+        await use_case.execute(project_id=project_id, user_id=user_id, query="hello")
+
+    async def test_query_org_user_cannot_access_unpublished_project(
+        self,
+        mock_project_repository: AsyncMock,
+        mock_embedding_service: AsyncMock,
+        mock_chunk_retrieval_service: AsyncMock,
+        mock_org_member_repository: AsyncMock,
+    ) -> None:
+        # Given
+        org_id = uuid4()
+        user_id = uuid4()
+        project_id = uuid4()
+        mock_project_repository.find_by_id.return_value = _make_project(
+            project_id, organization_id=org_id
+        )
+        mock_org_member_repository.find_by_organization_and_user.return_value = _make_member(
+            org_id, user_id, OrganizationMemberRole.USER
+        )
+        use_case = self._make_use_case(
+            mock_project_repository,
+            mock_embedding_service,
+            mock_chunk_retrieval_service,
+            mock_org_member_repository,
+        )
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project_id, user_id=user_id, query="hello")
+
     async def test_query_non_member_raises_error(
         self,
         mock_project_repository: AsyncMock,

--- a/server/tests/unit/application/use_cases/project/test_get_project.py
+++ b/server/tests/unit/application/use_cases/project/test_get_project.py
@@ -156,7 +156,7 @@ class TestGetProject:
 
         assert result.id == project.id
 
-    async def test_get_project_org_user_cannot_access(
+    async def test_get_project_org_user_cannot_access_unpublished_project(
         self,
         use_case: GetProject,
         mock_project_repository: AsyncMock,
@@ -187,3 +187,36 @@ class TestGetProject:
 
         with pytest.raises(ProjectNotFoundError):
             await use_case.execute(project_id=project.id, user_id=requester_id)
+
+    async def test_get_project_org_user_can_access_published_project(
+        self,
+        use_case: GetProject,
+        mock_project_repository: AsyncMock,
+        mock_organization_member_repository: AsyncMock,
+    ) -> None:
+        organization_id = uuid4()
+        requester_id = uuid4()
+        project = Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            organization_id=organization_id,
+            name="Org project",
+            description="desc",
+            system_prompt="prompt",
+            is_published=True,
+            created_at=datetime.now(UTC),
+        )
+        mock_project_repository.find_by_id.return_value = project
+        mock_organization_member_repository.find_by_organization_and_user.return_value = (
+            OrganizationMember(
+                id=uuid4(),
+                organization_id=organization_id,
+                user_id=requester_id,
+                role=OrganizationMemberRole.USER,
+                joined_at=datetime.now(UTC),
+            )
+        )
+
+        result = await use_case.execute(project_id=project.id, user_id=requester_id)
+
+        assert result.id == project.id


### PR DESCRIPTION
## Summary

- Les membres avec le rôle `USER` dans une organisation ne pouvaient pas accéder aux projets publiés (`get_project`, `query_relevant_chunks` retournaient `ProjectNotFoundError`)
- Applique le même pattern d'autorisation que `send_message` et `list_conversations` : `OWNER`/`MAKER` ont accès libre, `USER` accède uniquement aux projets publiés
- Ajoute 4 nouveaux tests couvrant les cas USER sur projet publié et non publié

## Fichiers modifiés

- `src/.../use_cases/project/get_project.py`
- `src/.../use_cases/chat/query_relevant_chunks.py`
- `tests/.../project/test_get_project.py`
- `tests/.../chat/test_query_relevant_chunks.py`

## Test plan

- [x] `pytest tests/unit/application/use_cases/project/test_get_project.py` — tous les tests passent
- [x] `pytest tests/unit/application/use_cases/chat/test_query_relevant_chunks.py` — tous les tests passent
- [x] `pytest tests/unit/` — suite complète (533 tests)
- [x] Vérifier manuellement qu'un utilisateur avec rôle `USER` peut consulter et interagir avec un projet publié d'organisation