### PR TITLE
feat(chat): topbar avec nom du projet et titre de la conversation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,17 @@ Read these before coding:
 - **docs/SKILLS.md** — Technical examples (Python, FastAPI, SQLAlchemy patterns)
 - **docs/TESTING_STRATEGY.md** — Testing philosophy and fixtures
 
+## Commande "envoie en prod"
+
+Quand l'utilisateur dit **"envoie en prod"**, exécuter dans l'ordre :
+
+1. Tirer une branche depuis `main` en respectant les conventions de nommage
+2. Faire le ou les commits unitaires (Conventional Commits, messages en français)
+3. Lancer les tests et les checks qualité (voir Pre-Push Checklist ci-dessous)
+4. `git push` vers le remote
+5. Créer la PR en respectant le template (titre et description en français)
+6. Merger la PR
+
 ## Pre-Push Checklist
 
 Run all of the following before every `git push`. All must pass with zero errors:

--- a/client/src/app/(dashboard)/projects/[projectId]/chat/[conversationId]/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/chat/[conversationId]/page.tsx
@@ -3,21 +3,29 @@
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ChatPanel } from "@/components/chat/chat-panel";
-import { ConversationSidebar } from "@/components/chat/conversation-sidebar";
+import { useConversation } from "@/lib/hooks/use-chat";
 import { useProject } from "@/lib/hooks/use-projects";
 
 export default function ConversationPage() {
   const params = useParams<{ projectId: string; conversationId: string }>();
   const { data: project } = useProject(params.projectId);
+  const { data: conversation } = useConversation(params.projectId, params.conversationId);
   const isProjectReindexing = project?.reindex_status === "in_progress";
   const t = useTranslations("projects.chatPage");
 
   return (
     <div className="-m-6 flex h-[calc(100vh-3.5rem)]">
-      <div className="hidden h-full lg:block">
-        <ConversationSidebar />
-      </div>
-      <div className="flex-1">
+<div className="flex flex-1 flex-col">
+        <div className="flex h-14 shrink-0 items-center gap-2 border-b px-6 text-sm">
+          <span className="font-bold">{project?.name}</span>
+          {conversation?.title && (
+            <>
+              <span className="text-muted-foreground">›</span>
+              <span className="text-muted-foreground">{conversation.title}</span>
+            </>
+          )}
+        </div>
+        <div className="min-h-0 flex-1">
         <ChatPanel
           projectId={params.projectId}
           conversationId={params.conversationId}
@@ -28,6 +36,7 @@ export default function ConversationPage() {
               : undefined
           }
         />
+        </div>
       </div>
     </div>
   );

--- a/client/src/app/(dashboard)/projects/[projectId]/chat/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/chat/page.tsx
@@ -3,7 +3,6 @@
 import { useParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ChatPanel } from "@/components/chat/chat-panel";
-import { ConversationSidebar } from "@/components/chat/conversation-sidebar";
 import { useProject } from "@/lib/hooks/use-projects";
 
 export default function ChatPage() {
@@ -14,10 +13,11 @@ export default function ChatPage() {
 
   return (
     <div className="-m-6 flex h-[calc(100vh-3.5rem)]">
-      <div className="hidden h-full lg:block">
-        <ConversationSidebar />
-      </div>
-      <div className="flex-1">
+<div className="flex flex-1 flex-col">
+        <div className="flex h-14 shrink-0 items-center border-b px-6">
+          <span className="text-sm font-bold">{project?.name}</span>
+        </div>
+        <div className="min-h-0 flex-1">
         <ChatPanel
           projectId={params.projectId}
           conversationId={null}
@@ -28,6 +28,7 @@ export default function ChatPage() {
               : undefined
           }
         />
+        </div>
       </div>
     </div>
   );

--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import {
   deleteConversation,
+  getConversation,
   listConversations,
   listMessages,
   sendMessage,
@@ -24,6 +25,16 @@ export function useConversations(projectId: string) {
     queryKey: ["conversations", projectId],
     queryFn: () => listConversations(token!, projectId),
     enabled: !!token && !!projectId,
+  });
+}
+
+export function useConversation(projectId: string, conversationId: string) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: ["conversation", projectId, conversationId],
+    queryFn: () => getConversation(token!, projectId, conversationId),
+    enabled: !!token && !!projectId && !!conversationId,
   });
 }
 


### PR DESCRIPTION
## Problème

La zone principale de chat n'avait aucun repère visuel contextuel : l'utilisateur ne pouvait pas savoir dans quel projet ou quelle conversation il se trouvait sans regarder la sidebar.

## Solution

Ajouter une topbar alignée sur l'élément brand de la sidebar (même hauteur `h-14`, même `border-b`), affichant le contexte de navigation courant.

## Implémentation

- `client/src/lib/hooks/use-chat.ts` : ajout du hook `useConversation` pour récupérer une conversation par son ID
- `client/src/app/(dashboard)/projects/[projectId]/chat/page.tsx` : topbar affichant le nom du projet (nouvelle conversation)
- `client/src/app/(dashboard)/projects/[projectId]/chat/[conversationId]/page.tsx` : topbar affichant **nom du projet** › titre de la conversation (dès qu'un titre est disponible)
- `CLAUDE.md` : documentation de la commande "envoie en prod"

## Recette

1. Naviguer vers un projet → ouvrir une nouvelle conversation → la topbar affiche le nom du projet en gras
2. Envoyer un message et attendre la génération du titre → la topbar affiche **nom du projet** › titre
3. Naviguer vers une conversation existante avec titre → vérifier l'affichage **projet** › **titre**
4. Vérifier l'alignement visuel de la topbar avec l'élément brand "Raggae" dans la sidebar