### PR TITLE
feat(organizations): badge 'Expirée' sur les invitations dépassées

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -398,7 +398,8 @@
       "resendSuccess": "Invitation resent",
       "resendError": "Failed to resend invitation",
       "revokeSuccess": "Invitation revoked",
-      "revokeError": "Failed to revoke invitation"
+      "revokeError": "Failed to revoke invitation",
+      "expired": "Expired"
     },
     "credentials": {
       "title": "AI provider API keys",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -398,7 +398,8 @@
       "resendSuccess": "Invitation renvoyée",
       "resendError": "Erreur lors du renvoi",
       "revokeSuccess": "Invitation révoquée",
-      "revokeError": "Erreur lors de la révocation"
+      "revokeError": "Erreur lors de la révocation",
+      "expired": "Expirée"
     },
     "credentials": {
       "title": "Clés API des fournisseurs IA",

--- a/client/src/components/organizations/organization-members-panel.tsx
+++ b/client/src/components/organizations/organization-members-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -169,7 +170,12 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                   className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3"
                 >
                   <div className="text-sm">
-                    <p className="font-medium">{invitation.email}</p>
+                    <div className="flex items-center gap-2">
+                      <p className="font-medium">{invitation.email}</p>
+                      {(invitation.status === "expired" || new Date(invitation.expires_at) < new Date()) && (
+                        <Badge variant="destructive">{t("expired")}</Badge>
+                      )}
+                    </div>
                     <p className="text-muted-foreground">
                       {invitation.role} - {invitation.status}
                     </p>

--- a/client/tests/components/organizations/organization-members-panel.test.tsx
+++ b/client/tests/components/organizations/organization-members-panel.test.tsx
@@ -23,7 +23,33 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
     ],
     isLoading: false,
   }),
-  useOrganizationInvitations: () => ({ data: [], isLoading: false }),
+  useOrganizationInvitations: () => ({
+    data: [
+      {
+        id: "inv-pending",
+        organization_id: "org-1",
+        email: "pending@example.com",
+        role: "user",
+        status: "pending",
+        invited_by_user_id: "user-1",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "inv-expired",
+        organization_id: "org-1",
+        email: "expired@example.com",
+        role: "user",
+        status: "pending",
+        invited_by_user_id: "user-1",
+        expires_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+    ],
+    isLoading: false,
+  }),
   useInviteOrganizationMember: () => ({ mutate: vi.fn(), isPending: false }),
   useUpdateOrganizationMemberRole: () => ({ mutate: vi.fn(), isPending: false }),
   useRemoveOrganizationMember: () => ({ mutate: vi.fn(), isPending: false }),
@@ -42,8 +68,15 @@ describe("OrganizationMembersPanel", () => {
     expect(screen.getByText("john.owner@example.com")).toBeInTheDocument();
   });
 
-  it("should show no pending invitations message when list is empty", () => {
+  it("should not show expired badge for a pending invitation within validity", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
-    expect(screen.getByText("No pending invitations.")).toBeInTheDocument();
+    const pendingRow = screen.getByText("pending@example.com").closest("div");
+    expect(pendingRow?.querySelector("[data-variant=destructive]")).toBeNull();
+  });
+
+  it("should show expired badge when invitation expires_at is in the past", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const expiredRow = screen.getByText("expired@example.com").closest("div");
+    expect(expiredRow).toHaveTextContent("Expired");
   });
 });


### PR DESCRIPTION
## Problème

Dans la liste des invitations en attente, rien n'indiquait visuellement qu'une invitation avait expiré. L'administrateur ne pouvait pas distinguer au premier coup d'œil les invitations encore valides des invitations périmées.

## Solution

Afficher un badge destructif «\u00a0Expirée\u00a0» / «\u00a0Expired\u00a0» à droite de l'email, dès que `expires_at` est dans le passé (ou que le statut vaut `"expired"`).

## Implémentation

- `organization-members-panel.tsx` : import du composant `Badge`, ajout de la condition `expires_at < now || status === "expired"` pour afficher `<Badge variant="destructive">`
- `messages/fr.json` et `messages/en.json` : ajout de la clé `organizations.members.expired`
- `organization-members-panel.test.tsx` : 2 nouveaux cas — badge absent sur invitation valide, badge présent sur invitation expirée

## Recette

1. Inviter un membre dans une organisation
2. Modifier manuellement `expires_at` à une date passée en base
3. Vérifier que le badge rouge «\u00a0Expirée\u00a0» s'affiche à côté de l'email dans la liste
4. Vérifier qu'une invitation non expirée n'affiche pas ce badge