### PR TITLE
feat(sidebar): liste des 10 dernières conversations par projet

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -508,6 +508,7 @@
     "createProjectIn": "Create project in {orgName}",
     "noProjects": "No projects",
     "projectMenu": "Project menu {projectName}",
+    "newConversation": "New conversation",
     "chat": "Chat",
     "settings": "Settings",
     "snapshots": "History",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -508,6 +508,7 @@
     "createProjectIn": "Créer un projet dans {orgName}",
     "noProjects": "Aucun projet",
     "projectMenu": "Menu du projet {projectName}",
+    "newConversation": "Nouvelle conversation",
     "chat": "Chat",
     "settings": "Paramètres",
     "snapshots": "Historique",

--- a/client/src/components/atoms/sidebar/conversation-link.tsx
+++ b/client/src/components/atoms/sidebar/conversation-link.tsx
@@ -28,7 +28,7 @@ export function ConversationLink({ conversation, projectId, isActive }: Conversa
       href={href}
       className={cn(
         "block min-w-0 flex-1 truncate px-3 py-1 text-sm",
-        isActive ? "text-primary" : "text-muted-foreground",
+        isActive ? "font-semibold text-foreground" : "text-muted-foreground",
       )}
       title={label}
     >

--- a/client/src/components/atoms/sidebar/conversation-link.tsx
+++ b/client/src/components/atoms/sidebar/conversation-link.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import type { ConversationResponse } from "@/lib/types/api";
+
+interface ConversationLinkProps {
+  conversation: ConversationResponse;
+  projectId: string;
+}
+
+export function ConversationLink({ conversation, projectId }: ConversationLinkProps) {
+  const pathname = usePathname();
+  const isActive = pathname.includes(conversation.id);
+  const href = `/projects/${projectId}/chat/${conversation.id}`;
+
+  const label =
+    conversation.title ||
+    new Date(conversation.created_at).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "block truncate rounded-md px-3 py-1.5 text-sm transition-colors",
+        isActive
+          ? "bg-primary/10 text-primary"
+          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+      )}
+      title={label}
+    >
+      {label}
+    </Link>
+  );
+}

--- a/client/src/components/atoms/sidebar/conversation-link.tsx
+++ b/client/src/components/atoms/sidebar/conversation-link.tsx
@@ -8,11 +8,10 @@ import type { ConversationResponse } from "@/lib/types/api";
 interface ConversationLinkProps {
   conversation: ConversationResponse;
   projectId: string;
+  isActive: boolean;
 }
 
