### PR TITLE
fix(ui): corrections IHM — parent-enfant par défaut et toggle reranking

### DIFF
--- a/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx
@@ -909,24 +909,13 @@ export default function ProjectSettingsPage() {
       {activeTab === "Context augmentation" && (
         <div className="max-w-3xl space-y-4 rounded-md">
           <p className="text-base font-semibold tracking-tight">{t("contextAugmentation.title")}</p>
-          <div className="flex items-center justify-between rounded-md border p-3">
-            <Label htmlFor="rerankingEnabled">{t("contextAugmentation.rerankingLabel")}</Label>
-            <button
+          <div className="flex items-center gap-2">
+            <Switch
               id="rerankingEnabled"
-              type="button"
-              role="switch"
-              aria-checked={effectiveRerankingEnabled}
-              onClick={() => setRerankingEnabled(!effectiveRerankingEnabled)}
-              className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-                effectiveRerankingEnabled ? "bg-primary" : "bg-muted"
-              }`}
-            >
-              <span
-                className={`inline-block h-5 w-5 transform rounded-full bg-background transition-transform ${
-                  effectiveRerankingEnabled ? "translate-x-5" : "translate-x-1"
-                }`}
-              />
-            </button>
+              checked={effectiveRerankingEnabled}
+              onCheckedChange={setRerankingEnabled}
+            />
+            <Label htmlFor="rerankingEnabled">{t("contextAugmentation.rerankingLabel")}</Label>
           </div>
           {effectiveRerankingEnabled ? (
             <>

--- a/server/alembic/versions/20260425_40_set_parent_child_chunking_default_true.py
+++ b/server/alembic/versions/20260425_40_set_parent_child_chunking_default_true.py
@@ -1,0 +1,31 @@
+"""set parent_child_chunking default to true
+
+Revision ID: 20260425_40
+Revises: 20260321_39
+Create Date: 2026-04-25
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "20260425_40"
+down_revision: str | None = "20260321_39"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "projects",
+        "parent_child_chunking",
+        server_default="true",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "projects",
+        "parent_child_chunking",
+        server_default="false",
+    )

--- a/server/src/raggae/application/use_cases/project/create_project.py
+++ b/server/src/raggae/application/use_cases/project/create_project.py
@@ -217,7 +217,7 @@ class CreateProject:
             is_published=False,
             created_at=datetime.now(UTC),
             chunking_strategy=chunking_strategy or ChunkingStrategy.AUTO,
-            parent_child_chunking=parent_child_chunking or False,
+            parent_child_chunking=parent_child_chunking if parent_child_chunking is not None else True,
             embedding_backend=embedding_backend,
             embedding_model=embedding_model,
             embedding_api_key_encrypted=encrypted_embedding_api_key,

--- a/server/src/raggae/infrastructure/database/models/project_model.py
+++ b/server/src/raggae/infrastructure/database/models/project_model.py
@@ -32,7 +32,7 @@ class ProjectModel(Base):
         String(32), nullable=False, default="auto", server_default="auto"
     )
     parent_child_chunking: Mapped[bool] = mapped_column(
-        Boolean(), nullable=False, default=False, server_default="false"
+        Boolean(), nullable=False, default=True, server_default="true"
     )
     reindex_status: Mapped[str] = mapped_column(
         String(32), nullable=False, default="idle", server_default="idle"

--- a/server/tests/e2e/test_project_endpoints.py
+++ b/server/tests/e2e/test_project_endpoints.py
@@ -78,7 +78,7 @@ class TestProjectEndpoints:
         assert "user_id" in data
         assert data["is_published"] is False
         assert data["chunking_strategy"] == "auto"
-        assert data["parent_child_chunking"] is False
+        assert data["parent_child_chunking"] is True
         assert "id" in data
 
     async def test_create_project_with_chunking_settings_returns_201(self, client: AsyncClient) -> None:


### PR DESCRIPTION
## Problème

Deux bugs d'interface dans la configuration des projets :

1. **Découpage parent-enfant** : à la création d'un projet, l'option était initialisée à `false` malgré la valeur par défaut `True` définie dans l'entité domaine. Cause : `parent_child_chunking or False` dans le use case (avec `None or False = False`), et `server_default="false"` dans le modèle SQLAlchemy.

2. **Toggle reranking** : le bouton custom utilisait `bg-muted` quand désactivé, ce qui le rendait invisible sur fond clair — l'utilisateur ne pouvait pas voir qu'un toggle existait.

## Solution

1. Corriger la logique du use case avec `if not None else True`, mettre à jour le modèle SQLAlchemy et ajouter une migration Alembic.
2. Remplacer le `<button>` custom par le composant `Switch` de shadcn/ui, déjà utilisé dans le reste du formulaire.

## Implémentation

- `server/src/raggae/application/use_cases/project/create_project.py` : `or False` → `if … is not None else True`
- `server/src/raggae/infrastructure/database/models/project_model.py` : `server_default="false"` → `server_default="true"`
- `server/alembic/versions/20260425_40_set_parent_child_chunking_default_true.py` : nouvelle migration
- `server/tests/e2e/test_project_endpoints.py` : assertion mise à jour (`is False` → `is True`)
- `client/src/app/(dashboard)/projects/[projectId]/settings/page.tsx` : toggle remplacé par `<Switch />`

## Recette

1. Créer un nouveau projet → aller dans ses paramètres → onglet "Knowledge indexing" → vérifier que "Découpage parent-enfant" est activé par défaut
2. Aller dans l'onglet "Augmentation du contexte" → vérifier que le toggle "Activer le reranking" est visible et fonctionnel