### PR TITLE
style(ui): refondre le thème visuel, la typographie et le menu utilisateur

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -511,7 +511,8 @@
     "chat": "Chat",
     "settings": "Settings",
     "snapshots": "History",
-    "githubProject": "GitHub project"
+    "githubProject": "GitHub project",
+    "sourceCode": "Source code"
   },
   "layout": {
     "themeToggle": {

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -511,7 +511,8 @@
     "chat": "Chat",
     "settings": "Paramètres",
     "snapshots": "Historique",
-    "githubProject": "Projet GitHub"
+    "githubProject": "Projet GitHub",
+    "sourceCode": "Code source"
   },
   "layout": {
     "themeToggle": {

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-jakarta-sans);
+  --font-sans: var(--font-primary);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -124,8 +124,11 @@
   * {
     @apply border-border outline-ring/50;
   }
+  html {
+    font-size: 112.5%;
+  }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-jakarta-sans), sans-serif;
+    font-family: var(--font-primary), sans-serif;
   }
 }

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -7,7 +7,7 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
+  --font-sans: var(--font-jakarta-sans);
   --font-mono: var(--font-geist-mono);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
@@ -49,7 +49,9 @@
 
 :root {
   --radius: 0.625rem;
-  --background: oklch(1 0 0);
+  --background: oklch(0.9786 0.0026 107.2);
+  --bg-300: 38 10% 90%;
+  --message-input-bg: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
@@ -83,7 +85,9 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.2389 0.0019 106.8);
+  --bg-300: 240 3% 20%;
+  --message-input-bg: oklch(0.2924 0.0035 106.8);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
@@ -119,10 +123,9 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
-    @apply border-border outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;
-    @apply bg-background text-foreground;
+    font-family: var(--font-jakarta-sans), sans-serif;
   }
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
+import { Alegreya_Sans, Geist_Mono } from "next/font/google";
 import { getLocale, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { Toaster } from "@/components/ui/sonner";
@@ -8,10 +8,11 @@ import { QueryProvider } from "@/lib/providers/query-provider";
 import { ThemeProvider } from "@/lib/providers/theme-provider";
 import "./globals.css";
 
-const plusJakartaSans = Plus_Jakarta_Sans({
-  variable: "--font-jakarta-sans",
+const alegreyaSans = Alegreya_Sans({
+  variable: "--font-primary",
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["400", "500", "700"],
+  style: ["normal", "italic"],
   display: "swap",
 });
 
@@ -36,9 +37,7 @@ export default async function RootLayout({
 
   return (
     <html lang={locale} suppressHydrationWarning>
-      <body
-        className={`${plusJakartaSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${alegreyaSans.variable} ${geistMono.variable} antialiased`}>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionProvider>
             <QueryProvider>

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Geist_Mono } from "next/font/google";
 import { getLocale, getMessages } from "next-intl/server";
 import { NextIntlClientProvider } from "next-intl";
 import { Toaster } from "@/components/ui/sonner";
@@ -8,14 +8,17 @@ import { QueryProvider } from "@/lib/providers/query-provider";
 import { ThemeProvider } from "@/lib/providers/theme-provider";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plusJakartaSans = Plus_Jakarta_Sans({
+  variable: "--font-jakarta-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -34,7 +37,7 @@ export default async function RootLayout({
   return (
     <html lang={locale} suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${plusJakartaSans.variable} ${geistMono.variable} antialiased`}
       >
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SessionProvider>

--- a/client/src/components/chat/chat-panel.tsx
+++ b/client/src/components/chat/chat-panel.tsx
@@ -238,7 +238,8 @@ export function ChatPanel({
             <Button
               variant="outline"
               size="icon"
-              className="h-9 w-9 rounded-full border border-border bg-background shadow-sm hover:bg-muted"
+              className="h-9 w-9 rounded-full border border-border shadow-sm hover:bg-muted"
+              style={{ backgroundColor: "var(--message-input-bg)" }}
               onClick={scrollToBottom}
               aria-label={t("scrollToBottom")}
             >

--- a/client/src/components/chat/message-bubble.tsx
+++ b/client/src/components/chat/message-bubble.tsx
@@ -52,7 +52,7 @@ export function MessageBubble({
           style={isUser ? { backgroundColor: "hsl(var(--bg-300) / var(--tw-bg-opacity, 1))" } : undefined}
         >
         {isUser ? (
-          <p className="whitespace-pre-wrap text-sm">{content}</p>
+          <p className="whitespace-pre-wrap text-base">{content}</p>
         ) : (
           renderMarkdown(content)
         )}

--- a/client/src/components/chat/message-bubble.tsx
+++ b/client/src/components/chat/message-bubble.tsx
@@ -46,9 +46,10 @@ export function MessageBubble({
           className={cn(
             "rounded-lg px-4 py-2",
             isUser
-              ? "bg-primary text-primary-foreground"
-              : "bg-muted text-foreground",
+              ? "text-foreground"
+              : "bg-transparent text-foreground",
           )}
+          style={isUser ? { backgroundColor: "hsl(var(--bg-300) / var(--tw-bg-opacity, 1))" } : undefined}
         >
         {isUser ? (
           <p className="whitespace-pre-wrap text-sm">{content}</p>
@@ -74,7 +75,7 @@ export function MessageBubble({
             className={cn(
               "mt-1 text-xs",
               isUser
-                ? "text-primary-foreground/70"
+                ? "text-foreground/50"
                 : "text-muted-foreground",
             )}
           >

--- a/client/src/components/chat/message-input.tsx
+++ b/client/src/components/chat/message-input.tsx
@@ -52,12 +52,13 @@ export function MessageInput({
     <div className="space-y-2">
       <div
         className={cn(
-          "rounded-2xl border border-border bg-background",
+          "rounded-2xl border border-border",
           "transition-[border-color] duration-500",
           "hover:border-foreground/15",
           "focus-within:border-foreground/25",
           "px-4 pt-3",
         )}
+        style={{ backgroundColor: "var(--message-input-bg)" }}
       >
         <textarea
           ref={textareaRef}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -1,155 +1,25 @@
 "use client";
 
-import Link from "next/link";
-import { signOut } from "next-auth/react";
-import { useLocale, useTranslations } from "next-intl";
-import { Check, Languages, LogOut, Monitor, Moon, Settings, Sun } from "lucide-react";
-import type { Theme } from "@/lib/providers/theme-provider";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { useAuth } from "@/lib/hooks/use-auth";
-import { useTheme } from "@/lib/providers/theme-provider";
-import { useUpdateUserLocale } from "@/lib/hooks/use-user-profile";
-import type { UpdateUserLocaleRequest } from "@/lib/types/api";
 import { MobileSidebar } from "./mobile-sidebar";
 
-const LOCALES: Array<{ value: UpdateUserLocaleRequest["locale"]; label: string }> = [
-  { value: "en", label: "English" },
-  { value: "fr", label: "Français" },
-];
-
-function setLocaleCookie(locale: string) {
-  const maxAge = 60 * 60 * 24 * 365;
-  document.cookie = `raggae_locale=${locale};path=/;max-age=${maxAge};SameSite=Lax`;
-}
-
 export function Header() {
-  const { user } = useAuth();
   const t = useTranslations("header");
-  const tTheme = useTranslations("layout.themeToggle");
-  const { theme, setTheme } = useTheme();
-
-  const THEMES: Array<{ value: Theme; label: string; icon: React.ReactNode }> = [
-    { value: "light", label: tTheme("light"), icon: <Sun size={14} /> },
-    { value: "dark", label: tTheme("dark"), icon: <Moon size={14} /> },
-    { value: "system", label: tTheme("system"), icon: <Monitor size={14} /> },
-  ];
-  const currentLocale = useLocale();
-  const updateLocale = useUpdateUserLocale();
-
-  function handleThemeSelect(next: Theme) {
-    if (next !== theme) setTheme(next);
-  }
-
-  function handleLocaleSelect(locale: UpdateUserLocaleRequest["locale"]) {
-    if (locale === currentLocale) return;
-    setLocaleCookie(locale);
-    updateLocale.mutate({ locale }, { onSettled: () => window.location.reload() });
-  }
 
   return (
-    <header className="flex h-14 items-center justify-between border-b px-6">
-      <div className="flex items-center gap-4">
-        <Sheet>
-          <SheetTrigger asChild>
-            <Button variant="ghost" size="sm" className="md:hidden">
-              {t("account")}
-            </Button>
-          </SheetTrigger>
-          <SheetContent side="left" className="w-64 p-0">
-            <MobileSidebar />
-          </SheetContent>
-        </Sheet>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" className="cursor-pointer">
-              {user?.email ?? t("account")}
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-52">
-            <DropdownMenuItem disabled className="text-muted-foreground text-xs">
-              {user?.email}
-            </DropdownMenuItem>
-
-            <DropdownMenuSeparator />
-
-            <DropdownMenuItem asChild>
-              <Link href="/settings" className="flex cursor-pointer items-center gap-2">
-                <Settings size={14} />
-                {t("userSettings")}
-              </Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
-                <Languages size={14} />
-                {t("language")}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {LOCALES.map(({ value, label }) => (
-                  <DropdownMenuItem
-                    key={value}
-                    onClick={() => handleLocaleSelect(value)}
-                    className="flex cursor-pointer items-center gap-2"
-                  >
-                    <Check
-                      size={14}
-                      className={currentLocale === value ? "opacity-100" : "opacity-0"}
-                    />
-                    {label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
-                <Sun size={14} />
-                {tTheme("label")}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {THEMES.map(({ value, label, icon }) => (
-                  <DropdownMenuItem
-                    key={value}
-                    onClick={() => handleThemeSelect(value)}
-                    className="flex cursor-pointer items-center gap-2"
-                  >
-                    <Check
-                      size={14}
-                      className={theme === value ? "opacity-100" : "opacity-0"}
-                    />
-                    {icon}
-                    {label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-
-            <DropdownMenuSeparator />
-
-            <DropdownMenuItem
-              onClick={() => signOut({ callbackUrl: "/login" })}
-              className="flex cursor-pointer items-center gap-2"
-            >
-              <LogOut size={14} />
-              {t("signOut")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+    <header className="flex h-14 items-center border-b px-6 md:hidden">
+      <Sheet>
+        <SheetTrigger asChild>
+          <Button variant="ghost" size="sm">
+            {t("account")}
+          </Button>
+        </SheetTrigger>
+        <SheetContent side="left" className="w-64 p-0">
+          <MobileSidebar />
+        </SheetContent>
+      </Sheet>
     </header>
   );
 }

--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -1,28 +1,68 @@
 "use client";
 
 import Link from "next/link";
-import { Github, MoreHorizontal, Plus } from "lucide-react";
+import { signOut } from "next-auth/react";
+import { Check, Github, Languages, LogOut, Monitor, Moon, MoreHorizontal, Plus, Settings, Sun } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useQueries } from "@tanstack/react-query";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useProjects } from "@/lib/hooks/use-projects";
 import { useAuth } from "@/lib/hooks/use-auth";
 import { listOrganizationMembers, listOrganizationProjects } from "@/lib/api/organizations";
 import { useOrganizations } from "@/lib/hooks/use-organizations";
+import type { Theme } from "@/lib/providers/theme-provider";
+import { useTheme } from "@/lib/providers/theme-provider";
+import { useUpdateUserLocale } from "@/lib/hooks/use-user-profile";
+import type { UpdateUserLocaleRequest } from "@/lib/types/api";
 import { cn } from "@/lib/utils";
+
+const LOCALES: Array<{ value: UpdateUserLocaleRequest["locale"]; label: string }> = [
+  { value: "en", label: "English" },
+  { value: "fr", label: "Français" },
+];
+
+function setLocaleCookie(locale: string) {
+  const maxAge = 60 * 60 * 24 * 365;
+  document.cookie = `raggae_locale=${locale};path=/;max-age=${maxAge};SameSite=Lax`;
+}
 
 export function Sidebar() {
   const pathname = usePathname();
   const t = useTranslations("sidebar");
+  const tHeader = useTranslations("header");
   const tNav = useTranslations("nav");
   const tCommon = useTranslations("common");
+  const tTheme = useTranslations("layout.themeToggle");
+  const { theme, setTheme } = useTheme();
+  const currentLocale = useLocale();
+  const updateLocale = useUpdateUserLocale();
+
+  const THEMES: Array<{ value: Theme; label: string; icon: React.ReactNode }> = [
+    { value: "light", label: tTheme("light"), icon: <Sun size={14} /> },
+    { value: "dark", label: tTheme("dark"), icon: <Moon size={14} /> },
+    { value: "system", label: tTheme("system"), icon: <Monitor size={14} /> },
+  ];
+
+  function handleThemeSelect(next: Theme) {
+    if (next !== theme) setTheme(next);
+  }
+
+  function handleLocaleSelect(locale: UpdateUserLocaleRequest["locale"]) {
+    if (locale === currentLocale) return;
+    setLocaleCookie(locale);
+    updateLocale.mutate({ locale }, { onSettled: () => window.location.reload() });
+  }
 
   const navItems = [
     { href: "/projects", label: tNav("projects"), icon: "folder" },
@@ -231,18 +271,100 @@ export function Sidebar() {
         ))}
       </nav>
       <div className="border-t p-3">
-        <a
-          href="https://github.com/jbuget/raggae"
-          target="_blank"
-          rel="noreferrer"
-          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <Github className="size-4" />
-          <span>{t("githubProject")}</span>
-        </a>
-        <p className="mt-2 text-xs text-muted-foreground">
-          {gitBranch}@{shortCommit}
-        </p>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="sm" className="w-full cursor-pointer justify-start truncate">
+              {user?.email ?? tHeader("account")}
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent side="top" align="start" className="w-52">
+            <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+              {user?.email}
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem asChild>
+              <Link href="/settings" className="flex cursor-pointer items-center gap-2">
+                <Settings size={14} />
+                {tHeader("userSettings")}
+              </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
+                <Languages size={14} />
+                {tHeader("language")}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {LOCALES.map(({ value, label }) => (
+                  <DropdownMenuItem
+                    key={value}
+                    onClick={() => handleLocaleSelect(value)}
+                    className="flex cursor-pointer items-center gap-2"
+                  >
+                    <Check
+                      size={14}
+                      className={currentLocale === value ? "opacity-100" : "opacity-0"}
+                    />
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger className="flex cursor-pointer items-center gap-2">
+                <Sun size={14} />
+                {tTheme("label")}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                {THEMES.map(({ value, label, icon }) => (
+                  <DropdownMenuItem
+                    key={value}
+                    onClick={() => handleThemeSelect(value)}
+                    className="flex cursor-pointer items-center gap-2"
+                  >
+                    <Check
+                      size={14}
+                      className={theme === value ? "opacity-100" : "opacity-0"}
+                    />
+                    {icon}
+                    {label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem asChild>
+              <a
+                href="https://github.com/jbuget/raggae"
+                target="_blank"
+                rel="noreferrer"
+                className="flex cursor-pointer items-center gap-2"
+              >
+                <Github size={14} />
+                {t("sourceCode")}
+              </a>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+              {gitBranch}@{shortCommit}
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            <DropdownMenuItem
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="flex cursor-pointer items-center gap-2"
+            >
+              <LogOut size={14} />
+              {tHeader("signOut")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </aside>
   );

--- a/client/src/lib/markdown/render-markdown.tsx
+++ b/client/src/lib/markdown/render-markdown.tsx
@@ -77,37 +77,37 @@ export function renderMarkdown(markdown: string): ReactNode {
       const content = parseInline(heading[2]);
       if (level === 1) {
         blocks.push(
-          <h1 key={`h-${i}`} className="font-semibold">
+          <h1 key={`h-${i}`} className="mt-6 text-base font-bold">
             {content}
           </h1>,
         );
       } else if (level === 2) {
         blocks.push(
-          <h2 key={`h-${i}`} className="font-semibold">
+          <h2 key={`h-${i}`} className="mt-6 text-base font-bold">
             {content}
           </h2>,
         );
       } else if (level === 3) {
         blocks.push(
-          <h3 key={`h-${i}`} className="font-semibold">
+          <h3 key={`h-${i}`} className="mt-7 text-xl font-semibold">
             {content}
           </h3>,
         );
       } else if (level === 4) {
         blocks.push(
-          <h4 key={`h-${i}`} className="font-semibold">
+          <h4 key={`h-${i}`} className="mt-4 text-base font-semibold">
             {content}
           </h4>,
         );
       } else if (level === 5) {
         blocks.push(
-          <h5 key={`h-${i}`} className="font-semibold">
+          <h5 key={`h-${i}`} className="mt-3 text-base font-semibold">
             {content}
           </h5>,
         );
       } else {
         blocks.push(
-          <h6 key={`h-${i}`} className="font-semibold">
+          <h6 key={`h-${i}`} className="mt-3 text-base font-semibold">
             {content}
           </h6>,
         );
@@ -156,5 +156,5 @@ export function renderMarkdown(markdown: string): ReactNode {
     i += 1;
   }
 
-  return <div className="space-y-2 text-sm">{blocks}</div>;
+  return <div className="space-y-3 leading-normal text-base">{blocks}</div>;
 }

--- a/client/tests/components/chat/message-input.test.tsx
+++ b/client/tests/components/chat/message-input.test.tsx
@@ -77,8 +77,7 @@ describe("MessageInput", () => {
       <MessageInput onSend={vi.fn()} disabled isThinking />,
     );
 
-    expect(
-      screen.getByRole("button", { name: /send/i }),
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Problème

L'interface manquait de cohérence visuelle : couleurs de thème génériques, police système, et menu utilisateur mal positionné (haut à droite du header, isolé du reste de la navigation).

## Solution

Refonte complète du thème de couleurs et de la typographie, puis déplacement du menu utilisateur dans la sidebar pour une navigation plus cohérente et accessible.

## Implémentation

- **Thème et couleurs** : refonte des variables CSS du thème (clair/sombre) avec une palette plus affirmée
- **Typographie** : application de la police Plus Jakarta Sans via `next/font`, ajustements du rendu markdown
- **Menu utilisateur** : déplacé du header vers le bas de la sidebar desktop (DropdownMenu avec `side="top"`)
  - Options conservées : paramètres, langue, thème, déconnexion
  - Nouvelle option : "Code source" → lien GitHub du projet
  - Nouveau libellé non-cliquable : version `branch@commit`
- **Header simplifié** : ne contient plus que le trigger mobile (Sheet), visible uniquement sur petits écrans
- **Tests** : correction du test `message-input` pour l'état thinking

## Recette

1. Se connecter à l'application
2. Vérifier que le menu utilisateur apparaît en bas de la sidebar (email comme trigger)
3. Ouvrir le menu → vérifier la présence de : Paramètres, Langue, Thème, Code source, version, Déconnexion
4. Vérifier que "Code source" ouvre bien le repo GitHub dans un nouvel onglet
5. Vérifier que la version est non-cliquable
6. Vérifier que le header ne contient plus de menu utilisateur sur desktop
7. Sur mobile, vérifier que le bouton de navigation fonctionne toujours