### PR TITLE
fix: read NEXT_PUBLIC_ENTRA_ENABLED at runtime via server component

### DIFF
--- a/client/src/app/(auth)/login/page.tsx
+++ b/client/src/app/(auth)/login/page.tsx
@@ -2,9 +2,11 @@ import { Suspense } from "react";
 import { LoginForm } from "@/components/auth/login-form";
 
 export default function LoginPage() {
+  const entraEnabled = process.env.NEXT_PUBLIC_ENTRA_ENABLED === "true";
+
   return (
     <Suspense>
-      <LoginForm />
+      <LoginForm entraEnabled={entraEnabled} />
     </Suspense>
   );
 }

--- a/client/src/components/auth/login-form.tsx
+++ b/client/src/components/auth/login-form.tsx
@@ -17,7 +17,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 
-const ENTRA_ENABLED = process.env.NEXT_PUBLIC_ENTRA_ENABLED === "true";
 const BACKEND_URL =
   process.env.NEXT_PUBLIC_BACKEND_URL || "http://localhost:8000";
 
@@ -39,7 +38,7 @@ function MicrosoftIcon() {
   );
 }
 
-export function LoginForm() {
+export function LoginForm({ entraEnabled = false }: { entraEnabled?: boolean }) {
   const t = useTranslations("auth.login");
   const router = useRouter();
   const searchParams = useSearchParams();


### PR DESCRIPTION
## Problem

`NEXT_PUBLIC_ENTRA_ENABLED` was read directly in `LoginForm`, a client component. In Next.js, `NEXT_PUBLIC_` variables used in client components are **inlined at build time** — passing them as Docker runtime environment variables has no effect.

## Solution

Move the env var read to `LoginPage` (a server component), which reads environment variables **at runtime**. The value is then passed as a prop to `LoginForm`.

This allows toggling ENTRA authentication on the VPS simply by setting the environment variable in `docker-compose.yml`, without rebuilding the Docker image.

## Changes

- `login/page.tsx` — reads `NEXT_PUBLIC_ENTRA_ENABLED` at runtime and passes it as `entraEnabled` prop
- `login-form.tsx` — removes direct `process.env` read, accepts `entraEnabled?: boolean` prop (defaults to `false`)

## Activation

In `docker-compose.yml`, add to the `client` service:

```yaml
environment:
  NEXT_PUBLIC_ENTRA_ENABLED: "true"
```