### PR TITLE
fix(chat): utiliser le LLM du projet pour générer le titre de la conversation

### DIFF
--- a/server/src/raggae/application/use_cases/chat/send_message.py
+++ b/server/src/raggae/application/use_cases/chat/send_message.py
@@ -174,6 +174,7 @@ class SendMessage:
                 title = await self._build_conversation_title(
                     user_message=message,
                     assistant_answer=refusal_answer,
+                    project=project,
                 )
                 await self._conversation_repository.update_title(conversation.id, title)
             return ChatMessageResponseDTO(
@@ -219,6 +220,7 @@ class SendMessage:
                 title = await self._build_conversation_title(
                     user_message=message,
                     assistant_answer=fallback_answer,
+                    project=project,
                 )
                 await self._conversation_repository.update_title(conversation.id, title)
             return ChatMessageResponseDTO(
@@ -283,6 +285,7 @@ class SendMessage:
             title = await self._build_conversation_title(
                 user_message=message,
                 assistant_answer=answer,
+                project=project,
             )
             await self._conversation_repository.update_title(conversation.id, title)
         return ChatMessageResponseDTO(
@@ -381,6 +384,7 @@ class SendMessage:
                 title = await self._build_conversation_title(
                     user_message=message,
                     assistant_answer=refusal_answer,
+                    project=project,
                 )
                 await self._conversation_repository.update_title(conversation.id, title)
             yield ChatStreamToken(token=refusal_answer)
@@ -426,6 +430,7 @@ class SendMessage:
                 title = await self._build_conversation_title(
                     user_message=message,
                     assistant_answer=fallback_answer,
+                    project=project,
                 )
                 await self._conversation_repository.update_title(conversation.id, title)
             yield ChatStreamToken(token=fallback_answer)
@@ -501,6 +506,7 @@ class SendMessage:
             title = await self._build_conversation_title(
                 user_message=message,
                 assistant_answer=accumulated_answer,
+                project=project,
             )
             await self._conversation_repository.update_title(conversation.id, title)
         yield ChatStreamDone(
@@ -513,13 +519,25 @@ class SendMessage:
             chunks_used=len(relevant_chunks),
         )
 
-    async def _build_conversation_title(self, user_message: str, assistant_answer: str) -> str:
+    async def _build_conversation_title(
+        self, user_message: str, assistant_answer: str, project: Project | None = None
+    ) -> str:
         fallback = self._normalize_title(user_message)
         try:
-            generated = await self._conversation_title_generator.generate_title(
-                user_message=user_message,
-                assistant_answer=assistant_answer,
-            )
+            if project is not None and self._project_llm_service_resolver is not None:
+                llm_service = self._project_llm_service_resolver.resolve(project)
+                title_prompt = (
+                    "Generate a short conversation title (max 8 words). "
+                    "Return only the title, no punctuation at the end."
+                    f"\n\nUser message: {user_message}"
+                    f"\nAssistant answer: {assistant_answer}"
+                )
+                generated = await llm_service.generate_answer(title_prompt)
+            else:
+                generated = await self._conversation_title_generator.generate_title(
+                    user_message=user_message,
+                    assistant_answer=assistant_answer,
+                )
         except Exception:
             return fallback
         normalized = self._normalize_title(generated)

--- a/server/tests/unit/application/use_cases/chat/test_send_message.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message.py
@@ -243,9 +243,9 @@ class TestSendMessage:
             limit=2,
         )
 
-        # Then
-        project_llm_service_resolver.resolve.assert_called_once()
-        resolved_llm_service.generate_answer.assert_awaited_once()
+        # Then — resolver called twice: once for the answer, once for the title
+        assert project_llm_service_resolver.resolve.call_count == 2
+        assert resolved_llm_service.generate_answer.await_count == 2
         assert result.answer == "resolved answer"
 
     async def test_send_message_resolves_provider_api_key_from_project_backend(


### PR DESCRIPTION
## Problème

Les titres de conversation affichaient "Answer based on prompt (1815 chars)" au lieu d'un titre généré par le LLM.

**Cause racine** : `_conversation_title_generator` utilisait `_llm_service` (LLM global de la plateforme). Quand `DEFAULT_LLM_PROVIDER` n'est pas configuré au niveau plateforme (cas fréquent — les projets ont chacun leur propre clé), `_llm_service` tombait sur `InMemoryLLMService`, qui retourne toujours `"Answer based on prompt (X chars)"`. Le chat fonctionnait lui normalement car il passe par `ProjectLLMServiceResolver` (clé par projet).

## Solution

`_build_conversation_title` reçoit maintenant le `Project` en paramètre. Quand `_project_llm_service_resolver` est disponible, le LLM du projet est résolu et utilisé directement pour générer le titre — le même LLM que celui utilisé pour la réponse.

Le fallback sur `_conversation_title_generator` est conservé pour les contextes sans resolver (tests unitaires, appels sans projet).

## Implémentation

- `send_message.py` : ajout du paramètre `project: Project | None = None` sur `_build_conversation_title` ; branche sur `_project_llm_service_resolver.resolve(project)` si disponible ; mise à jour des 6 call sites (`execute` + `execute_stream`, 3 scénarios chacun)
- `test_send_message.py` : mise à jour de `test_send_message_uses_project_llm_service_resolver` pour refléter que le resolver est appelé 2 fois (réponse + titre)

## Recette

1. Configurer un projet avec une clé LLM propre, sans `DEFAULT_LLM_PROVIDER` au niveau plateforme
2. Démarrer une nouvelle conversation
3. Vérifier que le titre est un résumé en langage naturel, pas "Answer based on prompt (X chars)"