### PR TITLE
feat(header): move language and theme selectors into user dropdown menu

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -32,6 +32,7 @@
   "header": {
     "account": "Account",
     "userSettings": "User settings",
+    "language": "Language",
     "signOut": "Sign out"
   },
   "auth": {

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -485,8 +485,10 @@
   },
   "layout": {
     "themeToggle": {
-      "dark": "Dark",
+      "label": "Theme",
       "light": "Light",
+      "dark": "Dark",
+      "system": "System",
       "switchToDark": "Switch to dark mode",
       "switchToLight": "Switch to light mode"
     },

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -32,6 +32,7 @@
   "header": {
     "account": "Compte",
     "userSettings": "Paramètres utilisateur",
+    "language": "Langue",
     "signOut": "Se déconnecter"
   },
   "auth": {

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -485,8 +485,10 @@
   },
   "layout": {
     "themeToggle": {
-      "dark": "Sombre",
+      "label": "Thème",
       "light": "Clair",
+      "dark": "Sombre",
+      "system": "Système",
       "switchToDark": "Passer en mode sombre",
       "switchToLight": "Passer en mode clair"
     },

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
-import { Check, Languages, Monitor, Moon, Settings, Sun } from "lucide-react";
+import { Check, Languages, LogOut, Monitor, Moon, Settings, Sun } from "lucide-react";
 import type { Theme } from "@/lib/providers/theme-provider";
 import { Button } from "@/components/ui/button";
 import {
@@ -142,8 +142,9 @@ export function Header() {
 
             <DropdownMenuItem
               onClick={() => signOut({ callbackUrl: "/login" })}
-              className="cursor-pointer"
+              className="flex cursor-pointer items-center gap-2"
             >
+              <LogOut size={14} />
               {t("signOut")}
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -87,14 +87,14 @@ export function Header() {
             <DropdownMenuSeparator />
 
             <DropdownMenuItem asChild>
-              <Link href="/settings" className="flex items-center gap-2">
+              <Link href="/settings" className="flex cursor-pointer items-center gap-2">
                 <Settings size={14} />
                 {t("userSettings")}
               </Link>
             </DropdownMenuItem>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="flex items-center gap-2">
+              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
                 <Languages size={14} />
                 {t("language")}
               </DropdownMenuSubTrigger>
@@ -103,7 +103,7 @@ export function Header() {
                   <DropdownMenuItem
                     key={value}
                     onClick={() => handleLocaleSelect(value)}
-                    className="flex items-center gap-2"
+                    className="flex cursor-pointer items-center gap-2"
                   >
                     <Check
                       size={14}
@@ -116,7 +116,7 @@ export function Header() {
             </DropdownMenuSub>
 
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="flex items-center gap-2">
+              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
                 <Sun size={14} />
                 {tTheme("label")}
               </DropdownMenuSubTrigger>
@@ -125,7 +125,7 @@ export function Header() {
                   <DropdownMenuItem
                     key={value}
                     onClick={() => handleThemeSelect(value)}
-                    className="flex items-center gap-2"
+                    className="flex cursor-pointer items-center gap-2"
                   >
                     <Check
                       size={14}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -2,24 +2,49 @@
 
 import Link from "next/link";
 import { signOut } from "next-auth/react";
+import { useLocale, useTranslations } from "next-intl";
+import { Check, Languages, Moon, Settings, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useTranslations } from "next-intl";
-import { ThemeToggle } from "@/components/layout/theme-toggle";
-import { LocaleSelector } from "@/components/layout/locale-selector";
-import { useAuth } from "@/lib/hooks/use-auth";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { useAuth } from "@/lib/hooks/use-auth";
+import { useTheme } from "@/lib/providers/theme-provider";
+import { useUpdateUserLocale } from "@/lib/hooks/use-user-profile";
+import type { UpdateUserLocaleRequest } from "@/lib/types/api";
 import { MobileSidebar } from "./mobile-sidebar";
+
+const LOCALES: Array<{ value: UpdateUserLocaleRequest["locale"]; label: string }> = [
+  { value: "en", label: "English" },
+  { value: "fr", label: "Français" },
+];
+
+function setLocaleCookie(locale: string) {
+  const maxAge = 60 * 60 * 24 * 365;
+  document.cookie = `raggae_locale=${locale};path=/;max-age=${maxAge};SameSite=Lax`;
+}
 
 export function Header() {
   const { user } = useAuth();
   const t = useTranslations("header");
+  const tTheme = useTranslations("layout.themeToggle");
+  const { theme, toggleTheme } = useTheme();
+  const currentLocale = useLocale();
+  const updateLocale = useUpdateUserLocale();
+
+  function handleLocaleSelect(locale: UpdateUserLocaleRequest["locale"]) {
+    if (locale === currentLocale) return;
+    setLocaleCookie(locale);
+    updateLocale.mutate({ locale }, { onSettled: () => window.location.reload() });
+  }
 
   return (
     <header className="flex h-14 items-center justify-between border-b px-6">
@@ -37,23 +62,62 @@ export function Header() {
       </div>
 
       <div className="flex items-center gap-2">
-        <LocaleSelector />
-        <ThemeToggle />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="sm" className="cursor-pointer">
               {user?.email ?? t("account")}
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem disabled>
+          <DropdownMenuContent align="end" className="w-52">
+            <DropdownMenuItem disabled className="text-muted-foreground text-xs">
               {user?.email}
             </DropdownMenuItem>
-            <DropdownMenuItem asChild>
-              <Link href="/settings">{t("userSettings")}</Link>
-            </DropdownMenuItem>
+
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => signOut({ callbackUrl: "/login" })}>
+
+            <DropdownMenuItem asChild>
+              <Link href="/settings" className="flex items-center gap-2">
+                <Settings size={14} />
+                {t("userSettings")}
+              </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex items-center gap-2">
+                <Languages size={14} />
+                {t("language")}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {LOCALES.map(({ value, label }) => (
+                  <DropdownMenuItem
+                    key={value}
+                    onClick={() => handleLocaleSelect(value)}
+                    className="flex items-center gap-2"
+                  >
+                    <Check
+                      size={14}
+                      className={currentLocale === value ? "opacity-100" : "opacity-0"}
+                    />
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuItem
+              onClick={toggleTheme}
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              {theme === "light" ? <Moon size={14} /> : <Sun size={14} />}
+              {theme === "light" ? tTheme("dark") : tTheme("light")}
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="cursor-pointer"
+            >
               {t("signOut")}
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { signOut } from "next-auth/react";
 import { useLocale, useTranslations } from "next-intl";
-import { Check, Languages, Moon, Settings, Sun } from "lucide-react";
+import { Check, Languages, Monitor, Moon, Settings, Sun } from "lucide-react";
+import type { Theme } from "@/lib/providers/theme-provider";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -36,9 +37,19 @@ export function Header() {
   const { user } = useAuth();
   const t = useTranslations("header");
   const tTheme = useTranslations("layout.themeToggle");
-  const { theme, toggleTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+
+  const THEMES: Array<{ value: Theme; label: string; icon: React.ReactNode }> = [
+    { value: "light", label: tTheme("light"), icon: <Sun size={14} /> },
+    { value: "dark", label: tTheme("dark"), icon: <Moon size={14} /> },
+    { value: "system", label: tTheme("system"), icon: <Monitor size={14} /> },
+  ];
   const currentLocale = useLocale();
   const updateLocale = useUpdateUserLocale();
+
+  function handleThemeSelect(next: Theme) {
+    if (next !== theme) setTheme(next);
+  }
 
   function handleLocaleSelect(locale: UpdateUserLocaleRequest["locale"]) {
     if (locale === currentLocale) return;
@@ -104,13 +115,28 @@ export function Header() {
               </DropdownMenuSubContent>
             </DropdownMenuSub>
 
-            <DropdownMenuItem
-              onClick={toggleTheme}
-              className="flex items-center gap-2 cursor-pointer"
-            >
-              {theme === "light" ? <Moon size={14} /> : <Sun size={14} />}
-              {theme === "light" ? tTheme("dark") : tTheme("light")}
-            </DropdownMenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex items-center gap-2">
+                <Sun size={14} />
+                {tTheme("label")}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {THEMES.map(({ value, label, icon }) => (
+                  <DropdownMenuItem
+                    key={value}
+                    onClick={() => handleThemeSelect(value)}
+                    className="flex items-center gap-2"
+                  >
+                    <Check
+                      size={14}
+                      className={theme === value ? "opacity-100" : "opacity-0"}
+                    />
+                    {icon}
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
 
             <DropdownMenuSeparator />
 

--- a/client/src/components/layout/theme-toggle.tsx
+++ b/client/src/components/layout/theme-toggle.tsx
@@ -5,18 +5,19 @@ import { Button } from "@/components/ui/button";
 import { useTheme } from "@/lib/providers/theme-provider";
 
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
   const t = useTranslations("layout.themeToggle");
+  const isDark = theme === "dark" || (theme === "system" && typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches);
 
   return (
     <Button
       variant="ghost"
       size="sm"
       className="cursor-pointer"
-      onClick={toggleTheme}
-      aria-label={theme === "light" ? t("switchToDark") : t("switchToLight")}
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label={isDark ? t("switchToLight") : t("switchToDark")}
     >
-      {theme === "light" ? t("dark") : t("light")}
+      {isDark ? t("light") : t("dark")}
     </Button>
   );
 }

--- a/client/src/lib/providers/theme-provider.tsx
+++ b/client/src/lib/providers/theme-provider.tsx
@@ -2,41 +2,58 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 
-type Theme = "light" | "dark";
+export type Theme = "light" | "dark" | "system";
 
 interface ThemeContextValue {
   theme: Theme;
-  toggleTheme: () => void;
+  setTheme: (theme: Theme) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
-  theme: "light",
-  toggleTheme: () => {},
+  theme: "system",
+  setTheme: () => {},
 });
 
 export function useTheme() {
   return useContext(ThemeContext);
 }
 
+function resolveTheme(theme: Theme): "light" | "dark" {
+  if (theme === "system") {
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+  return theme;
+}
+
+function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle("dark", resolveTheme(theme) === "dark");
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>("light");
+  const [theme, setThemeState] = useState<Theme>("system");
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme") as Theme | null;
-    const initial = stored || "light";
-    setTheme(initial);
-    document.documentElement.classList.toggle("dark", initial === "dark");
+    const stored = (localStorage.getItem("theme") as Theme | null) ?? "system";
+    setThemeState(stored);
+    applyTheme(stored);
   }, []);
 
-  const toggleTheme = () => {
-    const next = theme === "light" ? "dark" : "light";
-    setTheme(next);
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  function setTheme(next: Theme) {
+    setThemeState(next);
     localStorage.setItem("theme", next);
-    document.documentElement.classList.toggle("dark", next === "dark");
-  };
+    applyTheme(next);
+  }
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary

- Supprime `LocaleSelector` et `ThemeToggle` de la barre de navigation
- Intègre la langue et le thème directement dans le menu déroulant utilisateur
- Ajoute une option **Système** pour le thème (suit la préférence OS)
- Icônes lucide-react sur chaque entrée de menu (Settings, Languages, Sun, LogOut)
- `cursor-pointer` sur tous les items cliquables

## Changements

### `header.tsx`
- `LocaleSelector` et `ThemeToggle` retirés de la top bar
- Sous-menu **Langue** avec `Languages` icon → English / Français (coche sur l'actif)
- Sous-menu **Thème** avec `Sun` icon → Clair / Sombre / Système (coche sur l'actif)
- Icône `LogOut` sur "Se déconnecter"
- Icône `Settings` sur "Paramètres utilisateur"

### `theme-provider.tsx`
- Type `Theme` étendu à `"light" | "dark" | "system"`
- `toggleTheme` remplacé par `setTheme(theme: Theme)`
- Mode système : écoute `matchMedia("prefers-color-scheme: dark")` en temps réel

### `theme-toggle.tsx`
- Mis à jour pour utiliser `setTheme` au lieu de `toggleTheme`

### Traductions (`en.json` / `fr.json`)
- `header.language` ajouté
- `layout.themeToggle.label` et `layout.themeToggle.system` ajoutés

## Test plan

- [x] Langue : sélection EN/FR recharge et applique la locale
- [x] Thème Clair / Sombre : appliqué immédiatement
- [x] Thème Système : suit la préférence OS, change en temps réel
- [x] Coche visible sur l'option active (langue et thème)
- [x] Cursor pointer sur toutes les options