### PR TITLE
fix(organizations): restreindre la config d'organisation aux owners

### DIFF
--- a/client/src/components/organizations/organization-settings.tsx
+++ b/client/src/components/organizations/organization-settings.tsx
@@ -25,6 +25,8 @@ import {
   useOrganization,
   useUpdateOrganization,
 } from "@/lib/hooks/use-organization";
+import { useOrganizationMembers } from "@/lib/hooks/use-organization-members";
+import { useAuth } from "@/lib/hooks/use-auth";
 
 const ORG_SETTINGS_TABS = ["General", "Members", "API Keys"] as const;
 type OrgSettingsTab = (typeof ORG_SETTINGS_TABS)[number];
@@ -38,7 +40,9 @@ export function OrganizationSettings({ organizationId }: OrganizationSettingsPro
   const tCommon = useTranslations("common");
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user } = useAuth();
   const { data, isLoading, error } = useOrganization(organizationId);
+  const { data: members, isLoading: isMembersLoading } = useOrganizationMembers(organizationId);
   const deleteOrganization = useDeleteOrganization(organizationId);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const tabFromUrl = searchParams.get("tab");
@@ -58,7 +62,7 @@ export function OrganizationSettings({ organizationId }: OrganizationSettingsPro
     "API Keys": t("tabApiKeys"),
   };
 
-  if (isLoading) {
+  if (isLoading || isMembersLoading) {
     return (
       <div className="space-y-3">
         <Skeleton className="h-10 w-96" />
@@ -69,6 +73,12 @@ export function OrganizationSettings({ organizationId }: OrganizationSettingsPro
 
   if (error || !data) {
     return <div className="text-destructive">{t("loadError")}</div>;
+  }
+
+  const currentMember = members?.find((m) => m.user_id === user?.id);
+  if (currentMember?.role !== "owner") {
+    router.replace("/organizations");
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Problème

Un Maker pouvait accéder directement à `/organizations/{id}` par URL et voir toute la configuration de l'organisation (membres, clés API, paramètres généraux), même si le bouton "Gérer" n'était pas affiché dans l'UI.

Le backend est déjà entièrement protégé (OWNER only sur tous les use cases d'organisation). Il manquait la garde côté frontend.

## Solution

Dans `organization-settings.tsx`, après le chargement des membres, vérification que l'utilisateur courant est bien OWNER. Si ce n'est pas le cas, redirection immédiate vers `/organizations`.

## Recette

1. Se connecter en tant que Maker d'une organisation
2. Naviguer directement vers `/organizations/{orgId}` → redirection immédiate vers `/organizations`
3. En tant qu'Owner, la page s'affiche normalement