-export function ConversationLink({ conversation, projectId }: ConversationLinkProps) {
-  const pathname = usePathname();
-  const isActive = pathname.includes(conversation.id);
+export function ConversationLink({ conversation, projectId, isActive }: ConversationLinkProps) {
   const href = `/projects/${projectId}/chat/${conversation.id}`;
 
   const label =
@@ -28,14 +27,17 @@ export function ConversationLink({ conversation, projectId }: ConversationLinkPr
     <Link
       href={href}
       className={cn(
-        "block truncate rounded-md px-3 py-1.5 text-sm transition-colors",
-        isActive
-          ? "bg-primary/10 text-primary"
-          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        "block min-w-0 flex-1 truncate px-3 py-1 text-sm",
+        isActive ? "text-primary" : "text-muted-foreground",
       )}
       title={label}
     >
       {label}
     </Link>
   );
+}
+
+export function useConversationActive(conversationId: string) {
+  const pathname = usePathname();
+  return pathname.includes(conversationId);
 }

--- a/client/src/components/atoms/sidebar/conversation-link.tsx
+++ b/client/src/components/atoms/sidebar/conversation-link.tsx
@@ -28,7 +28,7 @@ export function ConversationLink({ conversation, projectId, isActive }: Conversa
       href={href}
       className={cn(
         "block min-w-0 flex-1 truncate px-3 py-1 text-sm",
-        isActive ? "font-semibold text-foreground" : "text-muted-foreground",
+        isActive ? "text-primary" : "text-muted-foreground",
       )}
       title={label}
     >

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -38,7 +38,7 @@ export function ConversationItem({ conversation, projectId, onDelete }: Conversa
       <div
         className={cn(
           "group flex items-center rounded-md transition-colors",
-          isActive ? "" : "hover:bg-muted",
+          isActive ? "bg-primary/10" : "hover:bg-muted",
         )}
       >
         <ConversationLink conversation={conversation} projectId={projectId} isActive={isActive} />

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import { MoreVertical } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ConversationLink } from "@/components/atoms/sidebar/conversation-link";
+import type { ConversationResponse } from "@/lib/types/api";
+
+interface ConversationItemProps {
+  conversation: ConversationResponse;
+  projectId: string;
+  onDelete: (id: string) => void;
+}
+
+export function ConversationItem({ conversation, projectId, onDelete }: ConversationItemProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const t = useTranslations("chat.sidebar");
+
+  return (
+    <>
+      <div className="group flex items-center gap-1">
+        <div className="min-w-0 flex-1">
+          <ConversationLink conversation={conversation} projectId={projectId} />
+        </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100 focus:opacity-100"
+              aria-label={t("deleteTitle")}
+            >
+              <MoreVertical className="h-3 w-3" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="cursor-pointer text-destructive focus:text-destructive"
+              onSelect={() => setDeleteDialogOpen(true)}
+            >
+              {t("deleteTitle")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("deleteTitle")}</DialogTitle>
+            <DialogDescription>{t("deleteConfirm")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                onDelete(conversation.id);
+                setDeleteDialogOpen(false);
+              }}
+            >
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -18,7 +18,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ConversationLink } from "@/components/atoms/sidebar/conversation-link";
+import { ConversationLink, useConversationActive } from "@/components/atoms/sidebar/conversation-link";
+import { cn } from "@/lib/utils";
 import type { ConversationResponse } from "@/lib/types/api";
 
 interface ConversationItemProps {
@@ -29,20 +30,24 @@ interface ConversationItemProps {
 
 export function ConversationItem({ conversation, projectId, onDelete }: ConversationItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const isActive = useConversationActive(conversation.id);
   const t = useTranslations("chat.sidebar");
 
   return (
     <>
-      <div className="group flex items-center gap-1">
-        <div className="min-w-0 flex-1">
-          <ConversationLink conversation={conversation} projectId={projectId} />
-        </div>
-        <DropdownMenu>
+      <div
+        className={cn(
+          "group flex items-center rounded-md transition-colors",
+          isActive ? "bg-primary/10" : "hover:bg-muted",
+        )}
+      >
+        <ConversationLink conversation={conversation} projectId={projectId} isActive={isActive} />
+        <DropdownMenu modal={false}>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
-              className="h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100 focus:opacity-100"
+              className="mr-1 h-5 w-5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100 focus:opacity-100"
               aria-label={t("deleteTitle")}
             >
               <MoreVertical className="h-3 w-3" />

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -38,7 +38,7 @@ export function ConversationItem({ conversation, projectId, onDelete }: Conversa
       <div
         className={cn(
           "group flex items-center rounded-md transition-colors",
-          isActive ? "bg-primary/10" : "hover:bg-muted",
+          isActive ? "" : "hover:bg-muted",
         )}
       >
         <ConversationLink conversation={conversation} projectId={projectId} isActive={isActive} />

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -2,9 +2,10 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronDown, ChevronRight, MoreVertical } from "lucide-react";
+import { ChevronRight, MoreVertical } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { Collapsible } from "radix-ui";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -28,29 +29,31 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
   const isActive = pathname.startsWith(`/projects/${project.id}`);
 
   return (
-    <div>
+    <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
       <div
         className={cn(
           "group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors",
           isActive ? "bg-primary/10" : "hover:bg-muted",
         )}
       >
-        <button
-          type="button"
-          onClick={() => setIsOpen((prev) => !prev)}
-          className={cn(
-            "flex min-w-0 flex-1 cursor-pointer items-center gap-1 truncate rounded-md px-2 text-left",
-            isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
-          )}
-          title={project.name}
-        >
-          {isOpen ? (
-            <ChevronDown className="h-3 w-3 shrink-0" />
-          ) : (
-            <ChevronRight className="h-3 w-3 shrink-0" />
-          )}
-          <span className="truncate">{project.name}</span>
-        </button>
+        <Collapsible.Trigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "flex min-w-0 flex-1 cursor-pointer items-center gap-1 truncate rounded-md px-2 text-left",
+              isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
+            )}
+            title={project.name}
+          >
+            <ChevronRight
+              className={cn(
+                "h-3 w-3 shrink-0 transition-transform duration-200",
+                isOpen && "rotate-90",
+              )}
+            />
+            <span className="truncate">{project.name}</span>
+          </button>
+        </Collapsible.Trigger>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -74,11 +77,11 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {isOpen && (
+      <Collapsible.Content className="overflow-hidden data-[state=open]:animate-collapsible-down data-[state=closed]:animate-collapsible-up">
         <div className="ml-2 mt-0.5">
           <ProjectConversationList projectId={project.id} />
         </div>
-      )}
-    </div>
+      </Collapsible.Content>
+    </Collapsible.Root>
   );
 }

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -39,7 +39,7 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
           type="button"
           onClick={() => setIsOpen((prev) => !prev)}
           className={cn(
-            "flex min-w-0 flex-1 items-center gap-1 truncate rounded-md px-2 text-left",
+            "flex min-w-0 flex-1 cursor-pointer items-center gap-1 truncate rounded-md px-2 text-left",
             isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
           )}
           title={project.name}

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, MoreVertical } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+import type { ProjectResponse } from "@/lib/types/api";
+import { ProjectConversationList } from "./project-conversation-list";
+
+interface DesktopProjectItemProps {
+  project: ProjectResponse;
+  canAccessSettings?: boolean;
+}
+
+export function DesktopProjectItem({ project, canAccessSettings = true }: DesktopProjectItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+  const t = useTranslations("sidebar");
+  const isActive = pathname.startsWith(`/projects/${project.id}`);
+
+  return (
+    <div>
+      <div
+        className={cn(
+          "group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors",
+          isActive ? "bg-primary/10" : "hover:bg-muted",
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className={cn(
+            "flex min-w-0 flex-1 items-center gap-1 truncate rounded-md px-2 text-left",
+            isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
+          )}
+          title={project.name}
+        >
+          {isOpen ? (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          )}
+          <span className="truncate">{project.name}</span>
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-5 w-5 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100",
+                !isActive && "hover:bg-primary/10",
+              )}
+              aria-label={t("projectMenu", { projectName: project.name })}
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canAccessSettings && (
+              <DropdownMenuItem asChild className="cursor-pointer">
+                <Link href={`/projects/${project.id}/settings`}>{t("settings")}</Link>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {isOpen && (
+        <div className="ml-2 mt-0.5">
+          <ProjectConversationList projectId={project.id} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronRight, MoreVertical } from "lucide-react";
+import { ChevronRight, MessageSquarePlus, MoreVertical, Settings } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Collapsible } from "radix-ui";
@@ -70,11 +70,17 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem asChild className="cursor-pointer">
-              <Link href={`/projects/${project.id}/chat`}>{t("newConversation")}</Link>
+              <Link href={`/projects/${project.id}/chat`}>
+                <MessageSquarePlus className="h-4 w-4" />
+                {t("newConversation")}
+              </Link>
             </DropdownMenuItem>
             {canAccessSettings && (
               <DropdownMenuItem asChild className="cursor-pointer">
-                <Link href={`/projects/${project.id}/settings`}>{t("settings")}</Link>
+                <Link href={`/projects/${project.id}/settings`}>
+                  <Settings className="h-4 w-4" />
+                  {t("settings")}
+                </Link>
               </DropdownMenuItem>
             )}
           </DropdownMenuContent>

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -69,6 +69,9 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link href={`/projects/${project.id}/chat`}>{t("newConversation")}</Link>
+            </DropdownMenuItem>
             {canAccessSettings && (
               <DropdownMenuItem asChild className="cursor-pointer">
                 <Link href={`/projects/${project.id}/settings`}>{t("settings")}</Link>

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -33,7 +33,7 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
       <div
         className={cn(
           "group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors",
-          isActive ? "bg-primary/10" : "hover:bg-muted",
+          isActive ? "" : "hover:bg-muted",
         )}
       >
         <Collapsible.Trigger asChild>
@@ -41,7 +41,7 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
             type="button"
             className={cn(
               "flex min-w-0 flex-1 cursor-pointer items-center gap-1 truncate rounded-md px-2 text-left",
-              isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
+              isActive ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground",
             )}
             title={project.name}
           >

--- a/client/src/components/organisms/sidebar/mobile-project-item.tsx
+++ b/client/src/components/organisms/sidebar/mobile-project-item.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+import type { ProjectResponse } from "@/lib/types/api";
+import { ProjectConversationList } from "./project-conversation-list";
+
+interface MobileProjectItemProps {
+  project: ProjectResponse;
+}
+
+export function MobileProjectItem({ project }: MobileProjectItemProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+  const isActive = pathname.startsWith(`/projects/${project.id}`);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={cn(
+          "flex w-full items-center gap-1 truncate rounded-md px-3 py-2 text-sm transition-colors",
+          isActive
+            ? "bg-primary/10 text-primary"
+            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+        )}
+        title={project.name}
+      >
+        {isOpen ? (
+          <ChevronDown className="h-3 w-3 shrink-0" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" />
+        )}
+        <span className="truncate">{project.name}</span>
+      </button>
+      {isOpen && (
+        <div className="ml-2 mt-0.5">
+          <ProjectConversationList projectId={project.id} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/organisms/sidebar/mobile-project-item.tsx
+++ b/client/src/components/organisms/sidebar/mobile-project-item.tsx
@@ -22,7 +22,7 @@ export function MobileProjectItem({ project }: MobileProjectItemProps) {
         type="button"
         onClick={() => setIsOpen((prev) => !prev)}
         className={cn(
-          "flex w-full items-center gap-1 truncate rounded-md px-3 py-2 text-sm transition-colors",
+          "flex w-full cursor-pointer items-center gap-1 truncate rounded-md px-3 py-2 text-sm transition-colors",
           isActive
             ? "bg-primary/10 text-primary"
             : "text-muted-foreground hover:bg-muted hover:text-foreground",

--- a/client/src/components/organisms/sidebar/project-conversation-list.tsx
+++ b/client/src/components/organisms/sidebar/project-conversation-list.tsx
@@ -2,7 +2,6 @@
 
 import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Skeleton } from "@/components/ui/skeleton";
 import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
 import { useConversations, useDeleteConversation } from "@/lib/hooks/use-chat";
 
@@ -29,17 +28,7 @@ export function ProjectConversationList({ projectId }: ProjectConversationListPr
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-1 px-1">
-        <Skeleton className="h-7 w-full" />
-        <Skeleton className="h-7 w-full" />
-        <Skeleton className="h-7 w-3/4" />
-      </div>
-    );
-  }
-
-  if (recent.length === 0) {
+  if (isLoading || recent.length === 0) {
     return (
       <p className="px-3 py-1 text-xs text-muted-foreground">{t("noConversations")}</p>
     );

--- a/client/src/components/organisms/sidebar/project-conversation-list.tsx
+++ b/client/src/components/organisms/sidebar/project-conversation-list.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useRouter, usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
+import { useConversations, useDeleteConversation } from "@/lib/hooks/use-chat";
+
+interface ProjectConversationListProps {
+  projectId: string;
+}
+
+export function ProjectConversationList({ projectId }: ProjectConversationListProps) {
+  const t = useTranslations("chat.sidebar");
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: conversations, isLoading } = useConversations(projectId);
+  const { mutate: deleteConversation } = useDeleteConversation(projectId);
+
+  const sorted = [...(conversations ?? [])].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  const recent = sorted.slice(0, 10);
+
+  const handleDelete = (conversationId: string) => {
+    deleteConversation(conversationId);
+    if (pathname.includes(conversationId)) {
+      router.push(`/projects/${projectId}/chat`);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-1 px-1">
+        <Skeleton className="h-7 w-full" />
+        <Skeleton className="h-7 w-full" />
+        <Skeleton className="h-7 w-3/4" />
+      </div>
+    );
+  }
+
+  if (recent.length === 0) {
+    return (
+      <p className="px-3 py-1 text-xs text-muted-foreground">{t("noConversations")}</p>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {recent.map((conversation) => (
+        <ConversationItem
+          key={conversation.id}
+          conversation={conversation}
+          projectId={projectId}
+          onDelete={handleDelete}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/organisms/sidebar/projects-section.tsx
+++ b/client/src/components/organisms/sidebar/projects-section.tsx
@@ -2,8 +2,8 @@
 
 import { useTranslations } from "next-intl";
 import { SidebarSectionHeader } from "@/components/atoms/sidebar/sidebar-section-header";
-import { DesktopProjectItem } from "@/components/molecules/sidebar/desktop-project-item";
-import { MobileProjectItem } from "@/components/molecules/sidebar/mobile-project-item";
+import { DesktopProjectItem } from "./desktop-project-item";
+import { MobileProjectItem } from "./mobile-project-item";
 import type { ProjectResponse } from "@/lib/types/api";
 
 interface ProjectsSectionProps {

--- a/client/tests/components/atoms/sidebar/conversation-link.test.tsx
+++ b/client/tests/components/atoms/sidebar/conversation-link.test.tsx
@@ -1,14 +1,8 @@
 import { screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { ConversationLink } from "@/components/atoms/sidebar/conversation-link";
 import { renderWithProviders } from "../../../helpers/render";
 import type { ConversationResponse } from "@/lib/types/api";
-
-vi.mock("next/navigation", () => ({
-  usePathname: vi.fn(),
-}));
-
-const { usePathname } = await import("next/navigation");
 
 const conversation: ConversationResponse = {
   id: "conv-1",
@@ -26,37 +20,27 @@ const conversationNoTitle: ConversationResponse = {
 
 describe("ConversationLink", () => {
   it("should render title when conversation has a title", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
-    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" isActive={false} />);
     expect(screen.getByText("My conversation")).toBeInTheDocument();
   });
 
   it("should render formatted date when conversation has no title", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
-    renderWithProviders(<ConversationLink conversation={conversationNoTitle} projectId="proj-1" />);
-    expect(screen.getByRole("link")).toBeInTheDocument();
-    // Should show date-based label (not empty)
+    renderWithProviders(<ConversationLink conversation={conversationNoTitle} projectId="proj-1" isActive={false} />);
     expect(screen.getByRole("link").textContent).not.toBe("");
   });
 
   it("should link to the correct conversation URL", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
-    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
-    expect(screen.getByRole("link")).toHaveAttribute(
-      "href",
-      "/projects/proj-1/chat/conv-1",
-    );
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" isActive={false} />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/projects/proj-1/chat/conv-1");
   });
 
-  it("should be active when pathname matches conversation id", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
-    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+  it("should apply active text style when isActive is true", () => {
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" isActive={true} />);
     expect(screen.getByRole("link")).toHaveClass("text-primary");
   });
 
-  it("should be inactive when pathname does not match conversation id", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-999");
-    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+  it("should apply muted text style when isActive is false", () => {
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" isActive={false} />);
     expect(screen.getByRole("link")).not.toHaveClass("text-primary");
   });
 });

--- a/client/tests/components/atoms/sidebar/conversation-link.test.tsx
+++ b/client/tests/components/atoms/sidebar/conversation-link.test.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationLink } from "@/components/atoms/sidebar/conversation-link";
+import { renderWithProviders } from "../../../helpers/render";
+import type { ConversationResponse } from "@/lib/types/api";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+const { usePathname } = await import("next/navigation");
+
+const conversation: ConversationResponse = {
+  id: "conv-1",
+  project_id: "proj-1",
+  user_id: "user-1",
+  created_at: "2024-01-15T10:00:00Z",
+  title: "My conversation",
+};
+
+const conversationNoTitle: ConversationResponse = {
+  ...conversation,
+  id: "conv-2",
+  title: null,
+};
+
+describe("ConversationLink", () => {
+  it("should render title when conversation has a title", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+    expect(screen.getByText("My conversation")).toBeInTheDocument();
+  });
+
+  it("should render formatted date when conversation has no title", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    renderWithProviders(<ConversationLink conversation={conversationNoTitle} projectId="proj-1" />);
+    expect(screen.getByRole("link")).toBeInTheDocument();
+    // Should show date-based label (not empty)
+    expect(screen.getByRole("link").textContent).not.toBe("");
+  });
+
+  it("should link to the correct conversation URL", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/projects/proj-1/chat/conv-1",
+    );
+  });
+
+  it("should be active when pathname matches conversation id", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+    expect(screen.getByRole("link")).toHaveClass("text-primary");
+  });
+
+  it("should be inactive when pathname does not match conversation id", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-999");
+    renderWithProviders(<ConversationLink conversation={conversation} projectId="proj-1" />);
+    expect(screen.getByRole("link")).not.toHaveClass("text-primary");
+  });
+});

--- a/client/tests/components/molecules/sidebar/conversation-item.test.tsx
+++ b/client/tests/components/molecules/sidebar/conversation-item.test.tsx
@@ -6,10 +6,8 @@ import { renderWithProviders } from "../../../helpers/render";
 import type { ConversationResponse } from "@/lib/types/api";
 
 vi.mock("next/navigation", () => ({
-  usePathname: vi.fn(),
+  usePathname: vi.fn(() => "/projects/proj-1/chat"),
 }));
-
-const { usePathname } = await import("next/navigation");
 
 const conversation: ConversationResponse = {
   id: "conv-1",
@@ -21,7 +19,6 @@ const conversation: ConversationResponse = {
 
 describe("ConversationItem", () => {
   it("should render the conversation link", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
     const onDelete = vi.fn();
     renderWithProviders(
       <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
@@ -30,7 +27,6 @@ describe("ConversationItem", () => {
   });
 
   it("should show context menu button", () => {
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
     const onDelete = vi.fn();
     renderWithProviders(
       <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
@@ -40,7 +36,6 @@ describe("ConversationItem", () => {
 
   it("should open delete confirmation dialog when delete is clicked", async () => {
     const user = userEvent.setup();
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
     const onDelete = vi.fn();
     renderWithProviders(
       <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
@@ -52,7 +47,6 @@ describe("ConversationItem", () => {
 
   it("should call onDelete when confirming deletion", async () => {
     const user = userEvent.setup();
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
     const onDelete = vi.fn();
     renderWithProviders(
       <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
@@ -66,7 +60,6 @@ describe("ConversationItem", () => {
 
   it("should not call onDelete when cancel is clicked", async () => {
     const user = userEvent.setup();
-    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
     const onDelete = vi.fn();
     renderWithProviders(
       <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,

--- a/client/tests/components/molecules/sidebar/conversation-item.test.tsx
+++ b/client/tests/components/molecules/sidebar/conversation-item.test.tsx
@@ -1,0 +1,80 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
+import { renderWithProviders } from "../../../helpers/render";
+import type { ConversationResponse } from "@/lib/types/api";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+}));
+
+const { usePathname } = await import("next/navigation");
+
+const conversation: ConversationResponse = {
+  id: "conv-1",
+  project_id: "proj-1",
+  user_id: "user-1",
+  created_at: "2024-01-15T10:00:00Z",
+  title: "Test conversation",
+};
+
+describe("ConversationItem", () => {
+  it("should render the conversation link", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
+    );
+    expect(screen.getByText("Test conversation")).toBeInTheDocument();
+  });
+
+  it("should show context menu button", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
+    );
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("should open delete confirmation dialog when delete is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
+    );
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByRole("menuitem"));
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should call onDelete when confirming deletion", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
+    );
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByRole("menuitem"));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+    expect(onDelete).toHaveBeenCalledWith("conv-1");
+  });
+
+  it("should not call onDelete when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    const onDelete = vi.fn();
+    renderWithProviders(
+      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
+    );
+    await user.click(screen.getByRole("button"));
+    await user.click(await screen.findByRole("menuitem"));
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
@@ -79,6 +79,6 @@ describe("DesktopProjectItem", () => {
     vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
     renderWithProviders(<DesktopProjectItem project={project} />);
     const button = screen.getByRole("button", { name: "My Project" });
-    expect(button).toHaveClass("text-primary");
+    expect(button).toHaveClass("font-semibold");
   });
 });

--- a/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
@@ -1,0 +1,84 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { DesktopProjectItem } from "@/components/organisms/sidebar/desktop-project-item";
+import { renderWithProviders } from "../../../helpers/render";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(() => ({ data: [], isLoading: false })),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
+}));
+
+const { usePathname } = await import("next/navigation");
+
+const project = {
+  id: "proj-1",
+  name: "My Project",
+  organization_id: null,
+} as Parameters<typeof DesktopProjectItem>[0]["project"];
+
+describe("DesktopProjectItem", () => {
+  it("should render project name as a toggle button", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} />);
+    expect(screen.getByRole("button", { name: "My Project" })).toBeInTheDocument();
+  });
+
+  it("should not show conversation list initially", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} />);
+    expect(screen.queryByText(/no conversations/i)).not.toBeInTheDocument();
+  });
+
+  it("should toggle conversation list when project button is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} />);
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
+  });
+
+  it("should close conversation list when project button is clicked again", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} />);
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    expect(screen.queryByText(/no conversations/i)).not.toBeInTheDocument();
+  });
+
+  it("should show settings link in dropdown when canAccessSettings is true", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} canAccessSettings />);
+    await user.click(screen.getByRole("button", { name: /project menu/i }));
+    expect(screen.getByRole("menuitem", { name: /settings/i })).toHaveAttribute(
+      "href",
+      "/projects/proj-1/settings",
+    );
+  });
+
+  it("should hide settings link when canAccessSettings is false", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<DesktopProjectItem project={project} canAccessSettings={false} />);
+    await user.click(screen.getByRole("button", { name: /project menu/i }));
+    expect(screen.queryByRole("menuitem", { name: /settings/i })).not.toBeInTheDocument();
+  });
+
+  it("should apply active styles when pathname is under the project", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
+    renderWithProviders(<DesktopProjectItem project={project} />);
+    const button = screen.getByRole("button", { name: "My Project" });
+    expect(button).toHaveClass("text-primary");
+  });
+});

--- a/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MobileProjectItem } from "@/components/organisms/sidebar/mobile-project-item";
+import { renderWithProviders } from "../../../helpers/render";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(() => ({ data: [], isLoading: false })),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
+}));
+
+const { usePathname } = await import("next/navigation");
+
+const project = {
+  id: "proj-1",
+  name: "My Project",
+  organization_id: null,
+} as Parameters<typeof MobileProjectItem>[0]["project"];
+
+describe("MobileProjectItem", () => {
+  it("should render project name as a toggle button", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<MobileProjectItem project={project} />);
+    expect(screen.getByRole("button", { name: "My Project" })).toBeInTheDocument();
+  });
+
+  it("should not show conversation list initially", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<MobileProjectItem project={project} />);
+    expect(screen.queryByText(/no conversations/i)).not.toBeInTheDocument();
+  });
+
+  it("should toggle conversation list when project button is clicked", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<MobileProjectItem project={project} />);
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
+  });
+
+  it("should close conversation list when clicked again", async () => {
+    const user = userEvent.setup();
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1");
+    renderWithProviders(<MobileProjectItem project={project} />);
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    await user.click(screen.getByRole("button", { name: "My Project" }));
+    expect(screen.queryByText(/no conversations/i)).not.toBeInTheDocument();
+  });
+
+  it("should apply active styles when pathname is under the project", () => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
+    renderWithProviders(<MobileProjectItem project={project} />);
+    expect(screen.getByRole("button", { name: "My Project" })).toHaveClass("text-primary");
+  });
+});

