### PR TITLE
style(sidebar): fond blanc en mode clair

### DIFF
--- a/client/src/components/layout/sidebar.tsx
+++ b/client/src/components/layout/sidebar.tsx
@@ -111,7 +111,7 @@ export function Sidebar() {
   const shortCommit = gitCommit === "unknown" ? gitCommit : gitCommit.slice(0, 7);
 
   return (
-    <aside className="hidden h-full w-64 border-r bg-muted/30 md:flex md:flex-col">
+    <aside className="hidden h-full w-64 border-r bg-white dark:bg-muted/30 md:flex md:flex-col">
       <div className="flex h-14 items-center border-b px-6">
         <Link href="/projects" className="text-xl font-bold">
           Raggae


### PR DESCRIPTION
## Problème

Le changement de fond blanc pour la sidebar en mode clair a été perdu lors du merge de la PR #43 (un revert avait été commité par erreur sur la branche).

## Solution

Réappliquer `bg-white dark:bg-muted/30` sur l'élément `<aside>` de la sidebar.

## Implémentation

- `client/src/components/layout/sidebar.tsx` : `bg-muted/30` → `bg-white dark:bg-muted/30`

## Recette

1. Ouvrir l'application en mode clair → la sidebar doit avoir un fond blanc
2. Passer en mode sombre → la sidebar doit revenir sur `bg-muted/30`