### PR TITLE
fix(invitation): token_hash manquant dans OrganizationInvitationDTO

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -387,6 +387,7 @@
       "invitePlaceholder": "user@example.com",
       "inviteSuccess": "Invitation sent",
       "inviteError": "Failed to invite member",
+      "inviteAlreadyPending": "An invitation is already pending for this email.",
       "currentMembers": "Current members",
       "joined": "Joined",
       "remove": "Remove",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -387,6 +387,7 @@
       "invitePlaceholder": "utilisateur@exemple.fr",
       "inviteSuccess": "Invitation envoyée",
       "inviteError": "Erreur lors de l'invitation",
+      "inviteAlreadyPending": "Une invitation est déjà en attente pour cet email.",
       "currentMembers": "Membres actuels",
       "joined": "Rejoint le",
       "remove": "Retirer",

--- a/client/src/components/organizations/organization-members-panel.tsx
+++ b/client/src/components/organizations/organization-members-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { ApiError } from "@/lib/api/client";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -78,7 +79,13 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                     setRole("user");
                     toast.success(t("inviteSuccess"));
                   },
-                  onError: () => toast.error(t("inviteError")),
+                  onError: (err) => {
+                    if (err instanceof ApiError && err.status === 409) {
+                      toast.error(t("inviteAlreadyPending"));
+                    } else {
+                      toast.error(t("inviteError"));
+                    }
+                  },
                 },
               )
             }

--- a/server/src/raggae/application/dto/organization_invitation_dto.py
+++ b/server/src/raggae/application/dto/organization_invitation_dto.py
@@ -19,6 +19,7 @@ class OrganizationInvitationDTO:
     role: OrganizationMemberRole
     status: OrganizationInvitationStatus
     invited_by_user_id: UUID
+    token_hash: str
     expires_at: datetime
     created_at: datetime
     updated_at: datetime
@@ -32,6 +33,7 @@ class OrganizationInvitationDTO:
             role=invitation.role,
             status=invitation.status,
             invited_by_user_id=invitation.invited_by_user_id,
+            token_hash=invitation.token_hash,
             expires_at=invitation.expires_at,
             created_at=invitation.created_at,
             updated_at=invitation.updated_at,


### PR DESCRIPTION
## Problème

Erreur 500 lors de l'envoi ou du listing d'invitations depuis la PR #68.

```
pydantic_core.ValidationError: 1 validation error for OrganizationInvitationResponse
token_hash
  Field required [type=missing]
```

La PR #68 a ajouté `token_hash` dans `OrganizationInvitationResponse` (schéma Pydantic) mais a oublié de l'ajouter dans `OrganizationInvitationDTO` — le DTO intermédiaire utilisé par le use case `InviteOrganizationMember` et renvoyé à l'endpoint via `invitation.__dict__`.

## Solution

Ajout de `token_hash: str` dans `OrganizationInvitationDTO` et dans son `from_entity()`.

## Recette

1. Inviter un membre dans une organisation → plus d'erreur 500
2. La liste des invitations en attente s'affiche normalement avec le bouton "Copier le lien"