### PR TITLE
feat(conversation): menu contextuel avec renommer/supprimer et icônes (#29)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -470,6 +470,10 @@
       "newConversation": "New Conversation",
       "loading": "Loading conversations...",
       "noConversations": "No conversations yet",
+      "menuLabel": "Conversation options",
+      "renameTitle": "Rename Conversation",
+      "renameDescription": "Enter a new name for this conversation.",
+      "renamePlaceholder": "Conversation name",
       "deleteTitle": "Delete Conversation",
       "deleteConfirm": "Are you sure you want to delete this conversation?"
     }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -470,6 +470,10 @@
       "newConversation": "Nouvelle conversation",
       "loading": "Chargement des conversations...",
       "noConversations": "Aucune conversation pour le moment",
+      "menuLabel": "Options de la conversation",
+      "renameTitle": "Renommer la conversation",
+      "renameDescription": "Saisissez un nouveau nom pour cette conversation.",
+      "renamePlaceholder": "Nom de la conversation",
       "deleteTitle": "Supprimer la conversation",
       "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?"
     }

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreVertical } from "lucide-react";
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,6 +18,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { ConversationLink, useConversationActive } from "@/components/atoms/sidebar/conversation-link";
 import { cn } from "@/lib/utils";
 import type { ConversationResponse } from "@/lib/types/api";
@@ -26,12 +27,29 @@ interface ConversationItemProps {
   conversation: ConversationResponse;
   projectId: string;
   onDelete: (id: string) => void;
+  onRename: (id: string, title: string) => void;
 }
 
