### PR TITLE
fix(tests): corriger les mocks use-chat cassés en CI

### DIFF
--- a/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
@@ -12,6 +12,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(() => ({ data: [], isLoading: false })),
   useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({

--- a/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
@@ -12,6 +12,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(() => ({ data: [], isLoading: false })),
   useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -13,6 +13,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(),
   useDeleteConversation: vi.fn(),
+  useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({


### PR DESCRIPTION
## Problème

La CI est cassée depuis la PR #66 : l'ajout du hook `useRenameConversation` dans `use-chat.ts` n'a pas été répercuté dans les mocks vitest de 3 fichiers de tests.

Tests en échec :
- `project-conversation-list.test.tsx` (5 tests)
- `desktop-project-item.test.tsx` (2 tests)
- `mobile-project-item.test.tsx` (2 tests)

## Solution

Ajout de `useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false }))` dans les 3 mocks `vi.mock("@/lib/hooks/use-chat", ...)`.

## Recette

`pnpm run test` dans `client/` → 0 erreur.