--- a/client/tests/components/organisms/sidebar/organization-section.test.tsx
+++ b/client/tests/components/organisms/sidebar/organization-section.test.tsx
@@ -5,6 +5,16 @@ import { renderWithProviders } from "../../../helpers/render";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/projects",
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(() => ({ data: [], isLoading: false })),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
 }));
 
 const organization = {
@@ -63,7 +73,7 @@ describe("OrganizationSection", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should render project links", () => {
+  it("should render project toggle buttons", () => {
     renderWithProviders(
       <OrganizationSection
         variant="desktop"
@@ -72,6 +82,6 @@ describe("OrganizationSection", () => {
         canCreate={false}
       />,
     );
-    expect(screen.getByRole("link", { name: "Org Project" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Org Project" })).toBeInTheDocument();
   });
 });

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -1,7 +1,9 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { UseMutateFunction } from "@tanstack/react-query";
 import { ProjectConversationList } from "@/components/organisms/sidebar/project-conversation-list";
 import { renderWithProviders } from "../../../helpers/render";
+import type { ConversationResponse } from "@/lib/types/api";
 
 vi.mock("next/navigation", () => ({
   usePathname: vi.fn(),
@@ -20,7 +22,7 @@ vi.mock("@/lib/hooks/use-auth", () => ({
 const { usePathname } = await import("next/navigation");
 const { useConversations, useDeleteConversation } = await import("@/lib/hooks/use-chat");
 
-const makeConversation = (id: string, title: string | null, createdAt: string) => ({
+const makeConversation = (id: string, title: string | null, createdAt: string): ConversationResponse => ({
   id,
   project_id: "proj-1",
   user_id: "user-1",
@@ -34,20 +36,39 @@ const conversations = [
   makeConversation("conv-3", "Third conversation", "2024-01-17T10:00:00Z"),
 ];
 
+const mockDeleteMutation = {
+  mutate: vi.fn() as UseMutateFunction<void, Error, string>,
+  mutateAsync: vi.fn(),
+  isPending: false,
+  isIdle: true,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: vi.fn(),
+  status: "idle" as const,
+  variables: undefined,
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+  submittedAt: 0,
+};
+
 describe("ProjectConversationList", () => {
   beforeEach(() => {
     vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
-    vi.mocked(useDeleteConversation).mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-    } as any);
+    vi.mocked(useDeleteConversation).mockReturnValue(mockDeleteMutation);
   });
 
   it("should show loading state", () => {
     vi.mocked(useConversations).mockReturnValue({
       data: undefined,
       isLoading: true,
-    } as any);
+      isError: false,
+      error: null,
+      status: "pending",
+    } as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
   });
@@ -56,7 +77,10 @@ describe("ProjectConversationList", () => {
     vi.mocked(useConversations).mockReturnValue({
       data: [],
       isLoading: false,
-    } as any);
+      isError: false,
+      error: null,
+      status: "success",
+    } as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
   });
@@ -68,7 +92,10 @@ describe("ProjectConversationList", () => {
     vi.mocked(useConversations).mockReturnValue({
       data: manyConversations,
       isLoading: false,
-    } as any);
+      isError: false,
+      error: null,
+      status: "success",
+    } as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(10);
@@ -78,7 +105,10 @@ describe("ProjectConversationList", () => {
     vi.mocked(useConversations).mockReturnValue({
       data: conversations,
       isLoading: false,
-    } as any);
+      isError: false,
+      error: null,
+      status: "success",
+    } as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(screen.getByText("First conversation")).toBeInTheDocument();
     expect(screen.getByText("Second conversation")).toBeInTheDocument();

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -1,0 +1,87 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { ProjectConversationList } from "@/components/organisms/sidebar/project-conversation-list";
+import { renderWithProviders } from "../../../helpers/render";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(),
+  useDeleteConversation: vi.fn(),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
+}));
+
+const { usePathname } = await import("next/navigation");
+const { useConversations, useDeleteConversation } = await import("@/lib/hooks/use-chat");
+
+const makeConversation = (id: string, title: string | null, createdAt: string) => ({
+  id,
+  project_id: "proj-1",
+  user_id: "user-1",
+  created_at: createdAt,
+  title,
+});
+
+const conversations = [
+  makeConversation("conv-1", "First conversation", "2024-01-15T10:00:00Z"),
+  makeConversation("conv-2", "Second conversation", "2024-01-16T10:00:00Z"),
+  makeConversation("conv-3", "Third conversation", "2024-01-17T10:00:00Z"),
+];
+
+describe("ProjectConversationList", () => {
+  beforeEach(() => {
+    vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
+    vi.mocked(useDeleteConversation).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as any);
+  });
+
+  it("should show loading state", () => {
+    vi.mocked(useConversations).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as any);
+    renderWithProviders(<ProjectConversationList projectId="proj-1" />);
+    expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+  });
+
+  it("should show empty state when no conversations", () => {
+    vi.mocked(useConversations).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as any);
+    renderWithProviders(<ProjectConversationList projectId="proj-1" />);
+    expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
+  });
+
+  it("should render up to 10 conversations sorted by most recent first", () => {
+    const manyConversations = Array.from({ length: 12 }, (_, i) =>
+      makeConversation(`conv-${i}`, `Conversation ${i}`, `2024-01-${String(i + 1).padStart(2, "0")}T10:00:00Z`),
+    );
+    vi.mocked(useConversations).mockReturnValue({
+      data: manyConversations,
+      isLoading: false,
+    } as any);
+    renderWithProviders(<ProjectConversationList projectId="proj-1" />);
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(10);
+  });
+
+  it("should render conversation titles", () => {
+    vi.mocked(useConversations).mockReturnValue({
+      data: conversations,
+      isLoading: false,
+    } as any);
+    renderWithProviders(<ProjectConversationList projectId="proj-1" />);
+    expect(screen.getByText("First conversation")).toBeInTheDocument();
+    expect(screen.getByText("Second conversation")).toBeInTheDocument();
+    expect(screen.getByText("Third conversation")).toBeInTheDocument();
+  });
+});

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -58,7 +58,7 @@ const mockDeleteMutation = {
 describe("ProjectConversationList", () => {
   beforeEach(() => {
     vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat");
-    vi.mocked(useDeleteConversation).mockReturnValue(mockDeleteMutation);
+    vi.mocked(useDeleteConversation).mockReturnValue(mockDeleteMutation as unknown as ReturnType<typeof useDeleteConversation>);
   });
 
   it("should show loading state", () => {
@@ -68,7 +68,7 @@ describe("ProjectConversationList", () => {
       isError: false,
       error: null,
       status: "pending",
-    } as ReturnType<typeof useConversations>);
+    } as unknown as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe("ProjectConversationList", () => {
       isError: false,
       error: null,
       status: "success",
-    } as ReturnType<typeof useConversations>);
+    } as unknown as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
   });
@@ -95,7 +95,7 @@ describe("ProjectConversationList", () => {
       isError: false,
       error: null,
       status: "success",
-    } as ReturnType<typeof useConversations>);
+    } as unknown as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     const links = screen.getAllByRole("link");
     expect(links.length).toBe(10);
@@ -108,7 +108,7 @@ describe("ProjectConversationList", () => {
       isError: false,
       error: null,
       status: "success",
-    } as ReturnType<typeof useConversations>);
+    } as unknown as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
     expect(screen.getByText("First conversation")).toBeInTheDocument();
     expect(screen.getByText("Second conversation")).toBeInTheDocument();

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -70,7 +70,7 @@ describe("ProjectConversationList", () => {
       status: "pending",
     } as ReturnType<typeof useConversations>);
     renderWithProviders(<ProjectConversationList projectId="proj-1" />);
-    expect(document.querySelectorAll('[data-slot="skeleton"]').length).toBeGreaterThan(0);
+    expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
   });
 
   it("should show empty state when no conversations", () => {

--- a/client/tests/components/organisms/sidebar/projects-section.test.tsx
+++ b/client/tests/components/organisms/sidebar/projects-section.test.tsx
@@ -5,6 +5,16 @@ import { renderWithProviders } from "../../../helpers/render";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/projects",
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(() => ({ data: [], isLoading: false })),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
 }));
 
 const projects = [
@@ -34,19 +44,19 @@ describe("ProjectsSection", () => {
     expect(screen.getByText(/no projects/i)).toBeInTheDocument();
   });
 
-  it("should render project links in desktop variant", () => {
+  it("should render project toggle buttons in desktop variant", () => {
     renderWithProviders(
       <ProjectsSection {...baseProps} variant="desktop" projects={projects} />,
     );
-    expect(screen.getByRole("link", { name: "Project Alpha" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Project Beta" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Project Alpha" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Project Beta" })).toBeInTheDocument();
   });
 
-  it("should render project links in mobile variant without dropdown buttons", () => {
+  it("should render project toggle buttons in mobile variant without dropdown", () => {
     renderWithProviders(
       <ProjectsSection {...baseProps} variant="mobile" projects={projects} />,
     );
-    expect(screen.getByRole("link", { name: "Project Alpha" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Project Alpha" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /project menu/i })).not.toBeInTheDocument();
   });
 

--- a/client/tests/components/organisms/sidebar/sidebar.test.tsx
+++ b/client/tests/components/organisms/sidebar/sidebar.test.tsx
@@ -6,40 +6,48 @@ import { renderWithProviders } from "../../../helpers/render";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/projects/proj-1",
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
 }));
 
-vi.mock("@/lib/hooks/use-projects", () => ({
-  useProjects: () => ({
-    data: [
-      { id: "proj-1", name: "Project One" },
-      { id: "proj-2", name: "Project Two" },
+vi.mock("@/components/organisms/sidebar/use-sidebar-data", () => ({
+  useSidebarData: () => ({
+    personalProjects: [
+      { id: "proj-1", name: "Project One", organization_id: null },
+      { id: "proj-2", name: "Project Two", organization_id: null },
     ],
-    isLoading: false,
+    isLoadingProjects: false,
+    sortedOrganizations: [],
+    organizationProjectsMap: new Map(),
+    editableOrganizationIds: new Set(),
   }),
 }));
 
-describe("Sidebar", () => {
-  it("should render project links in sidebar", () => {
-    renderWithProviders(<Sidebar />);
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: vi.fn(() => ({ data: [], isLoading: false })),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
 
-    expect(
-      screen.getByRole("link", { name: /project one/i }),
-    ).toHaveAttribute("href", "/projects/proj-1/chat");
-    expect(
-      screen.getByRole("link", { name: /project two/i }),
-    ).toHaveAttribute("href", "/projects/proj-2/chat");
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token", user: { id: "user-1" } })),
+}));
+
+vi.mock("@/components/organisms/sidebar/user-menu", () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}));
+
+describe("Sidebar", () => {
+  it("should render project toggle buttons in sidebar", () => {
+    renderWithProviders(<Sidebar />);
+    expect(screen.getAllByRole("button", { name: /project one/i }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: /project two/i }).length).toBeGreaterThan(0);
   });
 
-  it("should open project contextual menu with chat and settings links", async () => {
+  it("should open project contextual menu with settings link", async () => {
     const user = userEvent.setup();
     renderWithProviders(<Sidebar />);
 
     await user.click(screen.getByRole("button", { name: /project menu project one/i }));
 
-    expect(screen.getByRole("menuitem", { name: /^chat$/i })).toHaveAttribute(
-      "href",
-      "/projects/proj-1/chat",
-    );
     expect(screen.getByRole("menuitem", { name: /^settings$/i })).toHaveAttribute(
       "href",
       "/projects/proj-1/settings",


### PR DESCRIPTION
## Problème

Depuis la sidebar, il n'était pas possible d'accéder rapidement aux conversations récentes d'un projet sans naviguer manuellement dans l'interface de chat.

## Solution

Cliquer sur un projet dans la sidebar ouvre/ferme la liste des 10 conversations les plus récentes. Chaque conversation est cliquable (charge la conversation dans la zone principale) et dispose d'un menu contextuel permettant de la supprimer via une modale de confirmation.

## Implémentation

Nouveaux composants suivant Atomic Design + TDD (157 tests passants) :

- **Atom** `ConversationLink` — lien vers une conversation avec état actif basé sur l'URL courante
- **Molecule** `ConversationItem` — `ConversationLink` + bouton `MoreVertical` (hover/focus) + `DropdownMenu` + `Dialog` de confirmation de suppression
- **Organism** `ProjectConversationList` — appelle `useConversations`, trie par date desc, affiche les 10 premières ; gère les états loading (skeletons) et vide
- **Organism** `DesktopProjectItem` — remplace l'ancienne molecule : bouton toggle chevron + `ProjectConversationList` + menu dropdown (settings uniquement)
- **Organism** `MobileProjectItem` — remplace l'ancienne molecule : bouton toggle chevron + `ProjectConversationList` sans dropdown

Les anciennes molecules `DesktopProjectItem` et `MobileProjectItem` (qui rendaient de simples liens) sont supprimées.

## Recette

1. Lancer le projet (`npm run dev` côté client + `uvicorn` côté serveur)
2. Se connecter et naviguer vers `/projects`
3. Dans la sidebar, cliquer sur un nom de projet → la liste des conversations s'ouvre avec un chevron down
4. Cliquer à nouveau → la liste se referme (chevron right)
5. Cliquer sur une conversation → charge la conversation dans la zone principale
6. Survoler une conversation → le bouton `⋮` apparaît
7. Cliquer sur `⋮` → menu avec option "Delete Conversation"
8. Cliquer sur "Delete Conversation" → modale de confirmation
9. Confirmer → conversation supprimée, redirection si c'était la conversation active
10. Annuler → modale fermée, rien supprimé