-export function ConversationItem({ conversation, projectId, onDelete }: ConversationItemProps) {
+export function ConversationItem({ conversation, projectId, onDelete, onRename }: ConversationItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
   const isActive = useConversationActive(conversation.id);
   const t = useTranslations("chat.sidebar");
+  const tCommon = useTranslations("common");
+
+  function handleRenameOpen() {
+    setRenameValue(conversation.title ?? "");
+    setRenameDialogOpen(true);
+  }
+
+  function handleRenameConfirm() {
+    const trimmed = renameValue.trim();
+    if (trimmed) {
+      onRename(conversation.id, trimmed);
+    }
+    setRenameDialogOpen(false);
+  }
 
   return (
     <>
@@ -48,21 +66,55 @@ export function ConversationItem({ conversation, projectId, onDelete }: Conversa
               variant="ghost"
               size="icon"
               className="mr-1 h-5 w-5 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100 focus:opacity-100"
-              aria-label={t("deleteTitle")}
+              aria-label={t("menuLabel")}
             >
               <MoreVertical className="h-3 w-3" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             <DropdownMenuItem
-              className="cursor-pointer text-destructive focus:text-destructive"
+              className="cursor-pointer gap-2"
+              onSelect={handleRenameOpen}
+            >
+              <Pencil className="h-4 w-4" />
+              {t("renameTitle")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 text-destructive focus:text-destructive"
               onSelect={() => setDeleteDialogOpen(true)}
             >
+              <Trash2 className="h-4 w-4" />
               {t("deleteTitle")}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
+
+      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("renameTitle")}</DialogTitle>
+            <DialogDescription>{t("renameDescription")}</DialogDescription>
+          </DialogHeader>
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            placeholder={t("renamePlaceholder")}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleRenameConfirm();
+            }}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameDialogOpen(false)}>
+              {tCommon("cancel")}
+            </Button>
+            <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>
+              {tCommon("save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <DialogContent showCloseButton={false}>
@@ -72,7 +124,7 @@ export function ConversationItem({ conversation, projectId, onDelete }: Conversa
           </DialogHeader>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
-              Cancel
+              {tCommon("cancel")}
             </Button>
             <Button
               variant="destructive"
@@ -81,7 +133,7 @@ export function ConversationItem({ conversation, projectId, onDelete }: Conversa
                 setDeleteDialogOpen(false);
               }}
             >
-              Delete
+              {tCommon("delete")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/client/src/components/organisms/sidebar/project-conversation-list.tsx
+++ b/client/src/components/organisms/sidebar/project-conversation-list.tsx
@@ -3,7 +3,7 @@
 import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
-import { useConversations, useDeleteConversation } from "@/lib/hooks/use-chat";
+import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
 
 interface ProjectConversationListProps {
   projectId: string;
@@ -15,6 +15,7 @@ export function ProjectConversationList({ projectId }: ProjectConversationListPr
   const pathname = usePathname();
   const { data: conversations, isLoading } = useConversations(projectId, 10);
   const { mutate: deleteConversation } = useDeleteConversation(projectId);
+  const { mutate: renameConversation } = useRenameConversation(projectId);
 
   const recent = conversations ?? [];
 
@@ -45,6 +46,7 @@ export function ProjectConversationList({ projectId }: ProjectConversationListPr
           conversation={conversation}
           projectId={projectId}
           onDelete={handleDelete}
+          onRename={(id, title) => renameConversation({ conversationId: id, title })}
         />
       ))}
     </div>

--- a/client/src/lib/api/chat.ts
+++ b/client/src/lib/api/chat.ts
@@ -112,6 +112,18 @@ export function deleteConversation(
   );
 }
 
+export function renameConversation(
+  token: string,
+  projectId: string,
+  conversationId: string,
+  title: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/projects/${projectId}/chat/conversations/${conversationId}`,
+    { method: "PATCH", body: JSON.stringify({ title }), token },
+  );
+}
+
 export function listMessages(
   token: string,
   projectId: string,

--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -7,6 +7,7 @@ import {
   getConversation,
   listConversations,
   listMessages,
+  renameConversation,
   sendMessage,
   streamMessage,
 } from "@/lib/api/chat";
@@ -45,6 +46,19 @@ export function useMessages(projectId: string, conversationId: string | null) {
     queryKey: ["messages", projectId, conversationId],
     queryFn: () => listMessages(token!, projectId, conversationId!),
     enabled: !!token && !!projectId && !!conversationId,
+  });
+}
+
+export function useRenameConversation(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ conversationId, title }: { conversationId: string; title: string }) =>
+      renameConversation(token!, projectId, conversationId, title),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["conversations", projectId] });
+    },
   });
 }
 

--- a/client/tests/components/molecules/sidebar/conversation-item.test.tsx
+++ b/client/tests/components/molecules/sidebar/conversation-item.test.tsx
@@ -17,57 +17,83 @@ const conversation: ConversationResponse = {
   title: "Test conversation",
 };
 
+const defaultProps = {
+  conversation,
+  projectId: "proj-1",
+  onDelete: vi.fn(),
+  onRename: vi.fn(),
+};
+
 describe("ConversationItem", () => {
   it("should render the conversation link", () => {
-    const onDelete = vi.fn();
-    renderWithProviders(
-      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
-    );
+    renderWithProviders(<ConversationItem {...defaultProps} />);
     expect(screen.getByText("Test conversation")).toBeInTheDocument();
   });
 
   it("should show context menu button", () => {
-    const onDelete = vi.fn();
-    renderWithProviders(
-      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
-    );
+    renderWithProviders(<ConversationItem {...defaultProps} />);
     expect(screen.getByRole("button")).toBeInTheDocument();
   });
 
   it("should open delete confirmation dialog when delete is clicked", async () => {
     const user = userEvent.setup();
-    const onDelete = vi.fn();
-    renderWithProviders(
-      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
-    );
+    renderWithProviders(<ConversationItem {...defaultProps} />);
     await user.click(screen.getByRole("button"));
-    await user.click(await screen.findByRole("menuitem"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const deleteItem = menuItems.find((item) => item.textContent?.match(/supprimer|delete/i));
+    await user.click(deleteItem!);
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 
   it("should call onDelete when confirming deletion", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();
-    renderWithProviders(
-      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
-    );
+    renderWithProviders(<ConversationItem {...defaultProps} onDelete={onDelete} />);
     await user.click(screen.getByRole("button"));
-    await user.click(await screen.findByRole("menuitem"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const deleteItem = menuItems.find((item) => item.textContent?.match(/supprimer|delete/i));
+    await user.click(deleteItem!);
     await screen.findByRole("dialog");
-    await user.click(screen.getByRole("button", { name: /delete/i }));
+    await user.click(screen.getByRole("button", { name: /supprimer|delete/i }));
     expect(onDelete).toHaveBeenCalledWith("conv-1");
   });
 
   it("should not call onDelete when cancel is clicked", async () => {
     const user = userEvent.setup();
     const onDelete = vi.fn();
-    renderWithProviders(
-      <ConversationItem conversation={conversation} projectId="proj-1" onDelete={onDelete} />,
-    );
+    renderWithProviders(<ConversationItem {...defaultProps} onDelete={onDelete} />);
     await user.click(screen.getByRole("button"));
-    await user.click(await screen.findByRole("menuitem"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const deleteItem = menuItems.find((item) => item.textContent?.match(/supprimer|delete/i));
+    await user.click(deleteItem!);
     await screen.findByRole("dialog");
-    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    await user.click(screen.getByRole("button", { name: /annuler|cancel/i }));
     expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("should open rename dialog when rename is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationItem {...defaultProps} />);
+    await user.click(screen.getByRole("button"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const renameItem = menuItems.find((item) => item.textContent?.match(/renommer|rename/i));
+    await user.click(renameItem!);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should call onRename with trimmed value when confirming rename", async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    renderWithProviders(<ConversationItem {...defaultProps} onRename={onRename} />);
+    await user.click(screen.getByRole("button"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const renameItem = menuItems.find((item) => item.textContent?.match(/renommer|rename/i));
+    await user.click(renameItem!);
+    await screen.findByRole("dialog");
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Nouveau nom");
+    await user.click(screen.getByRole("button", { name: /enregistrer|save/i }));
+    expect(onRename).toHaveBeenCalledWith("conv-1", "Nouveau nom");
   });
 });


### PR DESCRIPTION
## Problème

Résout #29. Le menu contextuel d'une conversation ne permettait que la suppression, sans icône, et sans possibilité de renommer.

## Solution

Ajout d'une action "Renommer" avec dialog de saisie, et des icônes sur chaque entrée du menu déroulant.

## Implémentation

- `client/src/lib/api/chat.ts` : nouvelle fonction `renameConversation` (PATCH)
- `client/src/lib/hooks/use-chat.ts` : nouveau hook `useRenameConversation`
- `client/src/components/molecules/sidebar/conversation-item.tsx` :
  - Icône `Pencil` sur "Renommer", `Trash2` sur "Supprimer"
  - Dialog de renommage avec input pré-rempli, validation à la touche Entrée
  - Boutons du dialog de suppression utilisant désormais les traductions `common`
- `client/src/components/organisms/sidebar/project-conversation-list.tsx` : passage du handler `onRename`
- `client/messages/fr.json` et `en.json` : ajout des clés `menuLabel`, `renameTitle`, `renameDescription`, `renamePlaceholder`
- Tests mis à jour et enrichis (cas rename)

## Recette

1. Ouvrir la sidebar d'un projet avec des conversations
2. Survoler une conversation → le bouton ⋮ apparaît
3. Cliquer → le menu affiche deux entrées avec icônes : "Renommer" (crayon) et "Supprimer" (poubelle)
4. Cliquer "Renommer" → dialog avec le titre pré-rempli, valider avec le bouton ou Entrée → la conversation est renommée
5. Cliquer "Supprimer" → dialog de confirmation → la conversation est supprimée