### PR TITLE
feat(indexing): activer le parent-child chunking par défaut

### DIFF
--- a/client/src/components/projects/project-form.tsx
+++ b/client/src/components/projects/project-form.tsx
@@ -55,7 +55,7 @@ export function ProjectForm({
     initialData?.chunking_strategy ?? "auto"
   );
   const [parentChildChunking, setParentChildChunking] = useState<boolean>(
-    initialData?.parent_child_chunking ?? false
+    initialData?.parent_child_chunking ?? true
   );
   const [reindexWarningOpen, setReindexWarningOpen] = useState(false);
   const [pendingFormData, setPendingFormData] = useState<ProjectFormData | null>(null);

--- a/server/src/raggae/domain/entities/project.py
+++ b/server/src/raggae/domain/entities/project.py
@@ -22,7 +22,7 @@ class Project:
     is_published: bool
     created_at: datetime
     chunking_strategy: ChunkingStrategy = ChunkingStrategy.AUTO
-    parent_child_chunking: bool = False
+    parent_child_chunking: bool = True
     reindex_status: str = "idle"
     reindex_progress: int = 0
     reindex_total: int = 0

--- a/server/tests/unit/application/services/test_document_indexing_service.py
+++ b/server/tests/unit/application/services/test_document_indexing_service.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 from uuid import uuid4
@@ -497,8 +498,10 @@ class TestDocumentIndexingService:
             parent_child_chunking_service=ParentChildChunkingService(),
         )
 
+        project_without_parent_child = replace(project, parent_child_chunking=False)
+
         # When
-        await service.run_pipeline(document, project, b"hello world from raggae")
+        await service.run_pipeline(document, project_without_parent_child, b"hello world from raggae")
 
         # Then — all chunks are STANDARD
         saved_chunks = mock_document_chunk_repository.replace_document_chunks.call_args.args[1]


### PR DESCRIPTION
## Problème
L'option parent-child chunking était désactivée par défaut (`False`), ce qui ne correspond pas à la configuration recommandée pour une meilleure qualité de recherche.

## Solution
Passer le défaut à `True` côté backend (entité `Project`) et côté frontend (formulaire de création/édition de projet).

## Implémentation
- `server/src/raggae/domain/entities/project.py` : `parent_child_chunking: bool = True`
- `client/src/components/projects/project-form.tsx` : valeur par défaut `?? true`
- `server/tests/unit/application/services/test_document_indexing_service.py` : correction du test qui supposait `parent_child_chunking=False` par défaut

## Recette
1. Créer un nouveau projet → vérifier que "Enable parent-child chunking" est coché par défaut
2. Indexer un document → vérifier que des chunks PARENT et CHILD sont créés
3. Lancer les tests unitaires → tous doivent passer