### PR TITLE
style(ui): refondre les couleurs de thème et la typographie

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-jakarta-sans);
+  --font-sans: var(--font-primary);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -124,8 +124,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    font-size: 112.5%;
+  }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-jakarta-sans), sans-serif;
+    font-family: var(--font-primary), sans-serif;
   }
 }

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-jakarta-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -49,7 +49,9 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: oklch(0.9786 0.0026 107.2);
+  --bg-300: 38 10% 90%;
+  --message-input-bg: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -83,7 +85,9 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.2389 0.0019 106.8);
+  --bg-300: 240 3% 20%;
+  --message-input-bg: oklch(0.2924 0.0035 106.8);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
@@ -119,10 +123,9 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;
-    @apply bg-background text-foreground;
+    font-family: var(--font-jakarta-sans), sans-serif;
   }
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
+import { Alegreya_Sans, Geist_Mono } from "next/font/google";
 import { getLocale, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { Toaster } from "@/components/ui/sonner";
@@ -8,10 +8,11 @@ import { QueryProvider } from "@/lib/providers/query-provider";
 import { ThemeProvider } from "@/lib/providers/theme-provider";
 import "./globals.css";
 
-const plusJakartaSans = Plus_Jakarta_Sans({
-  variable: "--font-jakarta-sans",
+const alegreyaSans = Alegreya_Sans({
+  variable: "--font-primary",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["400", "500", "700"],
+  style: ["normal", "italic"],
   display: "swap",
 });
 
@@ -36,9 +37,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body
-        className={`${plusJakartaSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${alegreyaSans.variable} ${geistMono.variable} antialiased`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionProvider>
             <QueryProvider>

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
 import { getLocale, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { Toaster } from "@/components/ui/sonner";
@@ -8,14 +8,17 @@ import { QueryProvider } from "@/lib/providers/query-provider";
 import { ThemeProvider } from "@/lib/providers/theme-provider";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plusJakartaSans = Plus_Jakarta_Sans({
+  variable: "--font-jakarta-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -34,7 +37,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${plusJakartaSans.variable} ${geistMono.variable} antialiased`}
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionProvider>

--- a/client/src/components/chat/chat-panel.tsx
+++ b/client/src/components/chat/chat-panel.tsx
@@ -238,7 +238,8 @@ export function ChatPanel({
             <Button
               variant="outline"
               size="icon"
-              className="h-9 w-9 rounded-full border border-border bg-background shadow-sm hover:bg-muted"
+              className="h-9 w-9 rounded-full border border-border shadow-sm hover:bg-muted"
+              style={{ backgroundColor: "var(--message-input-bg)" }}
               onClick={scrollToBottom}
               aria-label={t("scrollToBottom")}
             >

--- a/client/src/components/chat/message-bubble.tsx
+++ b/client/src/components/chat/message-bubble.tsx
@@ -52,7 +52,7 @@ export function MessageBubble({
           style={isUser ? { backgroundColor: "hsl(var(--bg-300) / var(--tw-bg-opacity, 1))" } : undefined}
         >
         {isUser ? (
-          <p className="whitespace-pre-wrap text-sm">{content}</p>
+          <p className="whitespace-pre-wrap text-base">{content}</p>
         ) : (
           renderMarkdown(content)
         )}

--- a/client/src/components/chat/message-bubble.tsx
+++ b/client/src/components/chat/message-bubble.tsx
@@ -46,9 +46,10 @@ export function MessageBubble({
           className={cn(
             "rounded-lg px-4 py-2",
             isUser
-              ? "bg-primary text-primary-foreground"
-              : "bg-muted text-foreground",
+              ? "text-foreground"
+              : "bg-transparent text-foreground",
           )}
+          style={isUser ? { backgroundColor: "hsl(var(--bg-300) / var(--tw-bg-opacity, 1))" } : undefined}
         >
         {isUser ? (
           <p className="whitespace-pre-wrap text-sm">{content}</p>
@@ -74,7 +75,7 @@ export function MessageBubble({
             className={cn(
               "mt-1 text-xs",
               isUser
-                ? "text-primary-foreground/70"
+                ? "text-foreground/50"
                 : "text-muted-foreground",
             )}
           >

--- a/client/src/components/chat/message-input.tsx
+++ b/client/src/components/chat/message-input.tsx
@@ -52,12 +52,13 @@ export function MessageInput({
     <div className="space-y-2">
       <div
         className={cn(
-          "rounded-2xl border border-border bg-background",
+          "rounded-2xl border border-border",
           "transition-[border-color] duration-500",
           "hover:border-foreground/15",
           "focus-within:border-foreground/25",
           "px-4 pt-3",
         )}
+        style={{ backgroundColor: "var(--message-input-bg)" }}
       >
         <textarea
           ref={textareaRef}

--- a/client/src/lib/markdown/render-markdown.tsx
+++ b/client/src/lib/markdown/render-markdown.tsx
@@ -77,37 +77,37 @@ export function renderMarkdown(markdown: string): ReactNode {
       const content = parseInline(heading[2]);
       if (level === 1) {
         blocks.push(
-          <h1 key={`h-${i}`} className="font-semibold">
+          <h1 key={`h-${i}`} className="mt-6 text-base font-bold">
             {content}
           </h1>,
         );
       } else if (level === 2) {
         blocks.push(
-          <h2 key={`h-${i}`} className="font-semibold">
+          <h2 key={`h-${i}`} className="mt-6 text-base font-bold">
             {content}
           </h2>,
         );
       } else if (level === 3) {
         blocks.push(
-          <h3 key={`h-${i}`} className="font-semibold">
+          <h3 key={`h-${i}`} className="mt-7 text-xl font-semibold">
             {content}
           </h3>,
         );
       } else if (level === 4) {
         blocks.push(
-          <h4 key={`h-${i}`} className="font-semibold">
+          <h4 key={`h-${i}`} className="mt-4 text-base font-semibold">
             {content}
           </h4>,
         );
       } else if (level === 5) {
         blocks.push(
-          <h5 key={`h-${i}`} className="font-semibold">
+          <h5 key={`h-${i}`} className="mt-3 text-base font-semibold">
             {content}
           </h5>,
         );
       } else {
         blocks.push(
-          <h6 key={`h-${i}`} className="font-semibold">
+          <h6 key={`h-${i}`} className="mt-3 text-base font-semibold">
             {content}
           </h6>,
         );
@@ -156,5 +156,5 @@ export function renderMarkdown(markdown: string): ReactNode {
     i += 1;
   }
 
-  return <div className="space-y-2 text-sm">{blocks}</div>;
+  return <div className="space-y-3 leading-normal text-base">{blocks}</div>;
 }

--- a/client/tests/components/chat/message-input.test.tsx
+++ b/client/tests/components/chat/message-input.test.tsx
@@ -77,8 +77,7 @@ describe("MessageInput", () => {
       <MessageInput onSend={vi.fn()} disabled isThinking />,
     );
 
-    expect(
-      screen.getByRole("button", { name: /send/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Problème

L'interface manquait d'une identité visuelle cohérente : couleurs de fond génériques, police par défaut, rendu markdown peu lisible.

## Solution

Refonte des couleurs de thème clair/sombre, remplacement de la police par Alegreya Sans, et amélioration de la hiérarchie typographique dans le rendu markdown.

## Implémentation

**Couleurs de thème (`globals.css`)**
- Fond clair : `#f8f8f6` (oklch), fond sombre : `#1f1f1e` (oklch)
- Variable `--bg-300` pour les bulles utilisateur (thème clair/sombre)
- Variable `--message-input-bg` pour le fond du message input et du bouton scroll-to-bottom
- Taille de base : `font-size: 112.5%` sur `html` (accessibilité)

**Composants chat**
- `message-bubble` : bulles utilisateur via `--bg-300`, bulles assistant transparentes
- `message-input` : fond opaque adapté au thème
- `chat-panel` : bouton scroll-to-bottom avec fond opaque

**Typographie (`layout.tsx`)**
- Police : Alegreya Sans (400/500/700, normal + italic, `display: swap`)
- Variable CSS renommée `--font-primary` (sémantique)
- Italiques chargées pour un rendu correct des `<em>` markdown

**Rendu markdown (`render-markdown.tsx`)**
- Taille des messages : `text-base` (16px relatif)
- h3 : `text-xl`, h4–h6 : `text-base`
- Espacements différenciés selon le niveau de titre (`mt-4` à `mt-7`)
- Interligne : `leading-normal`

**Tests**
- Correction du test `message-input` : vérification du bouton "Stop" (et non "Send") quand `isThinking=true`

## Recette

1. Lancer `npm run dev` dans `client/`
2. Vérifier le rendu en thème clair et sombre
3. Envoyer un message avec du markdown (titres, listes, italiques) et vérifier la hiérarchie visuelle
4. Vérifier que le bouton scroll-to-bottom a un fond opaque lors du défilement
5. Vérifier que le message input a le bon fond selon le thème