### PR TITLE
feat: versioning des configurations de projet (ProjectSnapshot)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -279,6 +279,30 @@
         "chatHistoryMaxCharsNote": "Character budget for injected conversation history in the LLM prompt."
       }
     },
+    "snapshots": {
+      "title": "Version history",
+      "description": "View and restore previous versions of this project's configuration.",
+      "version": "Version",
+      "date": "Date",
+      "label": "Label",
+      "createdBy": "Created by",
+      "restoredFrom": "Restored from v{version}",
+      "currentVersion": "Current version",
+      "restore": "Restore",
+      "restoring": "Restoring...",
+      "restoreDialogTitle": "Restore version {version}",
+      "restoreDialogDescription": "This action will replace the current project configuration with the one from version {version}. A new snapshot of the current configuration will be created before restoring. This action is reversible.",
+      "restoreSuccess": "Version {version} restored successfully",
+      "restoreError": "Failed to restore version {version}",
+      "empty": "No versions available yet.",
+      "embeddingModel": "Embedding",
+      "llmModel": "LLM",
+      "retrievalStrategy": "Retrieval",
+      "previous": "Previous",
+      "next": "Next",
+      "pageInfo": "Page {current} of {total}",
+      "loadError": "Failed to load version history."
+    },
     "form": {
       "editTitle": "Edit Project",
       "newTitle": "New Project",
@@ -481,6 +505,7 @@
     "projectMenu": "Project menu {projectName}",
     "chat": "Chat",
     "settings": "Settings",
+    "snapshots": "History",
     "githubProject": "GitHub project"
   },
   "layout": {

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -154,7 +154,7 @@
         "contextRetrieval": "Context retrieval",
         "contextAugmentation": "Context augmentation",
         "answerGeneration": "Answer generation",
-        "history": "History"
+        "history": "Versions"
       },
       "reindexingWarning": "Reindexing in progress ({progress}/{total}). Upload, chat and reindex actions are temporarily blocked.",
       "saveChanges": "Save changes",

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -153,7 +153,8 @@
         "documentIngestion": "Document ingestion",
         "contextRetrieval": "Context retrieval",
         "contextAugmentation": "Context augmentation",
-        "answerGeneration": "Answer generation"
+        "answerGeneration": "Answer generation",
+        "history": "History"
       },
       "reindexingWarning": "Reindexing in progress ({progress}/{total}). Upload, chat and reindex actions are temporarily blocked.",
       "saveChanges": "Save changes",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -153,7 +153,8 @@
         "documentIngestion": "Documents",
         "contextRetrieval": "Retrieval",
         "contextAugmentation": "Augmentation",
-        "answerGeneration": "Génération"
+        "answerGeneration": "Génération",
+        "history": "Historique"
       },
       "reindexingWarning": "Réindexation en cours ({progress}/{total}). Les actions d'upload, chat et réindexation sont temporairement bloquées.",
       "saveChanges": "Enregistrer",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -154,7 +154,7 @@
         "contextRetrieval": "Retrieval",
         "contextAugmentation": "Augmentation",
         "answerGeneration": "Génération",
-        "history": "Historique"
+        "history": "Versions"
       },
       "reindexingWarning": "Réindexation en cours ({progress}/{total}). Les actions d'upload, chat et réindexation sont temporairement bloquées.",
       "saveChanges": "Enregistrer",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -279,6 +279,30 @@
         "chatHistoryMaxCharsNote": "Budget en caractères pour l'historique de conversation injecté dans le prompt LLM."
       }
     },
