### PR TITLE
fix(documents): indiquer les formats supportés dans la zone d'upload

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -491,6 +491,9 @@
     },
     "upload": {
       "dragAndDrop": "Drag and drop a file here, or click to select",
+      "supportedFormats": "Accepted formats: {formats}",
+      "unsupportedFormat": "Format {ext} is not supported",
+      "unknownExtension": "unknown",
       "selectFiles": "Select Files",
       "filesSelected": "file(s) selected",
       "uploading": "Uploading...",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -491,6 +491,9 @@
     },
     "upload": {
       "dragAndDrop": "Glissez-déposez un fichier ici, ou cliquez pour sélectionner",
+      "supportedFormats": "Formats acceptés : {formats}",
+      "unsupportedFormat": "Format {ext} non supporté",
+      "unknownExtension": "inconnu",
       "selectFiles": "Sélectionner des fichiers",
       "filesSelected": "fichier(s) sélectionné(s)",
       "uploading": "Téléversement...",

--- a/client/src/components/documents/document-upload.tsx
+++ b/client/src/components/documents/document-upload.tsx
@@ -3,9 +3,18 @@
 import { useCallback, useRef, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { formatFileSize } from "@/lib/utils/format";
+
+const SUPPORTED_EXTENSIONS = [".pdf", ".docx", ".txt", ".md"] as const;
+const ACCEPT = SUPPORTED_EXTENSIONS.join(",");
+
+function isSupportedFile(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return SUPPORTED_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
 
 interface DocumentUploadProps {
   onUpload: (files: File[]) => void;
@@ -20,29 +29,39 @@ export function DocumentUpload({ onUpload, isUploading, uploadProgress = 0, disa
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
 
-  const handleFiles = useCallback((files: File[]) => {
+  const handleFiles = useCallback((files: File[], toastFn: typeof toast) => {
+    const rejected = files.filter((f) => !isSupportedFile(f));
+    const accepted = files.filter(isSupportedFile);
+
+    for (const file of rejected) {
+      const ext = file.name.includes(".") ? `.${file.name.split(".").pop()}` : t("unknownExtension");
+      toastFn.error(t("unsupportedFormat", { ext }));
+    }
+
+    if (accepted.length === 0) return;
+
     setSelectedFiles((previous) => {
-      const merged = [...previous, ...files];
+      const merged = [...previous, ...accepted];
       const uniqueByName = new Map<string, File>();
       for (const file of merged) {
         uniqueByName.set(file.name, file);
       }
       return Array.from(uniqueByName.values());
     });
-  }, []);
+  }, [t]);
 
   function handleDrop(e: React.DragEvent) {
     if (disabled) return;
     e.preventDefault();
     setIsDragOver(false);
     const files = Array.from(e.dataTransfer.files);
-    if (files.length > 0) handleFiles(files);
+    if (files.length > 0) handleFiles(files, toast);
   }
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     if (disabled) return;
     const files = Array.from(e.target.files ?? []);
-    if (files.length > 0) handleFiles(files);
+    if (files.length > 0) handleFiles(files, toast);
   }
 
   function handleUpload() {
@@ -71,13 +90,19 @@ export function DocumentUpload({ onUpload, isUploading, uploadProgress = 0, disa
           onDrop={handleDrop}
           data-testid="drop-zone"
         >
-          <p className="text-sm text-muted-foreground">
-            {t("dragAndDrop")}
-          </p>
+          <div className="text-center">
+            <p className="text-sm text-muted-foreground">
+              {t("dragAndDrop")}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {t("supportedFormats", { formats: SUPPORTED_EXTENSIONS.join(", ") })}
+            </p>
+          </div>
           <input
             ref={inputRef}
             type="file"
             multiple
+            accept={ACCEPT}
             onChange={handleChange}
             className="hidden"
             aria-label={t("selectFiles")}

--- a/client/tests/components/documents/document-upload.test.tsx
+++ b/client/tests/components/documents/document-upload.test.tsx
@@ -1,15 +1,30 @@
-import { screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import { DocumentUpload } from "@/components/documents/document-upload";
 import { renderWithProviders } from "../../helpers/render";
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}));
+
+function createDragEvent(files: File[]) {
+  return {
+    dataTransfer: {
+      files,
+      items: files.map((file) => ({ kind: "file", type: file.type, getAsFile: () => file })),
+      types: ["Files"],
+    },
+  };
+}
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
 describe("DocumentUpload", () => {
-  it("should render the drop zone", () => {
+  it("should render the drop zone with supported formats hint", () => {
     renderWithProviders(
       <DocumentUpload onUpload={vi.fn()} isUploading={false} />,
     );
@@ -18,8 +33,39 @@ describe("DocumentUpload", () => {
       screen.getByText(/drag and drop a file here/i),
     ).toBeInTheDocument();
     expect(
+      screen.getByText(/\.pdf, \.docx, \.txt, \.md/i),
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("button", { name: /select files/i }),
     ).toBeInTheDocument();
+  });
+
+  it("should reject unsupported file formats dropped and show an error toast", () => {
+    renderWithProviders(
+      <DocumentUpload onUpload={vi.fn()} isUploading={false} />,
+    );
+
+    const zipFile = new File(["content"], "archive.zip", { type: "application/zip" });
+    const dropZone = screen.getByTestId("drop-zone");
+    fireEvent.drop(dropZone, createDragEvent([zipFile]));
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining(".zip"));
+    expect(screen.queryByText(/1 file\(s\) selected/i)).not.toBeInTheDocument();
+  });
+
+  it("should accept supported files and reject unsupported ones in the same drop batch", () => {
+    renderWithProviders(
+      <DocumentUpload onUpload={vi.fn()} isUploading={false} />,
+    );
+
+    const pdfFile = new File(["content"], "doc.pdf", { type: "application/pdf" });
+    const zipFile = new File(["content"], "archive.zip", { type: "application/zip" });
+    const dropZone = screen.getByTestId("drop-zone");
+    fireEvent.drop(dropZone, createDragEvent([pdfFile, zipFile]));
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining(".zip"));
+    expect(screen.getByText(/1 file\(s\) selected/i)).toBeInTheDocument();
+    expect(screen.getByText(/doc.pdf/i)).toBeInTheDocument();
   });
 
   it("should show file info after selecting a file", async () => {


### PR DESCRIPTION
Closes #35

## Problème
La zone d'upload de documents n'indiquait pas quels formats sont acceptés. En cas de dépôt d'un fichier non supporté (ex : `.zip`), aucun message d'erreur n'était affiché.

## Solution
- Afficher les formats acceptés directement dans la zone de dépôt
- Ajouter l'attribut `accept` sur l'`<input>` pour filtrer nativement dans le sélecteur de fichiers du système
- Valider côté JS les fichiers glissés-déposés et afficher un toast d'erreur explicite (ex : "Format .zip non supporté")
- Les fichiers valides d'un même lot sont tout de même acceptés

## Implémentation
- `document-upload.tsx` : constante `SUPPORTED_EXTENSIONS`, fonction `isSupportedFile`, attribut `accept`, affichage de la liste des formats, toast d'erreur sur format rejeté
- `fr.json` / `en.json` : ajout des clés `supportedFormats`, `unsupportedFormat`, `unknownExtension`
- `document-upload.test.tsx` : 2 nouveaux tests (drag-and-drop de fichiers non supportés)

## Recette
1. Ouvrir la page documents d'un projet
2. Vérifier que la zone affiche "Formats acceptés : .pdf, .docx, .txt, .md"
3. Ouvrir le sélecteur de fichiers : seuls les formats supportés sont proposés
4. Glisser-déposer un fichier `.zip` : un toast d'erreur s'affiche
5. Glisser-déposer un `.pdf` et un `.zip` ensemble : le `.pdf` est accepté, le `.zip` est rejeté avec un toast