### PR TITLE
fix(ui): cursor-pointer sur fermeture dialog et projet actif en gras

### DIFF
--- a/client/src/components/molecules/sidebar/desktop-project-item.tsx
+++ b/client/src/components/molecules/sidebar/desktop-project-item.tsx
@@ -26,16 +26,13 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
 
   return (
     <div
-      className={cn(
-        "group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors",
-        isActive ? "bg-primary/10" : "hover:bg-muted",
-      )}
+      className="group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors hover:bg-muted"
     >
       <Link
         href={`/projects/${project.id}/chat`}
         className={cn(
           "min-w-0 flex-1 truncate rounded-md px-2",
-          isActive ? "text-primary" : "text-muted-foreground hover:text-foreground",
+          isActive ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground",
         )}
         title={project.name}
       >

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -70,7 +70,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
## Problème
Deux problèmes d'interface :
1. Le bouton de fermeture des dialogs (croix) n'affichait pas le curseur pointer, ce qui rendait l'interaction non intuitive.
2. Dans la sidebar, le projet actif était mis en évidence avec un fond coloré (`bg-primary/10`) peu discret.

## Solution
1. Ajouter `cursor-pointer` sur le bouton de fermeture des dialogs.
2. Remplacer le fond coloré par du texte en gras (`font-semibold`) pour indiquer le projet actif.

## Implémentation
- `client/src/components/ui/dialog.tsx` : ajout de `cursor-pointer` sur `DialogPrimitive.Close`
- `client/src/components/molecules/sidebar/desktop-project-item.tsx` : classe active `text-primary bg-primary/10` → `font-semibold text-foreground`

## Recette
1. Ouvrir un dialog (ex. suppression de projet) → la croix doit afficher le curseur pointer au survol
2. Naviguer entre projets dans la sidebar → le projet actif doit apparaître en gras, sans fond coloré