+    "snapshots": {
+      "title": "Historique des versions",
+      "description": "Consultez et restaurez les versions précédentes de la configuration de ce projet.",
+      "version": "Version",
+      "date": "Date",
+      "label": "Étiquette",
+      "createdBy": "Créé par",
+      "restoredFrom": "Restauré depuis v{version}",
+      "currentVersion": "Version courante",
+      "restore": "Restaurer",
+      "restoring": "Restauration...",
+      "restoreDialogTitle": "Restaurer la version {version}",
+      "restoreDialogDescription": "Cette action va remplacer la configuration actuelle du projet par celle de la version {version}. Un nouveau snapshot de la configuration actuelle sera créé avant la restauration. Cette action est réversible.",
+      "restoreSuccess": "Version {version} restaurée avec succès",
+      "restoreError": "Erreur lors de la restauration de la version {version}",
+      "empty": "Aucune version disponible pour le moment.",
+      "embeddingModel": "Embedding",
+      "llmModel": "LLM",
+      "retrievalStrategy": "Retrieval",
+      "previous": "Précédent",
+      "next": "Suivant",
+      "pageInfo": "Page {current} sur {total}",
+      "loadError": "Impossible de charger l'historique des versions."
+    },
     "form": {
       "editTitle": "Modifier le projet",
       "newTitle": "Nouveau projet",
@@ -481,6 +505,7 @@
     "projectMenu": "Menu du projet {projectName}",
     "chat": "Chat",
     "settings": "Paramètres",
+    "snapshots": "Historique",
     "githubProject": "Projet GitHub"
   },
   "layout": {

--- a/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -21,6 +21,7 @@ import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { DocumentRow } from "@/components/documents/document-row";
 import { DocumentUpload } from "@/components/documents/document-upload";
+import { ProjectSnapshotsList } from "@/components/projects/project-snapshots-list";
 import {
   useDeleteDocument,
   useDocuments,
@@ -58,6 +59,7 @@ const SETTINGS_TABS = [
   "Context retrieval",
   "Context augmentation",
   "Answer generation",
+  "History",
 ] as const;
 type SettingsTab = (typeof SETTINGS_TABS)[number];
 
@@ -122,6 +124,7 @@ export default function ProjectSettingsPage() {
     "Context retrieval": t("tabs.contextRetrieval"),
     "Context augmentation": t("tabs.contextAugmentation"),
     "Answer generation": t("tabs.answerGeneration"),
+    "History": t("tabs.history"),
   };
 
   if (isLoading) {
@@ -1038,7 +1041,13 @@ export default function ProjectSettingsPage() {
         </div>
       )}
 
-      {activeTab !== "Document ingestion" && activeTab !== "General" && activeTab !== "Knowledge indexing" && activeTab !== "Publication" ? (
+      {activeTab === "History" && (
+        <div className="max-w-3xl space-y-6">
+          <ProjectSnapshotsList projectId={params.projectId} />
+        </div>
+      )}
+
+      {activeTab !== "Document ingestion" && activeTab !== "General" && activeTab !== "Knowledge indexing" && activeTab !== "Publication" && activeTab !== "History" ? (
         <Button className="cursor-pointer" disabled={isDisabled} onClick={handleSave}>
           {updateProject.isPending ? tCommon("saving") : t("saveChanges")}
         </Button>

--- a/client/src/app/(dashboard)/projects/[projectId]/snapshots/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/snapshots/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { ProjectSnapshotsList } from "@/components/projects/project-snapshots-list";
+
+export default function ProjectSnapshotsPage() {
+  const t = useTranslations("projects.snapshots");
+  const params = useParams<{ projectId: string }>();
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">{t("title")}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t("description")}</p>
+      </div>
+
+      <ProjectSnapshotsList projectId={params.projectId} />
+    </div>
+  );
+}

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -150,9 +150,6 @@ export function Sidebar() {
                       <Link href={`/projects/${project.id}/chat`}>{t("chat")}</Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild className="cursor-pointer">
-                      <Link href={`/projects/${project.id}/snapshots`}>{t("snapshots")}</Link>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild className="cursor-pointer">
                       <Link href={`/projects/${project.id}/settings`}>{t("settings")}</Link>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
@@ -219,9 +216,6 @@ export function Sidebar() {
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem asChild className="cursor-pointer">
                         <Link href={`/projects/${project.id}/chat`}>{t("chat")}</Link>
-                      </DropdownMenuItem>
-                      <DropdownMenuItem asChild className="cursor-pointer">
-                        <Link href={`/projects/${project.id}/snapshots`}>{t("snapshots")}</Link>
                       </DropdownMenuItem>
                       {editableOrganizationIds.has(organization.id) && (
                         <DropdownMenuItem asChild className="cursor-pointer">

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -150,6 +150,9 @@ export function Sidebar() {
                       <Link href={`/projects/${project.id}/chat`}>{t("chat")}</Link>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild className="cursor-pointer">
+                      <Link href={`/projects/${project.id}/snapshots`}>{t("snapshots")}</Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild className="cursor-pointer">
                       <Link href={`/projects/${project.id}/settings`}>{t("settings")}</Link>
                     </DropdownMenuItem>
                   </DropdownMenuContent>
@@ -216,6 +219,9 @@ export function Sidebar() {
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem asChild className="cursor-pointer">
                         <Link href={`/projects/${project.id}/chat`}>{t("chat")}</Link>
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild className="cursor-pointer">
+                        <Link href={`/projects/${project.id}/snapshots`}>{t("snapshots")}</Link>
                       </DropdownMenuItem>
                       {editableOrganizationIds.has(organization.id) && (
                         <DropdownMenuItem asChild className="cursor-pointer">

--- a/client/src/components/projects/project-snapshots-list.tsx
+++ b/client/src/components/projects/project-snapshots-list.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useProjectSnapshots,
+  useRestoreProjectSnapshot,
+} from "@/lib/hooks/use-project-snapshots";
+import type { ProjectSnapshotResponse } from "@/lib/types/api";
+import { formatDateTime } from "@/lib/utils/format";
+
+const DEFAULT_LIMIT = 20;
+
+interface ProjectSnapshotsListProps {
+  projectId: string;
+}
+
+interface SnapshotCardProps {
+  snapshot: ProjectSnapshotResponse;
+  isCurrentVersion: boolean;
+  onRestoreRequest: (snapshot: ProjectSnapshotResponse) => void;
+}
+
+function SnapshotCard({
+  snapshot,
+  isCurrentVersion,
+  onRestoreRequest,
+}: SnapshotCardProps) {
+  const t = useTranslations("projects.snapshots");
+
+  return (
+    <Card className="transition-colors hover:bg-muted/30 dark:hover:bg-muted/20">
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="font-mono text-xs">
+              v{snapshot.version_number}
+            </Badge>
+            {isCurrentVersion && (
+              <Badge variant="secondary" className="text-xs">
+                {t("currentVersion")}
+              </Badge>
+            )}
+            {snapshot.restored_from_version !== null && (
+              <Badge variant="outline" className="text-xs text-muted-foreground">
+                {t("restoredFrom", { version: snapshot.restored_from_version })}
+              </Badge>
+            )}
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={isCurrentVersion}
+            onClick={() => onRestoreRequest(snapshot)}
+          >
+            {t("restore")}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="text-sm text-muted-foreground">
+          {formatDateTime(snapshot.created_at)}
+        </div>
+        {snapshot.label && (
+          <p className="text-sm italic text-muted-foreground">{snapshot.label}</p>
+        )}
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {snapshot.embedding_model && (
+            <span>
+              <span className="font-medium">{t("embeddingModel")}:</span>{" "}
+              {snapshot.embedding_model}
+            </span>
+          )}
+          {snapshot.llm_model && (
+            <span>
+              <span className="font-medium">{t("llmModel")}:</span>{" "}
+              {snapshot.llm_model}
+            </span>
+          )}
+          <span>
+            <span className="font-medium">{t("retrievalStrategy")}:</span>{" "}
+            {snapshot.retrieval_strategy}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SnapshotsSkeleton() {
+  return (
+    <div className="space-y-4">
+      {[1, 2, 3].map((i) => (
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <div className="flex gap-2">
+                <Skeleton className="h-5 w-10" />
+                <Skeleton className="h-5 w-24" />
+              </div>
+              <Skeleton className="h-8 w-20" />
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-64" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export function ProjectSnapshotsList({ projectId }: ProjectSnapshotsListProps) {
+  const t = useTranslations("projects.snapshots");
+  const tCommon = useTranslations("common");
+
+  const [offset, setOffset] = useState(0);
+  const [confirmSnapshot, setConfirmSnapshot] =
+    useState<ProjectSnapshotResponse | null>(null);
+
+  const { data, isLoading, isError } = useProjectSnapshots(
+    projectId,
+    DEFAULT_LIMIT,
+    offset,
+  );
+  const restoreMutation = useRestoreProjectSnapshot(projectId);
+
+  const snapshots = data?.snapshots ?? [];
+  const total = data?.total ?? 0;
+  const currentPage = Math.floor(offset / DEFAULT_LIMIT) + 1;
+  const totalPages = Math.ceil(total / DEFAULT_LIMIT);
+
+  const maxVersion =
+    snapshots.length > 0
+      ? Math.max(...snapshots.map((s) => s.version_number))
+      : -1;
+
+  function handleRestoreRequest(snapshot: ProjectSnapshotResponse) {
+    setConfirmSnapshot(snapshot);
+  }
+
+  function handleConfirmRestore() {
+    if (!confirmSnapshot) return;
+
+    const version = confirmSnapshot.version_number;
+    restoreMutation.mutate(version, {
+      onSuccess: () => {
+        toast.success(t("restoreSuccess", { version }));
+        setConfirmSnapshot(null);
+      },
+      onError: () => {
+        toast.error(t("restoreError", { version }));
+        setConfirmSnapshot(null);
+      },
+    });
+  }
+
+  function handleCancelRestore() {
+    setConfirmSnapshot(null);
+  }
+
+  if (isLoading) {
+    return <SnapshotsSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">{t("loadError")}</p>
+    );
+  }
+
+  if (snapshots.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">{t("empty")}</p>
+    );
+  }
+
+  return (
+    <>
+      <div className="space-y-4">
+        {snapshots.map((snapshot) => (
+          <SnapshotCard
+            key={snapshot.id}
+            snapshot={snapshot}
+            isCurrentVersion={snapshot.version_number === maxVersion}
+            onRestoreRequest={handleRestoreRequest}
+          />
+        ))}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset === 0}
+            onClick={() => setOffset(Math.max(0, offset - DEFAULT_LIMIT))}
+          >
+            {t("previous")}
+          </Button>
+          <span className="text-sm text-muted-foreground">
+            {t("pageInfo", { current: currentPage, total: totalPages })}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={offset + DEFAULT_LIMIT >= total}
+            onClick={() => setOffset(offset + DEFAULT_LIMIT)}
+          >
+            {t("next")}
+          </Button>
+        </div>
+      )}
+
+      <Dialog
+        open={confirmSnapshot !== null}
+        onOpenChange={(open) => {
+          if (!open) handleCancelRestore();
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {confirmSnapshot
+                ? t("restoreDialogTitle", {
+                    version: confirmSnapshot.version_number,
+                  })
+                : ""}
+            </DialogTitle>
+            <DialogDescription>
+              {confirmSnapshot
+                ? t("restoreDialogDescription", {
+                    version: confirmSnapshot.version_number,
+                  })
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={handleCancelRestore}
+              disabled={restoreMutation.isPending}
+            >
+              {tCommon("cancel")}
+            </Button>
+            <Button
+              onClick={handleConfirmRestore}
+              disabled={restoreMutation.isPending}
+            >
+              {restoreMutation.isPending ? t("restoring") : t("restore")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/lib/api/project-snapshots.ts
+++ b/client/src/lib/api/project-snapshots.ts
@@ -1,0 +1,39 @@
+import type {
+  ProjectSnapshotListResponse,
+  ProjectSnapshotResponse,
+} from "@/lib/types/api";
+import { apiFetch } from "./client";
+
+export function listProjectSnapshots(
+  token: string,
+  projectId: string,
+  limit = 20,
+  offset = 0,
+): Promise<ProjectSnapshotListResponse> {
+  return apiFetch<ProjectSnapshotListResponse>(
+    `/projects/${projectId}/snapshots?limit=${limit}&offset=${offset}`,
+    { token },
+  );
+}
+
+export function getProjectSnapshot(
+  token: string,
+  projectId: string,
+  versionNumber: number,
+): Promise<ProjectSnapshotResponse> {
+  return apiFetch<ProjectSnapshotResponse>(
+    `/projects/${projectId}/snapshots/${versionNumber}`,
+    { token },
+  );
+}
+
+export function restoreProjectSnapshot(
+  token: string,
+  projectId: string,
+  versionNumber: number,
+): Promise<ProjectSnapshotResponse> {
+  return apiFetch<ProjectSnapshotResponse>(
+    `/projects/${projectId}/snapshots/${versionNumber}/restore`,
+    { method: "POST", token },
+  );
+}

--- a/client/src/lib/hooks/use-project-snapshots.ts
+++ b/client/src/lib/hooks/use-project-snapshots.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getProjectSnapshot,
+  listProjectSnapshots,
+  restoreProjectSnapshot,
+} from "@/lib/api/project-snapshots";
+import { useAuth } from "./use-auth";
+
+export function useProjectSnapshots(
+  projectId: string,
+  limit = 20,
+  offset = 0,
+) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: ["projects", projectId, "snapshots"],
+    queryFn: () => listProjectSnapshots(token!, projectId, limit, offset),
+    enabled: !!token && !!projectId,
+  });
+}
+
+export function useProjectSnapshot(projectId: string, versionNumber: number) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: ["projects", projectId, "snapshots", versionNumber],
+    queryFn: () => getProjectSnapshot(token!, projectId, versionNumber),
+    enabled: !!token && !!projectId && versionNumber > 0,
+  });
+}
+
+export function useRestoreProjectSnapshot(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (versionNumber: number) =>
+      restoreProjectSnapshot(token!, projectId, versionNumber),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["projects", projectId, "snapshots"],
+      });
+      queryClient.invalidateQueries({ queryKey: ["projects", projectId] });
+    },
+  });
+}

--- a/client/src/lib/types/api.ts
+++ b/client/src/lib/types/api.ts
@@ -367,6 +367,48 @@ export interface ModelEntry {
   label: string;
 }
 
+// Project Snapshots
+export interface ProjectSnapshotResponse {
+  id: string;
+  project_id: string;
+  version_number: number;
+  label: string | null;
+  created_at: string;
+  created_by_user_id: string;
+  name: string;
+  description: string;
+  system_prompt: string;
+  is_published: boolean;
+  chunking_strategy: string;
+  parent_child_chunking: boolean;
+  embedding_backend: string | null;
+  embedding_model: string | null;
+  embedding_api_key_credential_id: string | null;
+  org_embedding_api_key_credential_id: string | null;
+  llm_backend: string | null;
+  llm_model: string | null;
+  llm_api_key_credential_id: string | null;
+  org_llm_api_key_credential_id: string | null;
+  retrieval_strategy: string;
+  retrieval_top_k: number;
+  retrieval_min_score: number;
+  chat_history_window_size: number;
+  chat_history_max_chars: number;
+  reranking_enabled: boolean;
+  reranker_backend: string | null;
+  reranker_model: string | null;
+  reranker_candidate_multiplier: number;
+  restored_from_version: number | null;
+  organization_id: string | null;
+}
+
+export interface ProjectSnapshotListResponse {
+  snapshots: ProjectSnapshotResponse[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface ModelCatalogResponse {
   embedding: Record<ProjectEmbeddingBackend, ModelEntry[]>;
   llm: Record<ProjectLLMBackend, ModelEntry[]>;

--- a/server/alembic/versions/20260321_39_add_project_snapshots.py
+++ b/server/alembic/versions/20260321_39_add_project_snapshots.py
@@ -1,0 +1,123 @@
+"""add project_snapshots table
+
+Revision ID: 20260321_39
+Revises: 20260319_38
+Create Date: 2026-03-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260321_39"
+down_revision: str | None = "20260319_38"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.Column("label", sa.String(255), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("system_prompt", sa.Text(), nullable=False, server_default=""),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "chunking_strategy",
+            sa.String(32),
+            nullable=False,
+            server_default="auto",
+        ),
+        sa.Column(
+            "parent_child_chunking",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column(
+            "organization_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("embedding_backend", sa.String(32), nullable=True),
+        sa.Column("embedding_model", sa.String(128), nullable=True),
+        sa.Column(
+            "embedding_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "org_embedding_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column("llm_backend", sa.String(32), nullable=True),
+        sa.Column("llm_model", sa.String(128), nullable=True),
+        sa.Column(
+            "llm_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "org_llm_api_key_credential_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "retrieval_strategy",
+            sa.String(16),
+            nullable=False,
+            server_default="hybrid",
+        ),
+        sa.Column("retrieval_top_k", sa.Integer(), nullable=False, server_default="8"),
+        sa.Column("retrieval_min_score", sa.Float(), nullable=False, server_default="0.3"),
+        sa.Column("chat_history_window_size", sa.Integer(), nullable=False, server_default="8"),
+        sa.Column("chat_history_max_chars", sa.Integer(), nullable=False, server_default="4000"),
+        sa.Column(
+            "reranking_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+        sa.Column("reranker_backend", sa.String(32), nullable=True),
+        sa.Column("reranker_model", sa.String(255), nullable=True),
+        sa.Column(
+            "reranker_candidate_multiplier",
+            sa.Integer(),
+            nullable=False,
+            server_default="3",
+        ),
+        sa.Column("restored_from_version", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        "ix_project_snapshots_project_id_version",
+        "project_snapshots",
+        ["project_id", "version_number"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_snapshots_project_id_version", table_name="project_snapshots")
+    op.drop_table("project_snapshots")

--- a/server/src/raggae/application/dto/project_snapshot_dto.py
+++ b/server/src/raggae/application/dto/project_snapshot_dto.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+
+
+@dataclass
+class ProjectSnapshotDTO:
+    """Data Transfer Object for ProjectSnapshot."""
+
+    id: UUID
+    project_id: UUID
+    version_number: int
+    label: str | None
+    created_at: datetime
+    created_by_user_id: UUID
+    name: str
+    description: str
+    system_prompt: str
+    is_published: bool
+    chunking_strategy: ChunkingStrategy
+    parent_child_chunking: bool
+    organization_id: UUID | None
+    embedding_backend: str | None
+    embedding_model: str | None
+    embedding_api_key_credential_id: UUID | None
+    org_embedding_api_key_credential_id: UUID | None
+    llm_backend: str | None
+    llm_model: str | None
+    llm_api_key_credential_id: UUID | None
+    org_llm_api_key_credential_id: UUID | None
+    retrieval_strategy: str
+    retrieval_top_k: int
+    retrieval_min_score: float
+    chat_history_window_size: int
+    chat_history_max_chars: int
+    reranking_enabled: bool
+    reranker_backend: str | None
+    reranker_model: str | None
+    reranker_candidate_multiplier: int
+    restored_from_version: int | None
+
+    @classmethod
+    def from_entity(cls, snapshot: ProjectSnapshot) -> "ProjectSnapshotDTO":
+        return cls(
+            id=snapshot.id,
+            project_id=snapshot.project_id,
+            version_number=snapshot.version_number,
+            label=snapshot.label,
+            created_at=snapshot.created_at,
+            created_by_user_id=snapshot.created_by_user_id,
+            name=snapshot.name,
+            description=snapshot.description,
+            system_prompt=snapshot.system_prompt,
+            is_published=snapshot.is_published,
+            chunking_strategy=snapshot.chunking_strategy,
+            parent_child_chunking=snapshot.parent_child_chunking,
+            organization_id=snapshot.organization_id,
+            embedding_backend=snapshot.embedding_backend,
+            embedding_model=snapshot.embedding_model,
+            embedding_api_key_credential_id=snapshot.embedding_api_key_credential_id,
+            org_embedding_api_key_credential_id=snapshot.org_embedding_api_key_credential_id,
+            llm_backend=snapshot.llm_backend,
+            llm_model=snapshot.llm_model,
+            llm_api_key_credential_id=snapshot.llm_api_key_credential_id,
+            org_llm_api_key_credential_id=snapshot.org_llm_api_key_credential_id,
+            retrieval_strategy=snapshot.retrieval_strategy,
+            retrieval_top_k=snapshot.retrieval_top_k,
+            retrieval_min_score=snapshot.retrieval_min_score,
+            chat_history_window_size=snapshot.chat_history_window_size,
+            chat_history_max_chars=snapshot.chat_history_max_chars,
+            reranking_enabled=snapshot.reranking_enabled,
+            reranker_backend=snapshot.reranker_backend,
+            reranker_model=snapshot.reranker_model,
+            reranker_candidate_multiplier=snapshot.reranker_candidate_multiplier,
+            restored_from_version=snapshot.restored_from_version,
+        )

--- a/server/src/raggae/application/interfaces/repositories/project_snapshot_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/project_snapshot_repository.py
@@ -1,0 +1,27 @@
+from typing import Protocol
+from uuid import UUID
+
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+
+
+class ProjectSnapshotRepository(Protocol):
+    """Interface for project snapshot persistence."""
+
+    async def save(self, snapshot: ProjectSnapshot) -> None: ...
+
+    async def find_by_project_and_version(
+        self,
+        project_id: UUID,
+        version_number: int,
+    ) -> ProjectSnapshot | None: ...
+
+    async def find_by_project_id(
+        self,
+        project_id: UUID,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[ProjectSnapshot]: ...
+
+    async def count_by_project_id(self, project_id: UUID) -> int: ...
+
+    async def get_next_version_number(self, project_id: UUID) -> int: ...

--- a/server/src/raggae/application/use_cases/project/update_project.py
+++ b/server/src/raggae/application/use_cases/project/update_project.py
@@ -26,12 +26,16 @@ from raggae.application.interfaces.repositories.organization_member_repository i
 from raggae.application.interfaces.repositories.project_repository import (
     ProjectRepository,
 )
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
 from raggae.application.interfaces.repositories.provider_credential_repository import (
     ProviderCredentialRepository,
 )
 from raggae.application.interfaces.services.provider_api_key_crypto_service import (
     ProviderApiKeyCryptoService,
 )
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
 from raggae.domain.exceptions.project_exceptions import (
     InvalidProjectChatHistoryMaxCharsError,
     InvalidProjectChatHistoryWindowSizeError,
@@ -67,12 +71,14 @@ class UpdateProject:
         organization_member_repository: OrganizationMemberRepository | None = None,
         provider_credential_repository: ProviderCredentialRepository | None = None,
         org_provider_credential_repository: OrgProviderCredentialRepository | None = None,
+        snapshot_repository: ProjectSnapshotRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._organization_member_repository = organization_member_repository
         self._provider_credential_repository = provider_credential_repository
         self._org_provider_credential_repository = org_provider_credential_repository
         self._provider_api_key_crypto_service: ProviderApiKeyCryptoService | None = None
+        self._snapshot_repository = snapshot_repository
 
     def with_crypto_service(
         self,
@@ -310,6 +316,16 @@ class UpdateProject:
             ),
         )
         await self._project_repository.save(updated_project)
+
+        if self._snapshot_repository is not None:
+            version_number = await self._snapshot_repository.get_next_version_number(updated_project.id)
+            snapshot = ProjectSnapshot.from_project(
+                project=updated_project,
+                version_number=version_number,
+                created_by_user_id=user_id,
+            )
+            await self._snapshot_repository.save(snapshot)
+
         return ProjectDTO.from_entity(updated_project)
 
     def _resolve_encrypted_api_key(

--- a/server/src/raggae/application/use_cases/project_snapshot/create_project_snapshot.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/create_project_snapshot.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from raggae.application.dto.project_snapshot_dto import ProjectSnapshotDTO
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+
+
+class CreateProjectSnapshot:
+    """Use Case: Create a configuration snapshot for a project."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        snapshot_repository: ProjectSnapshotRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._snapshot_repository = snapshot_repository
+
+    async def execute(
+        self,
+        project_id: UUID,
+        created_by_user_id: UUID,
+        label: str | None = None,
+        restored_from_version: int | None = None,
+    ) -> ProjectSnapshotDTO:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+
+        version_number = await self._snapshot_repository.get_next_version_number(project_id)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=project,
+            version_number=version_number,
+            created_by_user_id=created_by_user_id,
+            label=label,
+            restored_from_version=restored_from_version,
+        )
+
+        await self._snapshot_repository.save(snapshot)
+
+        return ProjectSnapshotDTO.from_entity(snapshot)

--- a/server/src/raggae/application/use_cases/project_snapshot/get_project_snapshot.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/get_project_snapshot.py
@@ -1,12 +1,16 @@
 from uuid import UUID
 
 from raggae.application.dto.project_snapshot_dto import ProjectSnapshotDTO
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.application.interfaces.repositories.project_snapshot_repository import (
     ProjectSnapshotRepository,
 )
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class GetProjectSnapshot:
@@ -16,9 +20,11 @@ class GetProjectSnapshot:
         self,
         project_repository: ProjectRepository,
         snapshot_repository: ProjectSnapshotRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._snapshot_repository = snapshot_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -29,8 +35,19 @@ class GetProjectSnapshot:
         project = await self._project_repository.find_by_id(project_id)
         if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+
         if project.user_id != user_id:
-            raise ProjectNotFoundError(f"Project {project_id} not found")
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         snapshot = await self._snapshot_repository.find_by_project_and_version(
             project_id=project_id,

--- a/server/src/raggae/application/use_cases/project_snapshot/get_project_snapshot.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/get_project_snapshot.py
@@ -1,0 +1,44 @@
+from uuid import UUID
+
+from raggae.application.dto.project_snapshot_dto import ProjectSnapshotDTO
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+
+
+class GetProjectSnapshot:
+    """Use Case: Get a specific snapshot version for a project."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        snapshot_repository: ProjectSnapshotRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._snapshot_repository = snapshot_repository
+
+    async def execute(
+        self,
+        project_id: UUID,
+        version_number: int,
+        user_id: UUID,
+    ) -> ProjectSnapshotDTO:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+
+        snapshot = await self._snapshot_repository.find_by_project_and_version(
+            project_id=project_id,
+            version_number=version_number,
+        )
+        if snapshot is None:
+            raise ProjectSnapshotNotFoundError(
+                f"Snapshot version {version_number} not found for project {project_id}"
+            )
+
+        return ProjectSnapshotDTO.from_entity(snapshot)

--- a/server/src/raggae/application/use_cases/project_snapshot/list_project_snapshots.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/list_project_snapshots.py
@@ -1,0 +1,41 @@
+from uuid import UUID
+
+from raggae.application.dto.project_snapshot_dto import ProjectSnapshotDTO
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+
+
+class ListProjectSnapshots:
+    """Use Case: List all snapshots for a project."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        snapshot_repository: ProjectSnapshotRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._snapshot_repository = snapshot_repository
+
+    async def execute(
+        self,
+        project_id: UUID,
+        user_id: UUID,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[ProjectSnapshotDTO]:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+
+        snapshots = await self._snapshot_repository.find_by_project_id(
+            project_id=project_id,
+            limit=limit,
+            offset=offset,
+        )
+
+        return [ProjectSnapshotDTO.from_entity(s) for s in snapshots]

--- a/server/src/raggae/application/use_cases/project_snapshot/list_project_snapshots.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/list_project_snapshots.py
@@ -1,11 +1,15 @@
 from uuid import UUID
 
 from raggae.application.dto.project_snapshot_dto import ProjectSnapshotDTO
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.application.interfaces.repositories.project_snapshot_repository import (
     ProjectSnapshotRepository,
 )
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class ListProjectSnapshots:
@@ -15,9 +19,11 @@ class ListProjectSnapshots:
         self,
         project_repository: ProjectRepository,
         snapshot_repository: ProjectSnapshotRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._snapshot_repository = snapshot_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -25,17 +31,29 @@ class ListProjectSnapshots:
         user_id: UUID,
         limit: int = 20,
         offset: int = 0,
-    ) -> list[ProjectSnapshotDTO]:
+    ) -> tuple[list[ProjectSnapshotDTO], int]:
         project = await self._project_repository.find_by_id(project_id)
         if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+
         if project.user_id != user_id:
-            raise ProjectNotFoundError(f"Project {project_id} not found")
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                if not project.is_published:
+                    raise ProjectNotFoundError(f"Project {project_id} not found")
 
         snapshots = await self._snapshot_repository.find_by_project_id(
             project_id=project_id,
             limit=limit,
             offset=offset,
         )
+        total = await self._snapshot_repository.count_by_project_id(project_id)
 
-        return [ProjectSnapshotDTO.from_entity(s) for s in snapshots]
+        return [ProjectSnapshotDTO.from_entity(s) for s in snapshots], total

--- a/server/src/raggae/application/use_cases/project_snapshot/restore_project_snapshot.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/restore_project_snapshot.py
@@ -1,0 +1,90 @@
+from dataclasses import replace
+from uuid import UUID
+
+from raggae.application.dto.project_dto import ProjectDTO
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+
+
+class RestoreProjectSnapshot:
+    """Use Case: Restore a project to a previous snapshot version.
+
+    Applies the snapshot's configuration fields to the project and creates
+    a new snapshot recording the restore operation.
+    """
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        snapshot_repository: ProjectSnapshotRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._snapshot_repository = snapshot_repository
+
+    async def execute(
+        self,
+        project_id: UUID,
+        version_number: int,
+        user_id: UUID,
+    ) -> ProjectDTO:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+        if project.user_id != user_id:
+            raise ProjectNotFoundError(f"Project {project_id} not found")
+
+        snapshot = await self._snapshot_repository.find_by_project_and_version(
+            project_id=project_id,
+            version_number=version_number,
+        )
+        if snapshot is None:
+            raise ProjectSnapshotNotFoundError(
+                f"Snapshot version {version_number} not found for project {project_id}"
+            )
+
+        # Apply snapshot fields to the project (exclude transient and encrypted fields)
+        restored_project = replace(
+            project,
+            name=snapshot.name,
+            description=snapshot.description,
+            system_prompt=snapshot.system_prompt,
+            is_published=snapshot.is_published,
+            chunking_strategy=snapshot.chunking_strategy,
+            parent_child_chunking=snapshot.parent_child_chunking,
+            embedding_backend=snapshot.embedding_backend,
+            embedding_model=snapshot.embedding_model,
+            embedding_api_key_credential_id=snapshot.embedding_api_key_credential_id,
+            org_embedding_api_key_credential_id=snapshot.org_embedding_api_key_credential_id,
+            llm_backend=snapshot.llm_backend,
+            llm_model=snapshot.llm_model,
+            llm_api_key_credential_id=snapshot.llm_api_key_credential_id,
+            org_llm_api_key_credential_id=snapshot.org_llm_api_key_credential_id,
+            retrieval_strategy=snapshot.retrieval_strategy,
+            retrieval_top_k=snapshot.retrieval_top_k,
+            retrieval_min_score=snapshot.retrieval_min_score,
+            chat_history_window_size=snapshot.chat_history_window_size,
+            chat_history_max_chars=snapshot.chat_history_max_chars,
+            reranking_enabled=snapshot.reranking_enabled,
+            reranker_backend=snapshot.reranker_backend,
+            reranker_model=snapshot.reranker_model,
+            reranker_candidate_multiplier=snapshot.reranker_candidate_multiplier,
+        )
+
+        await self._project_repository.save(restored_project)
+
+        # Create a new snapshot recording this restore
+        next_version = await self._snapshot_repository.get_next_version_number(project_id)
+        restore_snapshot = ProjectSnapshot.from_project(
+            project=restored_project,
+            version_number=next_version,
+            created_by_user_id=user_id,
+            restored_from_version=version_number,
+        )
+        await self._snapshot_repository.save(restore_snapshot)
+
+        return ProjectDTO.from_entity(restored_project)

--- a/server/src/raggae/application/use_cases/project_snapshot/restore_project_snapshot.py
+++ b/server/src/raggae/application/use_cases/project_snapshot/restore_project_snapshot.py
@@ -2,6 +2,9 @@ from dataclasses import replace
 from uuid import UUID
 
 from raggae.application.dto.project_dto import ProjectDTO
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
 from raggae.application.interfaces.repositories.project_snapshot_repository import (
     ProjectSnapshotRepository,
@@ -9,6 +12,7 @@ from raggae.application.interfaces.repositories.project_snapshot_repository impo
 from raggae.domain.entities.project_snapshot import ProjectSnapshot
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 
 
 class RestoreProjectSnapshot:
@@ -22,9 +26,11 @@ class RestoreProjectSnapshot:
         self,
         project_repository: ProjectRepository,
         snapshot_repository: ProjectSnapshotRepository,
+        organization_member_repository: OrganizationMemberRepository | None = None,
     ) -> None:
         self._project_repository = project_repository
         self._snapshot_repository = snapshot_repository
+        self._organization_member_repository = organization_member_repository
 
     async def execute(
         self,
@@ -35,8 +41,19 @@ class RestoreProjectSnapshot:
         project = await self._project_repository.find_by_id(project_id)
         if project is None:
             raise ProjectNotFoundError(f"Project {project_id} not found")
+
         if project.user_id != user_id:
-            raise ProjectNotFoundError(f"Project {project_id} not found")
+            if project.organization_id is None or self._organization_member_repository is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            member = await self._organization_member_repository.find_by_organization_and_user(
+                organization_id=project.organization_id,
+                user_id=user_id,
+            )
+            if member is None:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
+            # Restore is a write operation — only OWNER and MAKER are allowed
+            if member.role not in {OrganizationMemberRole.OWNER, OrganizationMemberRole.MAKER}:
+                raise ProjectNotFoundError(f"Project {project_id} not found")
 
         snapshot = await self._snapshot_repository.find_by_project_and_version(
             project_id=project_id,

--- a/server/src/raggae/domain/entities/project_snapshot.py
+++ b/server/src/raggae/domain/entities/project_snapshot.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from raggae.domain.entities.project import Project
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+
+
+@dataclass(frozen=True)
+class ProjectSnapshot:
+    """Immutable snapshot of a Project configuration at a point in time.
+
+    Encrypted API keys and transient reindex state are intentionally excluded.
+    """
+
+    id: UUID
+    project_id: UUID
+    version_number: int
+    label: str | None
+    created_at: datetime
+    created_by_user_id: UUID
+
+    # Project configuration fields (excluding encrypted keys and reindex state)
+    name: str
+    description: str
+    system_prompt: str
+    is_published: bool
+    chunking_strategy: ChunkingStrategy
+    parent_child_chunking: bool
+    organization_id: UUID | None
+    embedding_backend: str | None
+    embedding_model: str | None
+    embedding_api_key_credential_id: UUID | None
+    org_embedding_api_key_credential_id: UUID | None
+    llm_backend: str | None
+    llm_model: str | None
+    llm_api_key_credential_id: UUID | None
+    org_llm_api_key_credential_id: UUID | None
+    retrieval_strategy: str
+    retrieval_top_k: int
+    retrieval_min_score: float
+    chat_history_window_size: int
+    chat_history_max_chars: int
+    reranking_enabled: bool
+    reranker_backend: str | None
+    reranker_model: str | None
+    reranker_candidate_multiplier: int
+    restored_from_version: int | None
+
+    @classmethod
+    def from_project(
+        cls,
+        project: Project,
+        version_number: int,
+        created_by_user_id: UUID,
+        label: str | None = None,
+        restored_from_version: int | None = None,
+    ) -> "ProjectSnapshot":
+        """Create a new ProjectSnapshot from a Project entity."""
+        return cls(
+            id=uuid4(),
+            project_id=project.id,
+            version_number=version_number,
+            label=label,
+            created_at=datetime.now(UTC),
+            created_by_user_id=created_by_user_id,
+            name=project.name,
+            description=project.description,
+            system_prompt=project.system_prompt,
+            is_published=project.is_published,
+            chunking_strategy=project.chunking_strategy,
+            parent_child_chunking=project.parent_child_chunking,
+            organization_id=project.organization_id,
+            embedding_backend=project.embedding_backend,
+            embedding_model=project.embedding_model,
+            embedding_api_key_credential_id=project.embedding_api_key_credential_id,
+            org_embedding_api_key_credential_id=project.org_embedding_api_key_credential_id,
+            llm_backend=project.llm_backend,
+            llm_model=project.llm_model,
+            llm_api_key_credential_id=project.llm_api_key_credential_id,
+            org_llm_api_key_credential_id=project.org_llm_api_key_credential_id,
+            retrieval_strategy=project.retrieval_strategy,
+            retrieval_top_k=project.retrieval_top_k,
+            retrieval_min_score=project.retrieval_min_score,
+            chat_history_window_size=project.chat_history_window_size,
+            chat_history_max_chars=project.chat_history_max_chars,
+            reranking_enabled=project.reranking_enabled,
+            reranker_backend=project.reranker_backend,
+            reranker_model=project.reranker_model,
+            reranker_candidate_multiplier=project.reranker_candidate_multiplier,
+            restored_from_version=restored_from_version,
+        )

--- a/server/src/raggae/domain/exceptions/project_snapshot_exceptions.py
+++ b/server/src/raggae/domain/exceptions/project_snapshot_exceptions.py
@@ -1,0 +1,2 @@
+class ProjectSnapshotNotFoundError(Exception):
+    """Raised when a project snapshot cannot be found."""

--- a/server/src/raggae/infrastructure/database/models/__init__.py
+++ b/server/src/raggae/infrastructure/database/models/__init__.py
@@ -11,6 +11,7 @@ from raggae.infrastructure.database.models.organization_member_model import (
 )
 from raggae.infrastructure.database.models.organization_model import OrganizationModel
 from raggae.infrastructure.database.models.project_model import ProjectModel
+from raggae.infrastructure.database.models.project_snapshot_model import ProjectSnapshotModel
 from raggae.infrastructure.database.models.user_model import UserModel
 from raggae.infrastructure.database.models.user_model_provider_credential_model import (
     UserModelProviderCredentialModel,
@@ -26,6 +27,7 @@ __all__ = [
     "OrganizationMemberModel",
     "OrganizationModel",
     "ProjectModel",
+    "ProjectSnapshotModel",
     "UserModel",
     "UserModelProviderCredentialModel",
 ]

--- a/server/src/raggae/infrastructure/database/models/project_snapshot_model.py
+++ b/server/src/raggae/infrastructure/database/models/project_snapshot_model.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from raggae.infrastructure.database.models.base import Base
+
+
+class ProjectSnapshotModel(Base):
+    __tablename__ = "project_snapshots"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    version_number: Mapped[int] = mapped_column(Integer(), nullable=False)
+    label: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_by_user_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text(), nullable=False, default="")
+    system_prompt: Mapped[str] = mapped_column(Text(), nullable=False, default="")
+    is_published: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=False)
+    chunking_strategy: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="auto", server_default="auto"
+    )
+    parent_child_chunking: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, default=False, server_default="false"
+    )
+    organization_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+    embedding_backend: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    embedding_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    embedding_api_key_credential_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    org_embedding_api_key_credential_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    llm_backend: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    llm_model: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    llm_api_key_credential_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    org_llm_api_key_credential_id: Mapped[UUID | None] = mapped_column(PGUUID(as_uuid=True), nullable=True)
+    retrieval_strategy: Mapped[str] = mapped_column(
+        String(16), nullable=False, default="hybrid", server_default="hybrid"
+    )
+    retrieval_top_k: Mapped[int] = mapped_column(Integer(), nullable=False, default=8, server_default="8")
+    retrieval_min_score: Mapped[float] = mapped_column(
+        Float(), nullable=False, default=0.3, server_default="0.3"
+    )
+    chat_history_window_size: Mapped[int] = mapped_column(
+        Integer(), nullable=False, default=8, server_default="8"
+    )
+    chat_history_max_chars: Mapped[int] = mapped_column(
+        Integer(), nullable=False, default=4000, server_default="4000"
+    )
+    reranking_enabled: Mapped[bool] = mapped_column(
+        Boolean(), nullable=False, default=False, server_default="false"
+    )
+    reranker_backend: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    reranker_model: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    reranker_candidate_multiplier: Mapped[int] = mapped_column(
+        Integer(), nullable=False, default=3, server_default="3"
+    )
+    restored_from_version: Mapped[int | None] = mapped_column(Integer(), nullable=True)

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_project_snapshot_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_project_snapshot_repository.py
@@ -1,0 +1,42 @@
+from uuid import UUID
+
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+
+
+class InMemoryProjectSnapshotRepository:
+    """In-memory project snapshot repository for testing."""
+
+    def __init__(self) -> None:
+        self._snapshots: list[ProjectSnapshot] = []
+
+    async def save(self, snapshot: ProjectSnapshot) -> None:
+        self._snapshots.append(snapshot)
+
+    async def find_by_project_and_version(
+        self,
+        project_id: UUID,
+        version_number: int,
+    ) -> ProjectSnapshot | None:
+        return next(
+            (s for s in self._snapshots if s.project_id == project_id and s.version_number == version_number),
+            None,
+        )
+
+    async def find_by_project_id(
+        self,
+        project_id: UUID,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[ProjectSnapshot]:
+        matching = [s for s in self._snapshots if s.project_id == project_id]
+        matching.sort(key=lambda s: s.version_number, reverse=True)
+        return matching[offset : offset + limit]
+
+    async def count_by_project_id(self, project_id: UUID) -> int:
+        return sum(1 for s in self._snapshots if s.project_id == project_id)
+
+    async def get_next_version_number(self, project_id: UUID) -> int:
+        project_snapshots = [s for s in self._snapshots if s.project_id == project_id]
+        if not project_snapshots:
+            return 1
+        return max(s.version_number for s in project_snapshots) + 1

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_snapshot_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_snapshot_repository.py
@@ -1,0 +1,141 @@
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.infrastructure.database.models.project_snapshot_model import ProjectSnapshotModel
+
+
+class SQLAlchemyProjectSnapshotRepository:
+    """PostgreSQL project snapshot repository using SQLAlchemy async sessions."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def save(self, snapshot: ProjectSnapshot) -> None:
+        async with self._session_factory() as session:
+            model = ProjectSnapshotModel(
+                id=snapshot.id,
+                project_id=snapshot.project_id,
+                version_number=snapshot.version_number,
+                label=snapshot.label,
+                created_at=snapshot.created_at,
+                created_by_user_id=snapshot.created_by_user_id,
+                name=snapshot.name,
+                description=snapshot.description,
+                system_prompt=snapshot.system_prompt,
+                is_published=snapshot.is_published,
+                chunking_strategy=snapshot.chunking_strategy.value,
+                parent_child_chunking=snapshot.parent_child_chunking,
+                organization_id=snapshot.organization_id,
+                embedding_backend=snapshot.embedding_backend,
+                embedding_model=snapshot.embedding_model,
+                embedding_api_key_credential_id=snapshot.embedding_api_key_credential_id,
+                org_embedding_api_key_credential_id=snapshot.org_embedding_api_key_credential_id,
+                llm_backend=snapshot.llm_backend,
+                llm_model=snapshot.llm_model,
+                llm_api_key_credential_id=snapshot.llm_api_key_credential_id,
+                org_llm_api_key_credential_id=snapshot.org_llm_api_key_credential_id,
+                retrieval_strategy=snapshot.retrieval_strategy,
+                retrieval_top_k=snapshot.retrieval_top_k,
+                retrieval_min_score=snapshot.retrieval_min_score,
+                chat_history_window_size=snapshot.chat_history_window_size,
+                chat_history_max_chars=snapshot.chat_history_max_chars,
+                reranking_enabled=snapshot.reranking_enabled,
+                reranker_backend=snapshot.reranker_backend,
+                reranker_model=snapshot.reranker_model,
+                reranker_candidate_multiplier=snapshot.reranker_candidate_multiplier,
+                restored_from_version=snapshot.restored_from_version,
+            )
+            session.add(model)
+            await session.commit()
+
+    async def find_by_project_and_version(
+        self,
+        project_id: UUID,
+        version_number: int,
+    ) -> ProjectSnapshot | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectSnapshotModel).where(
+                    ProjectSnapshotModel.project_id == project_id,
+                    ProjectSnapshotModel.version_number == version_number,
+                )
+            )
+            model = result.scalar_one_or_none()
+            if model is None:
+                return None
+            return self._to_entity(model)
+
+    async def find_by_project_id(
+        self,
+        project_id: UUID,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> list[ProjectSnapshot]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectSnapshotModel)
+                .where(ProjectSnapshotModel.project_id == project_id)
+                .order_by(ProjectSnapshotModel.version_number.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+            models = result.scalars().all()
+            return [self._to_entity(m) for m in models]
+
+    async def count_by_project_id(self, project_id: UUID) -> int:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(func.count()).where(ProjectSnapshotModel.project_id == project_id)
+            )
+            return result.scalar_one()
+
+    async def get_next_version_number(self, project_id: UUID) -> int:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(func.max(ProjectSnapshotModel.version_number)).where(
+                    ProjectSnapshotModel.project_id == project_id
+                )
+            )
+            max_version = result.scalar_one_or_none()
+            if max_version is None:
+                return 1
+            return max_version + 1
+
+    def _to_entity(self, model: ProjectSnapshotModel) -> ProjectSnapshot:
+        return ProjectSnapshot(
+            id=model.id,
+            project_id=model.project_id,
+            version_number=model.version_number,
+            label=model.label,
+            created_at=model.created_at,
+            created_by_user_id=model.created_by_user_id,
+            name=model.name,
+            description=model.description,
+            system_prompt=model.system_prompt,
+            is_published=model.is_published,
+            chunking_strategy=ChunkingStrategy(model.chunking_strategy),
+            parent_child_chunking=model.parent_child_chunking,
+            organization_id=model.organization_id,
+            embedding_backend=model.embedding_backend,
+            embedding_model=model.embedding_model,
+            embedding_api_key_credential_id=model.embedding_api_key_credential_id,
+            org_embedding_api_key_credential_id=model.org_embedding_api_key_credential_id,
+            llm_backend=model.llm_backend,
+            llm_model=model.llm_model,
+            llm_api_key_credential_id=model.llm_api_key_credential_id,
+            org_llm_api_key_credential_id=model.org_llm_api_key_credential_id,
+            retrieval_strategy=model.retrieval_strategy,
+            retrieval_top_k=model.retrieval_top_k,
+            retrieval_min_score=model.retrieval_min_score,
+            chat_history_window_size=model.chat_history_window_size,
+            chat_history_max_chars=model.chat_history_max_chars,
+            reranking_enabled=model.reranking_enabled,
+            reranker_backend=model.reranker_backend,
+            reranker_model=model.reranker_model,
+            reranker_candidate_multiplier=model.reranker_candidate_multiplier,
+            restored_from_version=model.restored_from_version,
+        )

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_snapshot_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_snapshot_repository.py
@@ -91,7 +91,7 @@ class SQLAlchemyProjectSnapshotRepository:
             result = await session.execute(
                 select(func.count()).where(ProjectSnapshotModel.project_id == project_id)
             )
-            return result.scalar_one()
+            return int(result.scalar_one())
 
     async def get_next_version_number(self, project_id: UUID) -> int:
         async with self._session_factory() as session:
@@ -103,7 +103,7 @@ class SQLAlchemyProjectSnapshotRepository:
             max_version = result.scalar_one_or_none()
             if max_version is None:
                 return 1
-            return max_version + 1
+            return int(max_version) + 1
 
     def _to_entity(self, model: ProjectSnapshotModel) -> ProjectSnapshot:
         return ProjectSnapshot(

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -1024,6 +1024,7 @@ def get_list_project_snapshots_use_case() -> ListProjectSnapshots:
     return ListProjectSnapshots(
         project_repository=_project_repository,
         snapshot_repository=_project_snapshot_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 
@@ -1031,6 +1032,7 @@ def get_get_project_snapshot_use_case() -> GetProjectSnapshot:
     return GetProjectSnapshot(
         project_repository=_project_repository,
         snapshot_repository=_project_snapshot_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 
@@ -1038,6 +1040,7 @@ def get_restore_project_snapshot_use_case() -> RestoreProjectSnapshot:
     return RestoreProjectSnapshot(
         project_repository=_project_repository,
         snapshot_repository=_project_snapshot_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -28,6 +28,9 @@ from raggae.application.interfaces.repositories.organization_repository import (
     OrganizationRepository,
 )
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.interfaces.repositories.project_snapshot_repository import (
+    ProjectSnapshotRepository,
+)
 from raggae.application.interfaces.repositories.provider_credential_repository import (
     ProviderCredentialRepository,
 )
@@ -156,6 +159,11 @@ from raggae.application.use_cases.project.publish_project import PublishProject
 from raggae.application.use_cases.project.reindex_project import ReindexProject
 from raggae.application.use_cases.project.unpublish_project import UnpublishProject
 from raggae.application.use_cases.project.update_project import UpdateProject
+from raggae.application.use_cases.project_snapshot.get_project_snapshot import GetProjectSnapshot
+from raggae.application.use_cases.project_snapshot.list_project_snapshots import ListProjectSnapshots
+from raggae.application.use_cases.project_snapshot.restore_project_snapshot import (
+    RestoreProjectSnapshot,
+)
 from raggae.application.use_cases.provider_credentials.activate_provider_api_key import (
     ActivateProviderApiKey,
 )
@@ -210,6 +218,9 @@ from raggae.infrastructure.database.repositories.in_memory_organization_reposito
 from raggae.infrastructure.database.repositories.in_memory_project_repository import (
     InMemoryProjectRepository,
 )
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
 from raggae.infrastructure.database.repositories.in_memory_provider_credential_repository import (
     InMemoryProviderCredentialRepository,
 )
@@ -242,6 +253,9 @@ from raggae.infrastructure.database.repositories.sqlalchemy_organization_reposit
 )
 from raggae.infrastructure.database.repositories.sqlalchemy_project_repository import (
     SQLAlchemyProjectRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_project_snapshot_repository import (
+    SQLAlchemyProjectSnapshotRepository,
 )
 from raggae.infrastructure.database.repositories.sqlalchemy_provider_credential_repository import (
     SQLAlchemyProviderCredentialRepository,
@@ -369,6 +383,9 @@ def _build_embedding_service() -> EmbeddingService:
 if settings.persistence_backend == "postgres":
     _user_repository: UserRepository = SQLAlchemyUserRepository(session_factory=SessionFactory)
     _project_repository: ProjectRepository = SQLAlchemyProjectRepository(session_factory=SessionFactory)
+    _project_snapshot_repository: ProjectSnapshotRepository = SQLAlchemyProjectSnapshotRepository(
+        session_factory=SessionFactory
+    )
     _document_repository: DocumentRepository = SQLAlchemyDocumentRepository(session_factory=SessionFactory)
     _document_chunk_repository: DocumentChunkRepository = SQLAlchemyDocumentChunkRepository(
         session_factory=SessionFactory
@@ -402,6 +419,7 @@ if settings.persistence_backend == "postgres":
 else:
     _user_repository = InMemoryUserRepository()
     _project_repository = InMemoryProjectRepository()
+    _project_snapshot_repository = InMemoryProjectSnapshotRepository()
     _document_repository = InMemoryDocumentRepository()
     _document_chunk_repository = InMemoryDocumentChunkRepository()
     _conversation_repository = InMemoryConversationRepository()
@@ -640,6 +658,7 @@ def get_update_project_use_case() -> UpdateProject:
         organization_member_repository=_organization_member_repository,
         provider_credential_repository=_provider_credential_repository,
         org_provider_credential_repository=_org_credential_repository,
+        snapshot_repository=_project_snapshot_repository,
     ).with_crypto_service(_provider_api_key_crypto_service)
 
 
@@ -998,6 +1017,27 @@ def get_delete_org_provider_api_key_use_case() -> DeleteOrgProviderApiKey:
         org_credential_repository=_org_credential_repository,
         organization_member_repository=_organization_member_repository,
         project_repository=_project_repository,
+    )
+
+
+def get_list_project_snapshots_use_case() -> ListProjectSnapshots:
+    return ListProjectSnapshots(
+        project_repository=_project_repository,
+        snapshot_repository=_project_snapshot_repository,
+    )
+
+
+def get_get_project_snapshot_use_case() -> GetProjectSnapshot:
+    return GetProjectSnapshot(
+        project_repository=_project_repository,
+        snapshot_repository=_project_snapshot_repository,
+    )
+
+
+def get_restore_project_snapshot_use_case() -> RestoreProjectSnapshot:
+    return RestoreProjectSnapshot(
+        project_repository=_project_repository,
+        snapshot_repository=_project_snapshot_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/v1/endpoints/project_snapshots.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/project_snapshots.py
@@ -41,7 +41,7 @@ async def list_project_snapshots(
     offset: int = Query(default=0, ge=0),
 ) -> ProjectSnapshotListResponse:
     try:
-        snapshot_dtos = await use_case.execute(
+        snapshot_dtos, total = await use_case.execute(
             project_id=project_id,
             user_id=user_id,
             limit=limit,
@@ -92,7 +92,7 @@ async def list_project_snapshots(
 
     return ProjectSnapshotListResponse(
         snapshots=snapshots,
-        total=len(snapshots),
+        total=total,
         limit=limit,
         offset=offset,
     )

--- a/server/src/raggae/presentation/api/v1/endpoints/project_snapshots.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/project_snapshots.py
@@ -1,0 +1,217 @@
+from typing import Annotated, Literal, cast
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from raggae.application.use_cases.project_snapshot.get_project_snapshot import GetProjectSnapshot
+from raggae.application.use_cases.project_snapshot.list_project_snapshots import ListProjectSnapshots
+from raggae.application.use_cases.project_snapshot.restore_project_snapshot import (
+    RestoreProjectSnapshot,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+from raggae.presentation.api.dependencies import (
+    get_current_user_id,
+    get_get_project_snapshot_use_case,
+    get_list_project_snapshots_use_case,
+    get_restore_project_snapshot_use_case,
+)
+from raggae.presentation.api.v1.schemas.project_schemas import ProjectResponse
+from raggae.presentation.api.v1.schemas.project_snapshot_schemas import (
+    ProjectSnapshotListResponse,
+    ProjectSnapshotResponse,
+)
+
+router = APIRouter(
+    prefix="/projects/{project_id}/snapshots",
+    tags=["project-snapshots"],
+    dependencies=[Depends(get_current_user_id)],
+)
+
+ProjectRetrievalStrategy = Literal["vector", "fulltext", "hybrid"]
+ProjectRerankerBackend = Literal["none", "cross_encoder", "inmemory", "mmr"]
+
+
+@router.get("", response_model=ProjectSnapshotListResponse)
+async def list_project_snapshots(
+    project_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ListProjectSnapshots, Depends(get_list_project_snapshots_use_case)],
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> ProjectSnapshotListResponse:
+    try:
+        snapshot_dtos = await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            limit=limit,
+            offset=offset,
+        )
+    except ProjectNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        ) from None
+
+    snapshots = [
+        ProjectSnapshotResponse(
+            id=s.id,
+            project_id=s.project_id,
+            version_number=s.version_number,
+            label=s.label,
+            created_at=s.created_at,
+            created_by_user_id=s.created_by_user_id,
+            name=s.name,
+            description=s.description,
+            system_prompt=s.system_prompt,
+            is_published=s.is_published,
+            chunking_strategy=s.chunking_strategy,
+            parent_child_chunking=s.parent_child_chunking,
+            organization_id=s.organization_id,
+            embedding_backend=s.embedding_backend,
+            embedding_model=s.embedding_model,
+            embedding_api_key_credential_id=s.embedding_api_key_credential_id,
+            org_embedding_api_key_credential_id=s.org_embedding_api_key_credential_id,
+            llm_backend=s.llm_backend,
+            llm_model=s.llm_model,
+            llm_api_key_credential_id=s.llm_api_key_credential_id,
+            org_llm_api_key_credential_id=s.org_llm_api_key_credential_id,
+            retrieval_strategy=cast(ProjectRetrievalStrategy, s.retrieval_strategy),
+            retrieval_top_k=s.retrieval_top_k,
+            retrieval_min_score=s.retrieval_min_score,
+            chat_history_window_size=s.chat_history_window_size,
+            chat_history_max_chars=s.chat_history_max_chars,
+            reranking_enabled=s.reranking_enabled,
+            reranker_backend=cast(ProjectRerankerBackend | None, s.reranker_backend),
+            reranker_model=s.reranker_model,
+            reranker_candidate_multiplier=s.reranker_candidate_multiplier,
+            restored_from_version=s.restored_from_version,
+        )
+        for s in snapshot_dtos
+    ]
+
+    return ProjectSnapshotListResponse(
+        snapshots=snapshots,
+        total=len(snapshots),
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{version_number}", response_model=ProjectSnapshotResponse)
+async def get_project_snapshot(
+    project_id: UUID,
+    version_number: int,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[GetProjectSnapshot, Depends(get_get_project_snapshot_use_case)],
+) -> ProjectSnapshotResponse:
+    try:
+        snapshot_dto = await use_case.execute(
+            project_id=project_id,
+            version_number=version_number,
+            user_id=user_id,
+        )
+    except ProjectNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        ) from None
+    except ProjectSnapshotNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Snapshot not found",
+        ) from None
+
+    return ProjectSnapshotResponse(
+        id=snapshot_dto.id,
+        project_id=snapshot_dto.project_id,
+        version_number=snapshot_dto.version_number,
+        label=snapshot_dto.label,
+        created_at=snapshot_dto.created_at,
+        created_by_user_id=snapshot_dto.created_by_user_id,
+        name=snapshot_dto.name,
+        description=snapshot_dto.description,
+        system_prompt=snapshot_dto.system_prompt,
+        is_published=snapshot_dto.is_published,
+        chunking_strategy=snapshot_dto.chunking_strategy,
+        parent_child_chunking=snapshot_dto.parent_child_chunking,
+        organization_id=snapshot_dto.organization_id,
+        embedding_backend=snapshot_dto.embedding_backend,
+        embedding_model=snapshot_dto.embedding_model,
+        embedding_api_key_credential_id=snapshot_dto.embedding_api_key_credential_id,
+        org_embedding_api_key_credential_id=snapshot_dto.org_embedding_api_key_credential_id,
+        llm_backend=snapshot_dto.llm_backend,
+        llm_model=snapshot_dto.llm_model,
+        llm_api_key_credential_id=snapshot_dto.llm_api_key_credential_id,
+        org_llm_api_key_credential_id=snapshot_dto.org_llm_api_key_credential_id,
+        retrieval_strategy=cast(ProjectRetrievalStrategy, snapshot_dto.retrieval_strategy),
+        retrieval_top_k=snapshot_dto.retrieval_top_k,
+        retrieval_min_score=snapshot_dto.retrieval_min_score,
+        chat_history_window_size=snapshot_dto.chat_history_window_size,
+        chat_history_max_chars=snapshot_dto.chat_history_max_chars,
+        reranking_enabled=snapshot_dto.reranking_enabled,
+        reranker_backend=cast(ProjectRerankerBackend | None, snapshot_dto.reranker_backend),
+        reranker_model=snapshot_dto.reranker_model,
+        reranker_candidate_multiplier=snapshot_dto.reranker_candidate_multiplier,
+        restored_from_version=snapshot_dto.restored_from_version,
+    )
+
+
+@router.post("/{version_number}/restore", status_code=status.HTTP_200_OK)
+async def restore_project_snapshot(
+    project_id: UUID,
+    version_number: int,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[RestoreProjectSnapshot, Depends(get_restore_project_snapshot_use_case)],
+) -> ProjectResponse:
+    try:
+        project_dto = await use_case.execute(
+            project_id=project_id,
+            version_number=version_number,
+            user_id=user_id,
+        )
+    except ProjectNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Project not found",
+        ) from None
+    except ProjectSnapshotNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Snapshot not found",
+        ) from None
+
+    return ProjectResponse(
+        id=project_dto.id,
+        user_id=project_dto.user_id,
+        organization_id=project_dto.organization_id,
+        name=project_dto.name,
+        description=project_dto.description,
+        system_prompt=project_dto.system_prompt,
+        is_published=project_dto.is_published,
+        created_at=project_dto.created_at,
+        chunking_strategy=project_dto.chunking_strategy,
+        parent_child_chunking=project_dto.parent_child_chunking,
+        reindex_status=project_dto.reindex_status,
+        reindex_progress=project_dto.reindex_progress,
+        reindex_total=project_dto.reindex_total,
+        embedding_backend=project_dto.embedding_backend,
+        embedding_model=project_dto.embedding_model,
+        embedding_api_key_masked=project_dto.embedding_api_key_masked,
+        embedding_api_key_credential_id=project_dto.embedding_api_key_credential_id,
+        org_embedding_api_key_credential_id=project_dto.org_embedding_api_key_credential_id,
+        llm_backend=project_dto.llm_backend,
+        llm_model=project_dto.llm_model,
+        llm_api_key_masked=project_dto.llm_api_key_masked,
+        llm_api_key_credential_id=project_dto.llm_api_key_credential_id,
+        org_llm_api_key_credential_id=project_dto.org_llm_api_key_credential_id,
+        retrieval_strategy=cast(ProjectRetrievalStrategy, project_dto.retrieval_strategy),
+        retrieval_top_k=project_dto.retrieval_top_k,
+        retrieval_min_score=project_dto.retrieval_min_score,
+        chat_history_window_size=project_dto.chat_history_window_size,
+        chat_history_max_chars=project_dto.chat_history_max_chars,
+        reranking_enabled=project_dto.reranking_enabled,
+        reranker_backend=cast(ProjectRerankerBackend | None, project_dto.reranker_backend),
+        reranker_model=project_dto.reranker_model,
+        reranker_candidate_multiplier=project_dto.reranker_candidate_multiplier,
+    )

--- a/server/src/raggae/presentation/api/v1/schemas/project_snapshot_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/project_snapshot_schemas.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+
+
+class ProjectSnapshotResponse(BaseModel):
+    id: UUID
+    project_id: UUID
+    version_number: int
+    label: str | None
+    created_at: datetime
+    created_by_user_id: UUID
+    name: str
+    description: str
+    system_prompt: str
+    is_published: bool
+    chunking_strategy: ChunkingStrategy
+    parent_child_chunking: bool
+    organization_id: UUID | None
+    embedding_backend: str | None
+    embedding_model: str | None
+    embedding_api_key_credential_id: UUID | None
+    org_embedding_api_key_credential_id: UUID | None
+    llm_backend: str | None
+    llm_model: str | None
+    llm_api_key_credential_id: UUID | None
+    org_llm_api_key_credential_id: UUID | None
+    retrieval_strategy: Literal["vector", "fulltext", "hybrid"]
+    retrieval_top_k: int
+    retrieval_min_score: float
+    chat_history_window_size: int
+    chat_history_max_chars: int
+    reranking_enabled: bool
+    reranker_backend: Literal["none", "cross_encoder", "inmemory", "mmr"] | None
+    reranker_model: str | None
+    reranker_candidate_multiplier: int
+    restored_from_version: int | None
+
+
+class ProjectSnapshotListResponse(BaseModel):
+    snapshots: list[ProjectSnapshotResponse]
+    total: int
+    limit: int
+    offset: int

--- a/server/src/raggae/presentation/main.py
+++ b/server/src/raggae/presentation/main.py
@@ -20,6 +20,9 @@ from raggae.presentation.api.v1.endpoints.org_model_credentials import (
     router as org_model_credentials_router,
 )
 from raggae.presentation.api.v1.endpoints.organizations import router as organizations_router
+from raggae.presentation.api.v1.endpoints.project_snapshots import (
+    router as project_snapshots_router,
+)
 from raggae.presentation.api.v1.endpoints.projects import router as projects_router
 
 logger = logging.getLogger(__name__)
@@ -67,6 +70,7 @@ app.add_middleware(
 app.include_router(auth_router, prefix="/api/v1")
 app.include_router(entra_router, prefix="/api/v1")
 app.include_router(projects_router, prefix="/api/v1")
+app.include_router(project_snapshots_router, prefix="/api/v1")
 app.include_router(organizations_router, prefix="/api/v1")
 app.include_router(documents_router, prefix="/api/v1")
 app.include_router(chat_router, prefix="/api/v1")

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -43,6 +43,10 @@ def _reset_repositories() -> None:
         dependencies._organization_invitation_repository, "_invitations"
     ):
         dependencies._organization_invitation_repository._invitations.clear()
+    if hasattr(dependencies, "_project_snapshot_repository") and hasattr(
+        dependencies._project_snapshot_repository, "_snapshots"
+    ):
+        dependencies._project_snapshot_repository._snapshots.clear()
 
 
 @pytest.fixture

--- a/server/tests/unit/application/use_cases/project/test_update_project.py
+++ b/server/tests/unit/application/use_cases/project/test_update_project.py
@@ -26,6 +26,12 @@ from raggae.domain.exceptions.project_exceptions import (
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
 from raggae.domain.value_objects.model_provider import ModelProvider
 from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+from raggae.infrastructure.database.repositories.in_memory_project_repository import (
+    InMemoryProjectRepository,
+)
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
 
 
 class TestUpdateProject:
@@ -1081,3 +1087,114 @@ class TestUpdateProject:
                 embedding_backend="openai",
                 embedding_api_key_credential_id=uuid4(),
             )
+
+    async def test_update_project_creates_snapshot_on_successful_update(self) -> None:
+        # Given
+        project_id = uuid4()
+        user_id = uuid4()
+        project = Project(
+            id=project_id,
+            user_id=user_id,
+            name="Old name",
+            description="Old description",
+            system_prompt="Old prompt",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+        project_repository = InMemoryProjectRepository()
+        await project_repository.save(project)
+        snapshot_repository = InMemoryProjectSnapshotRepository()
+
+        use_case = UpdateProject(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            name="New name",
+            description="New description",
+            system_prompt="New prompt",
+        )
+
+        # Then
+        count = await snapshot_repository.count_by_project_id(project_id)
+        assert count == 1
+
+    async def test_update_project_snapshot_version_increments_on_each_update(self) -> None:
+        # Given
+        project_id = uuid4()
+        user_id = uuid4()
+        project = Project(
+            id=project_id,
+            user_id=user_id,
+            name="Old name",
+            description="Old description",
+            system_prompt="Old prompt",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+        project_repository = InMemoryProjectRepository()
+        await project_repository.save(project)
+        snapshot_repository = InMemoryProjectSnapshotRepository()
+
+        use_case = UpdateProject(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            name="New name 1",
+            description="",
+            system_prompt="",
+        )
+        await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            name="New name 2",
+            description="",
+            system_prompt="",
+        )
+
+        # Then
+        count = await snapshot_repository.count_by_project_id(project_id)
+        assert count == 2
+        snapshots = await snapshot_repository.find_by_project_id(project_id)
+        versions = {s.version_number for s in snapshots}
+        assert versions == {1, 2}
+
+    async def test_update_project_without_snapshot_repository_still_works(self) -> None:
+        # Given
+        project_id = uuid4()
+        user_id = uuid4()
+        project = Project(
+            id=project_id,
+            user_id=user_id,
+            name="Old name",
+            description="Old description",
+            system_prompt="Old prompt",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+        project_repository = InMemoryProjectRepository()
+        await project_repository.save(project)
+
+        # No snapshot_repository provided
+        use_case = UpdateProject(project_repository=project_repository)
+
+        # When
+        result = await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            name="New name",
+            description="New description",
+            system_prompt="New prompt",
+        )
+
+        # Then — update works even without snapshot repo
+        assert result.name == "New name"

--- a/server/tests/unit/application/use_cases/project_snapshot/test_create_project_snapshot.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_create_project_snapshot.py
@@ -1,0 +1,200 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_snapshot.create_project_snapshot import (
+    CreateProjectSnapshot,
+)
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.infrastructure.database.repositories.in_memory_project_repository import (
+    InMemoryProjectRepository,
+)
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
+
+
+class TestCreateProjectSnapshot:
+    @pytest.fixture
+    def project_repository(self) -> InMemoryProjectRepository:
+        return InMemoryProjectRepository()
+
+    @pytest.fixture
+    def snapshot_repository(self) -> InMemoryProjectSnapshotRepository:
+        return InMemoryProjectSnapshotRepository()
+
+    @pytest.fixture
+    def use_case(
+        self,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+    ) -> CreateProjectSnapshot:
+        return CreateProjectSnapshot(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+    @pytest.fixture
+    def sample_project(self) -> Project:
+        return Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="My Project",
+            description="A project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+
+    async def test_create_project_snapshot_success(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        user_id = sample_project.user_id
+
+        # When
+        snapshot_dto = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=user_id,
+        )
+
+        # Then
+        assert snapshot_dto.project_id == sample_project.id
+        assert snapshot_dto.version_number == 1
+        assert snapshot_dto.created_by_user_id == user_id
+        assert snapshot_dto.label is None
+        assert snapshot_dto.restored_from_version is None
+
+    async def test_create_project_snapshot_version_increments_sequentially(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        user_id = sample_project.user_id
+
+        # When
+        snapshot1 = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=user_id,
+        )
+        snapshot2 = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=user_id,
+        )
+        snapshot3 = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=user_id,
+        )
+
+        # Then
+        assert snapshot1.version_number == 1
+        assert snapshot2.version_number == 2
+        assert snapshot3.version_number == 3
+
+    async def test_create_project_snapshot_with_label(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        label = "release-1.0"
+
+        # When
+        snapshot_dto = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=sample_project.user_id,
+            label=label,
+        )
+
+        # Then
+        assert snapshot_dto.label == label
+
+    async def test_create_project_snapshot_with_restored_from_version(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+
+        # When
+        snapshot_dto = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=sample_project.user_id,
+            restored_from_version=3,
+        )
+
+        # Then
+        assert snapshot_dto.restored_from_version == 3
+
+    async def test_create_project_snapshot_raises_when_project_not_found(
+        self,
+        use_case: CreateProjectSnapshot,
+    ) -> None:
+        # Given
+        non_existent_project_id = uuid4()
+        user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=non_existent_project_id,
+                created_by_user_id=user_id,
+            )
+
+    async def test_create_project_snapshot_persists_snapshot(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+
+        # When
+        await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then
+        count = await snapshot_repository.count_by_project_id(sample_project.id)
+        assert count == 1
+
+    async def test_create_project_snapshot_preserves_project_config(
+        self,
+        use_case: CreateProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+
+        # When
+        snapshot_dto = await use_case.execute(
+            project_id=sample_project.id,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert snapshot_dto.name == sample_project.name
+        assert snapshot_dto.description == sample_project.description
+        assert snapshot_dto.system_prompt == sample_project.system_prompt
+        assert snapshot_dto.is_published == sample_project.is_published

--- a/server/tests/unit/application/use_cases/project_snapshot/test_get_project_snapshot.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_get_project_snapshot.py
@@ -1,0 +1,169 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_snapshot.get_project_snapshot import (
+    GetProjectSnapshot,
+)
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.infrastructure.database.repositories.in_memory_project_repository import (
+    InMemoryProjectRepository,
+)
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
+
+
+class TestGetProjectSnapshot:
+    @pytest.fixture
+    def project_repository(self) -> InMemoryProjectRepository:
+        return InMemoryProjectRepository()
+
+    @pytest.fixture
+    def snapshot_repository(self) -> InMemoryProjectSnapshotRepository:
+        return InMemoryProjectSnapshotRepository()
+
+    @pytest.fixture
+    def use_case(
+        self,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+    ) -> GetProjectSnapshot:
+        return GetProjectSnapshot(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+    @pytest.fixture
+    def sample_project(self) -> Project:
+        return Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="My Project",
+            description="A project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+
+    async def test_get_project_snapshot_success(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            version_number=1,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert result.project_id == sample_project.id
+        assert result.version_number == 1
+        assert result.name == sample_project.name
+
+    async def test_get_project_snapshot_raises_when_project_not_found(
+        self,
+        use_case: GetProjectSnapshot,
+    ) -> None:
+        # Given
+        non_existent_project_id = uuid4()
+        user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=non_existent_project_id,
+                version_number=1,
+                user_id=user_id,
+            )
+
+    async def test_get_project_snapshot_raises_for_unauthorized_user(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        another_user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=sample_project.id,
+                version_number=1,
+                user_id=another_user_id,
+            )
+
+    async def test_get_project_snapshot_raises_when_version_not_found(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When / Then
+        with pytest.raises(ProjectSnapshotNotFoundError):
+            await use_case.execute(
+                project_id=sample_project.id,
+                version_number=99,
+                user_id=sample_project.user_id,
+            )
+
+    async def test_get_project_snapshot_returns_correct_dto_fields(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        label = "stable"
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=2,
+            created_by_user_id=sample_project.user_id,
+            label=label,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            version_number=2,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert result.version_number == 2
+        assert result.label == label
+        assert result.created_by_user_id == sample_project.user_id

--- a/server/tests/unit/application/use_cases/project_snapshot/test_get_project_snapshot.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_get_project_snapshot.py
@@ -6,11 +6,16 @@ import pytest
 from raggae.application.use_cases.project_snapshot.get_project_snapshot import (
     GetProjectSnapshot,
 )
+from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project
 from raggae.domain.entities.project_snapshot import ProjectSnapshot
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+from raggae.infrastructure.database.repositories.in_memory_organization_member_repository import (
+    InMemoryOrganizationMemberRepository,
+)
 from raggae.infrastructure.database.repositories.in_memory_project_repository import (
     InMemoryProjectRepository,
 )
@@ -29,14 +34,20 @@ class TestGetProjectSnapshot:
         return InMemoryProjectSnapshotRepository()
 
     @pytest.fixture
+    def org_member_repository(self) -> InMemoryOrganizationMemberRepository:
+        return InMemoryOrganizationMemberRepository()
+
+    @pytest.fixture
     def use_case(
         self,
         project_repository: InMemoryProjectRepository,
         snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
     ) -> GetProjectSnapshot:
         return GetProjectSnapshot(
             project_repository=project_repository,
             snapshot_repository=snapshot_repository,
+            organization_member_repository=org_member_repository,
         )
 
     @pytest.fixture
@@ -167,3 +178,205 @@ class TestGetProjectSnapshot:
         assert result.version_number == 2
         assert result.label == label
         assert result.created_by_user_id == sample_project.user_id
+
+    async def test_get_project_snapshot_allows_org_owner(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        org_member_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(org_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=owner_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=org_member_user_id,
+            role=OrganizationMemberRole.OWNER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        result = await use_case.execute(
+            project_id=org_project.id,
+            version_number=1,
+            user_id=org_member_user_id,
+        )
+
+        # Then
+        assert result.version_number == 1
+
+    async def test_get_project_snapshot_allows_org_maker(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        maker_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(org_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=owner_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=maker_user_id,
+            role=OrganizationMemberRole.MAKER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        result = await use_case.execute(
+            project_id=org_project.id,
+            version_number=1,
+            user_id=maker_user_id,
+        )
+
+        # Then
+        assert result.version_number == 1
+
+    async def test_get_project_snapshot_allows_org_user_for_published_project(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        regular_user_id = uuid4()
+
+        published_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Published Project",
+            description="A published project",
+            system_prompt="You are helpful.",
+            is_published=True,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(published_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=published_project,
+            version_number=1,
+            created_by_user_id=owner_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=regular_user_id,
+            role=OrganizationMemberRole.USER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        result = await use_case.execute(
+            project_id=published_project.id,
+            version_number=1,
+            user_id=regular_user_id,
+        )
+
+        # Then
+        assert result.version_number == 1
+
+    async def test_get_project_snapshot_raises_for_org_user_on_unpublished_project(
+        self,
+        use_case: GetProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        regular_user_id = uuid4()
+
+        unpublished_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Unpublished Project",
+            description="An unpublished project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(unpublished_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=unpublished_project,
+            version_number=1,
+            created_by_user_id=owner_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=regular_user_id,
+            role=OrganizationMemberRole.USER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=unpublished_project.id,
+                version_number=1,
+                user_id=regular_user_id,
+            )

--- a/server/tests/unit/application/use_cases/project_snapshot/test_list_project_snapshots.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_list_project_snapshots.py
@@ -1,0 +1,185 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_snapshot.list_project_snapshots import (
+    ListProjectSnapshots,
+)
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.infrastructure.database.repositories.in_memory_project_repository import (
+    InMemoryProjectRepository,
+)
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
+
+
+class TestListProjectSnapshots:
+    @pytest.fixture
+    def project_repository(self) -> InMemoryProjectRepository:
+        return InMemoryProjectRepository()
+
+    @pytest.fixture
+    def snapshot_repository(self) -> InMemoryProjectSnapshotRepository:
+        return InMemoryProjectSnapshotRepository()
+
+    @pytest.fixture
+    def use_case(
+        self,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+    ) -> ListProjectSnapshots:
+        return ListProjectSnapshots(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+    @pytest.fixture
+    def sample_project(self) -> Project:
+        return Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="My Project",
+            description="A project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+
+    async def test_list_project_snapshots_returns_empty_when_no_snapshots(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert result == []
+
+    async def test_list_project_snapshots_returns_all_snapshots(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        for version_number in range(1, 4):
+            snapshot = ProjectSnapshot.from_project(
+                project=sample_project,
+                version_number=version_number,
+                created_by_user_id=sample_project.user_id,
+            )
+            await snapshot_repository.save(snapshot)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert len(result) == 3
+
+    async def test_list_project_snapshots_raises_when_project_not_found(
+        self,
+        use_case: ListProjectSnapshots,
+    ) -> None:
+        # Given
+        non_existent_project_id = uuid4()
+        user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=non_existent_project_id,
+                user_id=user_id,
+            )
+
+    async def test_list_project_snapshots_raises_for_unauthorized_user(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        another_user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=sample_project.id,
+                user_id=another_user_id,
+            )
+
+    async def test_list_project_snapshots_supports_pagination(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        for version_number in range(1, 6):
+            snapshot = ProjectSnapshot.from_project(
+                project=sample_project,
+                version_number=version_number,
+                created_by_user_id=sample_project.user_id,
+            )
+            await snapshot_repository.save(snapshot)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            user_id=sample_project.user_id,
+            limit=2,
+            offset=0,
+        )
+
+        # Then
+        assert len(result) == 2
+
+    async def test_list_project_snapshots_returns_dtos(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When
+        result = await use_case.execute(
+            project_id=sample_project.id,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert len(result) == 1
+        dto = result[0]
+        assert dto.project_id == sample_project.id
+        assert dto.version_number == 1
+        assert dto.name == sample_project.name

--- a/server/tests/unit/application/use_cases/project_snapshot/test_list_project_snapshots.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_list_project_snapshots.py
@@ -6,10 +6,15 @@ import pytest
 from raggae.application.use_cases.project_snapshot.list_project_snapshots import (
     ListProjectSnapshots,
 )
+from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project
 from raggae.domain.entities.project_snapshot import ProjectSnapshot
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+from raggae.infrastructure.database.repositories.in_memory_organization_member_repository import (
+    InMemoryOrganizationMemberRepository,
+)
 from raggae.infrastructure.database.repositories.in_memory_project_repository import (
     InMemoryProjectRepository,
 )
@@ -28,14 +33,20 @@ class TestListProjectSnapshots:
         return InMemoryProjectSnapshotRepository()
 
     @pytest.fixture
+    def org_member_repository(self) -> InMemoryOrganizationMemberRepository:
+        return InMemoryOrganizationMemberRepository()
+
+    @pytest.fixture
     def use_case(
         self,
         project_repository: InMemoryProjectRepository,
         snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
     ) -> ListProjectSnapshots:
         return ListProjectSnapshots(
             project_repository=project_repository,
             snapshot_repository=snapshot_repository,
+            organization_member_repository=org_member_repository,
         )
 
     @pytest.fixture
@@ -61,13 +72,14 @@ class TestListProjectSnapshots:
         await project_repository.save(sample_project)
 
         # When
-        result = await use_case.execute(
+        snapshots, total = await use_case.execute(
             project_id=sample_project.id,
             user_id=sample_project.user_id,
         )
 
         # Then
-        assert result == []
+        assert snapshots == []
+        assert total == 0
 
     async def test_list_project_snapshots_returns_all_snapshots(
         self,
@@ -87,13 +99,14 @@ class TestListProjectSnapshots:
             await snapshot_repository.save(snapshot)
 
         # When
-        result = await use_case.execute(
+        snapshots, total = await use_case.execute(
             project_id=sample_project.id,
             user_id=sample_project.user_id,
         )
 
         # Then
-        assert len(result) == 3
+        assert len(snapshots) == 3
+        assert total == 3
 
     async def test_list_project_snapshots_raises_when_project_not_found(
         self,
@@ -145,15 +158,16 @@ class TestListProjectSnapshots:
             await snapshot_repository.save(snapshot)
 
         # When
-        result = await use_case.execute(
+        snapshots, total = await use_case.execute(
             project_id=sample_project.id,
             user_id=sample_project.user_id,
             limit=2,
             offset=0,
         )
 
-        # Then
-        assert len(result) == 2
+        # Then — page has 2 items, total is 5
+        assert len(snapshots) == 2
+        assert total == 5
 
     async def test_list_project_snapshots_returns_dtos(
         self,
@@ -172,14 +186,192 @@ class TestListProjectSnapshots:
         await snapshot_repository.save(snapshot)
 
         # When
-        result = await use_case.execute(
+        snapshots, total = await use_case.execute(
             project_id=sample_project.id,
             user_id=sample_project.user_id,
         )
 
         # Then
-        assert len(result) == 1
-        dto = result[0]
+        assert len(snapshots) == 1
+        assert total == 1
+        dto = snapshots[0]
         assert dto.project_id == sample_project.id
         assert dto.version_number == 1
         assert dto.name == sample_project.name
+
+    async def test_list_project_snapshots_allows_org_owner(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        org_member_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(org_project)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=org_member_user_id,
+            role=OrganizationMemberRole.OWNER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=owner_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When
+        snapshots, total = await use_case.execute(
+            project_id=org_project.id,
+            user_id=org_member_user_id,
+        )
+
+        # Then
+        assert len(snapshots) == 1
+        assert total == 1
+
+    async def test_list_project_snapshots_allows_org_maker(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        maker_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(org_project)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=maker_user_id,
+            role=OrganizationMemberRole.MAKER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        snapshots, total = await use_case.execute(
+            project_id=org_project.id,
+            user_id=maker_user_id,
+        )
+
+        # Then — empty list, but no exception
+        assert snapshots == []
+        assert total == 0
+
+    async def test_list_project_snapshots_allows_org_user_for_published_project(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        regular_user_id = uuid4()
+
+        published_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Published Project",
+            description="A published project",
+            system_prompt="You are helpful.",
+            is_published=True,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(published_project)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=regular_user_id,
+            role=OrganizationMemberRole.USER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        snapshots, total = await use_case.execute(
+            project_id=published_project.id,
+            user_id=regular_user_id,
+        )
+
+        # Then
+        assert snapshots == []
+        assert total == 0
+
+    async def test_list_project_snapshots_raises_for_org_user_on_unpublished_project(
+        self,
+        use_case: ListProjectSnapshots,
+        project_repository: InMemoryProjectRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        owner_user_id = uuid4()
+        regular_user_id = uuid4()
+
+        unpublished_project = Project(
+            id=uuid4(),
+            user_id=owner_user_id,
+            organization_id=organization_id,
+            name="Unpublished Project",
+            description="An unpublished project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+        )
+        await project_repository.save(unpublished_project)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=regular_user_id,
+            role=OrganizationMemberRole.USER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=unpublished_project.id,
+                user_id=regular_user_id,
+            )

--- a/server/tests/unit/application/use_cases/project_snapshot/test_restore_project_snapshot.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_restore_project_snapshot.py
@@ -1,0 +1,243 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_snapshot.restore_project_snapshot import (
+    RestoreProjectSnapshot,
+)
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.infrastructure.database.repositories.in_memory_project_repository import (
+    InMemoryProjectRepository,
+)
+from raggae.infrastructure.database.repositories.in_memory_project_snapshot_repository import (
+    InMemoryProjectSnapshotRepository,
+)
+
+
+class TestRestoreProjectSnapshot:
+    @pytest.fixture
+    def project_repository(self) -> InMemoryProjectRepository:
+        return InMemoryProjectRepository()
+
+    @pytest.fixture
+    def snapshot_repository(self) -> InMemoryProjectSnapshotRepository:
+        return InMemoryProjectSnapshotRepository()
+
+    @pytest.fixture
+    def use_case(
+        self,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+    ) -> RestoreProjectSnapshot:
+        return RestoreProjectSnapshot(
+            project_repository=project_repository,
+            snapshot_repository=snapshot_repository,
+        )
+
+    @pytest.fixture
+    def sample_project(self) -> Project:
+        return Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="My Project",
+            description="A project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_candidate_multiplier=3,
+        )
+
+    async def test_restore_project_snapshot_applies_snapshot_fields_to_project(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given — a snapshot with different values
+        original_name = "Original name"
+        original_system_prompt = "Original prompt"
+        snapshot = ProjectSnapshot.from_project(
+            project=Project(
+                id=sample_project.id,
+                user_id=sample_project.user_id,
+                name=original_name,
+                description="Original description",
+                system_prompt=original_system_prompt,
+                is_published=False,
+                created_at=datetime.now(UTC),
+                chunking_strategy=ChunkingStrategy.AUTO,
+                retrieval_strategy="hybrid",
+                retrieval_top_k=8,
+                retrieval_min_score=0.3,
+                chat_history_window_size=8,
+                chat_history_max_chars=4000,
+                reranking_enabled=False,
+                reranker_candidate_multiplier=3,
+            ),
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # Update the project so it differs from the snapshot
+        updated_project = Project(
+            id=sample_project.id,
+            user_id=sample_project.user_id,
+            name="Updated name",
+            description="Updated description",
+            system_prompt="Updated prompt",
+            is_published=False,
+            created_at=sample_project.created_at,
+            chunking_strategy=ChunkingStrategy.AUTO,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_candidate_multiplier=3,
+        )
+        await project_repository.save(updated_project)
+
+        # When
+        result_dto = await use_case.execute(
+            project_id=sample_project.id,
+            version_number=1,
+            user_id=sample_project.user_id,
+        )
+
+        # Then — result reflects restored snapshot values
+        assert result_dto.name == original_name
+        assert result_dto.system_prompt == original_system_prompt
+
+    async def test_restore_project_snapshot_creates_new_snapshot_with_restored_from_version(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+        await project_repository.save(sample_project)
+
+        # When
+        await use_case.execute(
+            project_id=sample_project.id,
+            version_number=1,
+            user_id=sample_project.user_id,
+        )
+
+        # Then — a new snapshot is created with restored_from_version set
+        count = await snapshot_repository.count_by_project_id(sample_project.id)
+        assert count == 2  # original + the restored one
+
+        new_snapshot = await snapshot_repository.find_by_project_and_version(
+            project_id=sample_project.id,
+            version_number=2,
+        )
+        assert new_snapshot is not None
+        assert new_snapshot.restored_from_version == 1
+
+    async def test_restore_project_snapshot_raises_when_project_not_found(
+        self,
+        use_case: RestoreProjectSnapshot,
+    ) -> None:
+        # Given
+        non_existent_project_id = uuid4()
+        user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=non_existent_project_id,
+                version_number=1,
+                user_id=user_id,
+            )
+
+    async def test_restore_project_snapshot_raises_for_unauthorized_user(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        another_user_id = uuid4()
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=sample_project.id,
+                version_number=1,
+                user_id=another_user_id,
+            )
+
+    async def test_restore_project_snapshot_raises_when_version_not_found(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        await project_repository.save(sample_project)
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        # When / Then
+        with pytest.raises(ProjectSnapshotNotFoundError):
+            await use_case.execute(
+                project_id=sample_project.id,
+                version_number=99,
+                user_id=sample_project.user_id,
+            )
+
+    async def test_restore_project_snapshot_returns_project_dto(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        await snapshot_repository.save(snapshot)
+        await project_repository.save(sample_project)
+
+        # When
+        result_dto = await use_case.execute(
+            project_id=sample_project.id,
+            version_number=1,
+            user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert result_dto.id == sample_project.id
+        assert result_dto.name == sample_project.name

--- a/server/tests/unit/application/use_cases/project_snapshot/test_restore_project_snapshot.py
+++ b/server/tests/unit/application/use_cases/project_snapshot/test_restore_project_snapshot.py
@@ -6,11 +6,16 @@ import pytest
 from raggae.application.use_cases.project_snapshot.restore_project_snapshot import (
     RestoreProjectSnapshot,
 )
+from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.entities.project import Project
 from raggae.domain.entities.project_snapshot import ProjectSnapshot
 from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
 from raggae.domain.exceptions.project_snapshot_exceptions import ProjectSnapshotNotFoundError
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+from raggae.infrastructure.database.repositories.in_memory_organization_member_repository import (
+    InMemoryOrganizationMemberRepository,
+)
 from raggae.infrastructure.database.repositories.in_memory_project_repository import (
     InMemoryProjectRepository,
 )
@@ -29,14 +34,20 @@ class TestRestoreProjectSnapshot:
         return InMemoryProjectSnapshotRepository()
 
     @pytest.fixture
+    def org_member_repository(self) -> InMemoryOrganizationMemberRepository:
+        return InMemoryOrganizationMemberRepository()
+
+    @pytest.fixture
     def use_case(
         self,
         project_repository: InMemoryProjectRepository,
         snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
     ) -> RestoreProjectSnapshot:
         return RestoreProjectSnapshot(
             project_repository=project_repository,
             snapshot_repository=snapshot_repository,
+            organization_member_repository=org_member_repository,
         )
 
     @pytest.fixture
@@ -241,3 +252,175 @@ class TestRestoreProjectSnapshot:
         # Then
         assert result_dto.id == sample_project.id
         assert result_dto.name == sample_project.name
+
+    async def test_restore_project_snapshot_allows_org_owner(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        creator_user_id = uuid4()
+        org_owner_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=creator_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_candidate_multiplier=3,
+        )
+        await project_repository.save(org_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=creator_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=org_owner_user_id,
+            role=OrganizationMemberRole.OWNER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        result_dto = await use_case.execute(
+            project_id=org_project.id,
+            version_number=1,
+            user_id=org_owner_user_id,
+        )
+
+        # Then
+        assert result_dto.id == org_project.id
+
+    async def test_restore_project_snapshot_allows_org_maker(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given
+        organization_id = uuid4()
+        creator_user_id = uuid4()
+        maker_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=creator_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_candidate_multiplier=3,
+        )
+        await project_repository.save(org_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=creator_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=maker_user_id,
+            role=OrganizationMemberRole.MAKER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When
+        result_dto = await use_case.execute(
+            project_id=org_project.id,
+            version_number=1,
+            user_id=maker_user_id,
+        )
+
+        # Then
+        assert result_dto.id == org_project.id
+
+    async def test_restore_project_snapshot_raises_for_org_user(
+        self,
+        use_case: RestoreProjectSnapshot,
+        project_repository: InMemoryProjectRepository,
+        snapshot_repository: InMemoryProjectSnapshotRepository,
+        org_member_repository: InMemoryOrganizationMemberRepository,
+    ) -> None:
+        # Given — org USER role cannot restore (read-only)
+        organization_id = uuid4()
+        creator_user_id = uuid4()
+        regular_user_id = uuid4()
+
+        org_project = Project(
+            id=uuid4(),
+            user_id=creator_user_id,
+            organization_id=organization_id,
+            name="Org Project",
+            description="An org project",
+            system_prompt="You are helpful.",
+            is_published=True,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_candidate_multiplier=3,
+        )
+        await project_repository.save(org_project)
+
+        snapshot = ProjectSnapshot.from_project(
+            project=org_project,
+            version_number=1,
+            created_by_user_id=creator_user_id,
+        )
+        await snapshot_repository.save(snapshot)
+
+        member = OrganizationMember(
+            id=uuid4(),
+            organization_id=organization_id,
+            user_id=regular_user_id,
+            role=OrganizationMemberRole.USER,
+            joined_at=datetime.now(UTC),
+        )
+        await org_member_repository.save(member)
+
+        # When / Then — USER cannot restore even on published project
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(
+                project_id=org_project.id,
+                version_number=1,
+                user_id=regular_user_id,
+            )

--- a/server/tests/unit/domain/entities/test_project_snapshot.py
+++ b/server/tests/unit/domain/entities/test_project_snapshot.py
@@ -1,0 +1,250 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_snapshot import ProjectSnapshot
+from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
+
+
+class TestProjectSnapshot:
+    @pytest.fixture
+    def sample_project(self) -> Project:
+        return Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            name="Test Project",
+            description="A test project",
+            system_prompt="You are a helpful assistant.",
+            is_published=False,
+            created_at=datetime.now(UTC),
+            chunking_strategy=ChunkingStrategy.AUTO,
+            parent_child_chunking=False,
+            reindex_status="idle",
+            reindex_progress=0,
+            reindex_total=0,
+            embedding_backend="openai",
+            embedding_model="text-embedding-3-small",
+            embedding_api_key_encrypted="enc:super-secret",
+            embedding_api_key_credential_id=uuid4(),
+            org_embedding_api_key_credential_id=None,
+            llm_backend="openai",
+            llm_model="gpt-4.1",
+            llm_api_key_encrypted="enc:other-secret",
+            llm_api_key_credential_id=uuid4(),
+            org_llm_api_key_credential_id=None,
+            retrieval_strategy="hybrid",
+            retrieval_top_k=8,
+            retrieval_min_score=0.3,
+            chat_history_window_size=8,
+            chat_history_max_chars=4000,
+            reranking_enabled=False,
+            reranker_backend=None,
+            reranker_model=None,
+            reranker_candidate_multiplier=3,
+            organization_id=None,
+        )
+
+    def test_from_project_creates_snapshot_with_correct_fields(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        version_number = 1
+        created_by_user_id = sample_project.user_id
+
+        # When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=version_number,
+            created_by_user_id=created_by_user_id,
+        )
+
+        # Then
+        assert snapshot.project_id == sample_project.id
+        assert snapshot.version_number == version_number
+        assert snapshot.created_by_user_id == created_by_user_id
+        assert snapshot.label is None
+        assert snapshot.restored_from_version is None
+
+    def test_from_project_snapshots_project_fields_correctly(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given / When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then — configuration fields are preserved
+        assert snapshot.name == sample_project.name
+        assert snapshot.description == sample_project.description
+        assert snapshot.system_prompt == sample_project.system_prompt
+        assert snapshot.is_published == sample_project.is_published
+        assert snapshot.chunking_strategy == sample_project.chunking_strategy
+        assert snapshot.parent_child_chunking == sample_project.parent_child_chunking
+        assert snapshot.embedding_backend == sample_project.embedding_backend
+        assert snapshot.embedding_model == sample_project.embedding_model
+        assert snapshot.embedding_api_key_credential_id == sample_project.embedding_api_key_credential_id
+        assert (
+            snapshot.org_embedding_api_key_credential_id == sample_project.org_embedding_api_key_credential_id
+        )
+        assert snapshot.llm_backend == sample_project.llm_backend
+        assert snapshot.llm_model == sample_project.llm_model
+        assert snapshot.llm_api_key_credential_id == sample_project.llm_api_key_credential_id
+        assert snapshot.org_llm_api_key_credential_id == sample_project.org_llm_api_key_credential_id
+        assert snapshot.retrieval_strategy == sample_project.retrieval_strategy
+        assert snapshot.retrieval_top_k == sample_project.retrieval_top_k
+        assert snapshot.retrieval_min_score == sample_project.retrieval_min_score
+        assert snapshot.chat_history_window_size == sample_project.chat_history_window_size
+        assert snapshot.chat_history_max_chars == sample_project.chat_history_max_chars
+        assert snapshot.reranking_enabled == sample_project.reranking_enabled
+        assert snapshot.reranker_backend == sample_project.reranker_backend
+        assert snapshot.reranker_model == sample_project.reranker_model
+        assert snapshot.reranker_candidate_multiplier == sample_project.reranker_candidate_multiplier
+
+    def test_from_project_does_not_include_encrypted_api_keys(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given / When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then — encrypted API keys are NOT part of the snapshot
+        assert not hasattr(snapshot, "embedding_api_key_encrypted")
+        assert not hasattr(snapshot, "llm_api_key_encrypted")
+
+    def test_from_project_does_not_include_transient_reindex_fields(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given / When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then — transient reindex fields are NOT part of the snapshot
+        assert not hasattr(snapshot, "reindex_status")
+        assert not hasattr(snapshot, "reindex_progress")
+        assert not hasattr(snapshot, "reindex_total")
+
+    def test_from_project_with_label(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        label = "v1.0-stable"
+
+        # When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+            label=label,
+        )
+
+        # Then
+        assert snapshot.label == label
+
+    def test_from_project_with_restored_from_version(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        restored_from = 3
+
+        # When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=4,
+            created_by_user_id=sample_project.user_id,
+            restored_from_version=restored_from,
+        )
+
+        # Then
+        assert snapshot.restored_from_version == restored_from
+
+    def test_snapshot_is_immutable(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then
+        with pytest.raises(AttributeError):
+            snapshot.version_number = 99  # type: ignore[misc]
+
+    def test_snapshot_has_unique_id(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given / When
+        snapshot1 = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+        snapshot2 = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=2,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then
+        assert snapshot1.id != snapshot2.id
+
+    def test_from_project_includes_organization_id(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = Project(
+            id=uuid4(),
+            user_id=uuid4(),
+            organization_id=org_id,
+            name="Org Project",
+            description="",
+            system_prompt="",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+
+        # When
+        snapshot = ProjectSnapshot.from_project(
+            project=project,
+            version_number=1,
+            created_by_user_id=project.user_id,
+        )
+
+        # Then
+        assert snapshot.organization_id == org_id
+
+    def test_from_project_snapshot_has_created_at(
+        self,
+        sample_project: Project,
+    ) -> None:
+        # Given
+        before = datetime.now(UTC)
+
+        # When
+        snapshot = ProjectSnapshot.from_project(
+            project=sample_project,
+            version_number=1,
+            created_by_user_id=sample_project.user_id,
+        )
+
+        # Then
+        after = datetime.now(UTC)
+        assert before <= snapshot.created_at <= after


### PR DESCRIPTION
## Résumé

Implémentation du versioning des configurations de projet via l'entité `ProjectSnapshot`.

- Chaque mise à jour d'un projet crée automatiquement un snapshot versionné (numéro séquentiel par projet)
- L'historique des versions est consultable et paginé
- La restauration d'une ancienne version crée une nouvelle version (historique immuable)
- Les clés API chiffrées et les champs d'état transitoire (reindex) sont exclus des snapshots

## Commits (11 atomiques — TDD + Clean Architecture)

- `test(domain)` + `feat(domain)` — entité `ProjectSnapshot` avec factory `from_project()`
- `feat(application)` — interface `ProjectSnapshotRepository` + fake en mémoire
- `test(application)` + `feat(application)` — UC `CreateProjectSnapshot`
- `test(application)` + `feat(application)` — `UpdateProject` crée un snapshot automatiquement
- `test(application)` + `feat(application)` — UC `ListProjectSnapshots`, `GetProjectSnapshot`, `RestoreProjectSnapshot`, DTO
- `feat(infra)` — modèle SQLAlchemy, migration Alembic, repository PostgreSQL
- `feat(presentation)` — 3 endpoints REST, schémas Pydantic, DI

## Endpoints ajoutés

```
GET  /projects/{id}/snapshots                        → historique paginé
GET  /projects/{id}/snapshots/{version_number}       → détail d'une version
POST /projects/{id}/snapshots/{version_number}/restore → rollback (crée v+1)
```

## Checklist qualité

- [x] 731 tests passent (0 échec)
- [x] `ruff format` propre
- [x] `ruff check` propre
- [x] `mypy` propre
- [x] Migration Alembic incluse (`20260321_39_add_project_snapshots`)