### PR TITLE
fix(sse): stabiliser la génération de réponse SSE (#38)

### DIFF
--- a/client/src/components/chat/chat-panel.tsx
+++ b/client/src/components/chat/chat-panel.tsx
@@ -46,7 +46,7 @@ export function ChatPanel({
     conversationId,
   );
   const { data: existingMessages } = useMessages(projectId, currentConversationId);
-  const { send, state, streamedContent, chunks } = useSendMessage(projectId);
+  const { send, cancel, state, streamedContent, chunks, error: streamError } = useSendMessage(projectId);
   const [optimisticMessages, setOptimisticMessages] = useState<MessageResponse[]>([]);
   const [showChunks, setShowChunks] = useState(false);
   const [selectedSourceDocument, setSelectedSourceDocument] =
@@ -218,7 +218,13 @@ export function ChatPanel({
               );
             })}
 
-            {state === "sending" && <StreamingIndicator />}
+            {(state === "sending" || (state === "streaming" && streamedContent.length === 0)) && (
+              <StreamingIndicator />
+            )}
+
+            {streamError && state === "idle" && (
+              <p className="text-sm text-destructive">{streamError}</p>
+            )}
 
             {shouldRenderTransientAssistant && (
               <div className="space-y-2">
@@ -280,6 +286,7 @@ export function ChatPanel({
           )}
           <MessageInput
             onSend={handleSend}
+            onStop={cancel}
             disabled={disabled || state !== "idle"}
             isThinking={!disabled && state !== "idle"}
             hasMessages={messages.length > 0}

--- a/client/src/components/chat/message-input.tsx
+++ b/client/src/components/chat/message-input.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 
 interface MessageInputProps {
   onSend: (message: string) => void;
+  onStop?: () => void;
   disabled?: boolean;
   isThinking?: boolean;
   hasMessages?: boolean;
@@ -15,6 +16,7 @@ interface MessageInputProps {
 
 export function MessageInput({
   onSend,
+  onStop,
   disabled = false,
   isThinking = false,
   hasMessages = false,
@@ -87,7 +89,7 @@ export function MessageInput({
                 ? "bg-primary text-primary-foreground hover:bg-primary/90"
                 : "bg-muted text-muted-foreground cursor-default",
             )}
-            onClick={handleSubmit}
+            onClick={isThinking ? onStop : handleSubmit}
             disabled={!isThinking && !canSend}
             aria-label={isThinking ? t("stop") : t("send")}
           >

--- a/client/src/lib/api/chat.ts
+++ b/client/src/lib/api/chat.ts
@@ -23,10 +23,25 @@ export function sendMessage(
   );
 }
 
+export class StreamAbortedError extends Error {
+  constructor() {
+    super("Stream aborted");
+    this.name = "StreamAbortedError";
+  }
+}
+
+export class StreamServerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StreamServerError";
+  }
+}
+
 export async function* streamMessage(
   token: string,
   projectId: string,
   data: SendMessageRequest,
+  signal?: AbortSignal,
 ): AsyncGenerator<StreamEvent> {
   const response = await fetch(
     `/api/v1/projects/${projectId}/chat/messages/stream`,
@@ -37,6 +52,7 @@ export async function* streamMessage(
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(data),
+      signal,
     },
   );
 
@@ -53,6 +69,10 @@ export async function* streamMessage(
 
   try {
     while (true) {
+      if (signal?.aborted) {
+        throw new StreamAbortedError();
+      }
+
       const { done, value } = await reader.read();
       if (done) break;
 
@@ -62,13 +82,21 @@ export async function* streamMessage(
 
       for (const line of lines) {
         if (line.startsWith("data: ")) {
-          const data = line.slice(6).trim();
-          if (data) {
+          const raw = line.slice(6).trim();
+          if (raw) {
+            let parsed: StreamEvent;
             try {
-              yield JSON.parse(data) as StreamEvent;
+              parsed = JSON.parse(raw) as StreamEvent;
             } catch {
-              // skip unparseable lines
+              continue;
             }
+            if ("error" in parsed) {
+              throw new StreamServerError(parsed.error);
+            }
+            if ("ping" in parsed) {
+              continue;
+            }
+            yield parsed;
           }
         }
       }

--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -1,14 +1,14 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
+  StreamAbortedError,
   deleteConversation,
   getConversation,
   listConversations,
   listMessages,
   renameConversation,
-  sendMessage,
   streamMessage,
 } from "@/lib/api/chat";
 import type {
@@ -85,6 +85,12 @@ export function useSendMessage(projectId: string) {
   const [state, setState] = useState<ChatState>("idle");
   const [streamedContent, setStreamedContent] = useState("");
   const [chunks, setChunks] = useState<RetrievedChunkResponse[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    abortControllerRef.current?.abort();
+  }, []);
 
   const send = useCallback(
     async (
@@ -93,78 +99,52 @@ export function useSendMessage(projectId: string) {
     ) => {
       if (!token) return;
 
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
       setState("sending");
       setStreamedContent("");
       setChunks([]);
+      setError(null);
 
       try {
         setState("streaming");
         let accumulated = "";
 
-        try {
-          for await (const event of streamMessage(token, projectId, data)) {
-            if ("token" in event) {
-              accumulated += (event as StreamTokenEvent).token;
-              setStreamedContent(accumulated);
-            } else if ("done" in event) {
-              const doneEvent = event as StreamDoneEvent;
-              setChunks(doneEvent.chunks);
-              const effectiveConversationId =
-                doneEvent.conversation_id || data.conversation_id;
-              if (effectiveConversationId) {
-                onConversationId?.(effectiveConversationId);
-                queryClient.invalidateQueries({
-                  queryKey: ["conversations", projectId],
-                });
-                queryClient.invalidateQueries({
-                  queryKey: [
-                    "messages",
-                    projectId,
-                    effectiveConversationId,
-                  ],
-                });
-              }
+        for await (const event of streamMessage(token, projectId, data, abortController.signal)) {
+          if ("token" in event) {
+            accumulated += (event as StreamTokenEvent).token;
+            setStreamedContent(accumulated);
+          } else if ("done" in event) {
+            const doneEvent = event as StreamDoneEvent;
+            setChunks(doneEvent.chunks);
+            const effectiveConversationId =
+              doneEvent.conversation_id || data.conversation_id;
+            if (effectiveConversationId) {
+              onConversationId?.(effectiveConversationId);
+              queryClient.invalidateQueries({
+                queryKey: ["conversations", projectId],
+              });
+              queryClient.invalidateQueries({
+                queryKey: ["messages", projectId, effectiveConversationId],
+              });
             }
           }
-        } catch {
-          let retryConversationId = data.conversation_id ?? null;
-          if (!retryConversationId) {
-            const latestConversations = await listConversations(
-              token,
-              projectId,
-              1,
-              0,
-            );
-            const latest = latestConversations[0];
-            if (latest) {
-              retryConversationId = latest.id;
-            }
-          }
-
-          const response = await sendMessage(token, projectId, {
-            ...data,
-            conversation_id: retryConversationId,
-          });
-          setStreamedContent(response.answer);
-          setChunks(response.chunks);
-          onConversationId?.(response.conversation_id);
-          queryClient.invalidateQueries({
-            queryKey: ["conversations", projectId],
-          });
-          queryClient.invalidateQueries({
-            queryKey: [
-              "messages",
-              projectId,
-              response.conversation_id,
-            ],
-          });
+        }
+      } catch (err) {
+        if (err instanceof StreamAbortedError) {
+          // Annulation volontaire — pas d'affichage d'erreur
+        } else {
+          const message = err instanceof Error ? err.message : "Une erreur est survenue";
+          setError(message);
         }
       } finally {
+        abortControllerRef.current = null;
         setState("idle");
       }
     },
     [token, projectId, queryClient],
   );
 
-  return { send, state, streamedContent, chunks };
+  return { send, cancel, state, streamedContent, chunks, error };
 }

--- a/client/src/lib/types/api.ts
+++ b/client/src/lib/types/api.ts
@@ -335,7 +335,16 @@ export interface StreamDoneEvent {
   chunks: RetrievedChunkResponse[];
 }
 
-export type StreamEvent = StreamTokenEvent | StreamDoneEvent;
+export interface StreamErrorEvent {
+  error: string;
+  done: true;
+}
+
+export interface StreamPingEvent {
+  ping: true;
+}
+
+export type StreamEvent = StreamTokenEvent | StreamDoneEvent | StreamErrorEvent | StreamPingEvent;
 
 // User model provider credentials
 export type ModelProvider = "openai" | "gemini" | "anthropic";

--- a/client/tests/components/chat/chat-panel.test.tsx
+++ b/client/tests/components/chat/chat-panel.test.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
@@ -13,6 +15,15 @@ vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
+}));
+
+const mockSendMessageResult = vi.hoisted(() => ({
+  send: vi.fn(),
+  cancel: vi.fn(),
+  state: "idle" as "idle" | "sending" | "streaming",
+  streamedContent: "",
+  chunks: [] as never[],
+  error: null as string | null,
 }));
 
 vi.mock("@/lib/hooks/use-chat", () => ({
@@ -46,12 +57,7 @@ vi.mock("@/lib/hooks/use-chat", () => ({
       },
     ],
   }),
-  useSendMessage: () => ({
-    send: vi.fn(),
-    state: "idle",
-    streamedContent: "",
-    chunks: [],
-  }),
+  useSendMessage: () => mockSendMessageResult,
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({
@@ -115,5 +121,18 @@ describe("ChatPanel", () => {
       (btn) => btn.getAttribute("title") === "Copy chunk ID",
     );
     expect(chunkCopyButtons).toHaveLength(2);
+  });
+
+  it("displays stream error message when state is idle and error is set", () => {
+    mockSendMessageResult.error = "Stream connection failed";
+    mockSendMessageResult.state = "idle";
+
+    renderWithProviders(
+      <ChatPanel projectId="proj-1" conversationId="conv-1" />,
+    );
+
+    expect(screen.getByText("Stream connection failed")).toBeInTheDocument();
+
+    mockSendMessageResult.error = null;
   });
 });

--- a/client/tests/components/chat/message-input.test.tsx
+++ b/client/tests/components/chat/message-input.test.tsx
@@ -80,4 +80,16 @@ describe("MessageInput", () => {
     expect(screen.getByRole("button", { name: /stop/i })).toBeInTheDocument();
     expect(screen.getByLabelText(/message/i)).toBeDisabled();
   });
+
+  it("should call onStop when stop button is clicked while thinking", async () => {
+    const onStop = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MessageInput onSend={vi.fn()} onStop={onStop} disabled isThinking />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /stop/i }));
+
+    expect(onStop).toHaveBeenCalledOnce();
+  });
 });

--- a/client/tests/unit/lib/api/chat.test.ts
+++ b/client/tests/unit/lib/api/chat.test.ts
@@ -1,6 +1,8 @@
 import { http, HttpResponse } from "msw";
 import { describe, expect, it, vi } from "vitest";
 import {
+  StreamAbortedError,
+  StreamServerError,
   deleteConversation,
   listConversations,
   listMessages,
@@ -136,6 +138,96 @@ describe("streamMessage", () => {
       conversation_id: "conv-1",
       chunks: [],
     });
+    fetchMock.mockRestore();
+  });
+
+  it("should throw StreamServerError when an error event is received", async () => {
+    const payload = 'data: {"error":"LLM failed","done":true}\n\n';
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+        controller.close();
+      },
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+
+    await expect(async () => {
+      for await (const _ of streamMessage("token", "proj-1", { message: "hi" })) {
+        // should throw before yielding
+      }
+    }).rejects.toThrow(StreamServerError);
+
+    fetchMock.mockRestore();
+  });
+
+  it("should skip ping events and not yield them", async () => {
+    const payload =
+      'data: {"ping":true}\n\n' +
+      'data: {"token":"hello"}\n\n' +
+      'data: {"done":true,"conversation_id":"conv-1","chunks":[]}\n\n';
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(payload));
+        controller.close();
+      },
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+
+    const events = [];
+    for await (const event of streamMessage("token", "proj-1", { message: "hi" })) {
+      events.push(event);
+    }
+
+    // ping must not appear in yielded events
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ token: "hello" });
+    expect(events[1]).toMatchObject({ done: true, conversation_id: "conv-1" });
+
+    fetchMock.mockRestore();
+  });
+
+  it("should throw StreamAbortedError when signal is pre-aborted", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"token":"hi"}\n\n'));
+        controller.close();
+      },
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }),
+      );
+
+    await expect(async () => {
+      for await (const _ of streamMessage("token", "proj-1", { message: "hi" }, abortController.signal)) {
+        // should throw before yielding
+      }
+    }).rejects.toThrow(StreamAbortedError);
+
     fetchMock.mockRestore();
   });
 });

--- a/server/src/raggae/presentation/api/v1/endpoints/chat.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/chat.py
@@ -152,26 +152,55 @@ async def stream_message(
     from raggae.application.dto.chat_stream_event import ChatStreamDone, ChatStreamToken
 
     async def event_stream() -> AsyncIterator[str]:
+        import asyncio
+
         started_at = perf_counter()
+
+        async def _stream_to_queue(
+            stream: AsyncIterator[object],
+            queue: asyncio.Queue[object],
+        ) -> None:
+            try:
+                async for event in stream:
+                    await queue.put(event)
+            except Exception as exc:
+                await queue.put(exc)
+            finally:
+                await queue.put(None)  # sentinel
+
+        queue: asyncio.Queue[object] = asyncio.Queue()
+        stream = use_case.execute_stream(
+            project_id=project_id,
+            user_id=user_id,
+            message=data.message,
+            limit=data.limit,
+            offset=data.offset,
+            conversation_id=data.conversation_id,
+            start_new_conversation=data.start_new_conversation,
+            retrieval_filters=(
+                data.retrieval_filters.model_dump(exclude_none=True)
+                if data.retrieval_filters is not None
+                else None
+            ),
+        )
+        producer = asyncio.create_task(_stream_to_queue(stream, queue))
+
         try:
-            stream = use_case.execute_stream(
-                project_id=project_id,
-                user_id=user_id,
-                message=data.message,
-                limit=data.limit,
-                offset=data.offset,
-                conversation_id=data.conversation_id,
-                start_new_conversation=data.start_new_conversation,
-                retrieval_filters=(
-                    data.retrieval_filters.model_dump(exclude_none=True)
-                    if data.retrieval_filters is not None
-                    else None
-                ),
-            )
-            async for event in stream:
-                if isinstance(event, ChatStreamToken):
-                    yield f"data: {json.dumps({'token': event.token})}\n\n"
-                elif isinstance(event, ChatStreamDone):
+            _KEEPALIVE_INTERVAL = 15.0
+            while True:
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=_KEEPALIVE_INTERVAL)
+                except TimeoutError:
+                    yield f"data: {json.dumps({'ping': True})}\n\n"
+                    continue
+
+                if item is None:
+                    break
+                if isinstance(item, Exception):
+                    raise item
+                if isinstance(item, ChatStreamToken):
+                    yield f"data: {json.dumps({'token': item.token})}\n\n"
+                elif isinstance(item, ChatStreamDone):
                     chunks_payload = [
                         {
                             "chunk_id": str(chunk.chunk_id),
@@ -182,18 +211,18 @@ async def stream_message(
                             "vector_score": chunk.vector_score,
                             "fulltext_score": chunk.fulltext_score,
                         }
-                        for chunk in event.chunks
+                        for chunk in item.chunks
                     ]
                     yield (
                         "data: "
                         + json.dumps(
                             {
                                 "done": True,
-                                "conversation_id": str(event.conversation_id),
-                                "retrieval_strategy_used": event.retrieval_strategy_used,
-                                "retrieval_execution_time_ms": event.retrieval_execution_time_ms,
-                                "history_messages_used": event.history_messages_used,
-                                "chunks_used": event.chunks_used,
+                                "conversation_id": str(item.conversation_id),
+                                "retrieval_strategy_used": item.retrieval_strategy_used,
+                                "retrieval_execution_time_ms": item.retrieval_execution_time_ms,
+                                "history_messages_used": item.history_messages_used,
+                                "chunks_used": item.chunks_used,
                                 "chunks": chunks_payload,
                             }
                         )
@@ -206,19 +235,21 @@ async def stream_message(
                             "project_id": str(project_id),
                             "user_id": str(user_id),
                             "limit": data.limit,
-                            "chunks_count": len(event.chunks),
+                            "chunks_count": len(item.chunks),
                             "llm_backend": settings.default_llm_provider,
                             "elapsed_ms": round(elapsed_ms, 2),
                         },
                     )
         except ProjectNotFoundError:
-            yield f"data: {json.dumps({'error': 'Project not found'})}\n\n"
+            yield f"data: {json.dumps({'error': 'Project not found', 'done': True})}\n\n"
         except ProjectReindexInProgressError:
-            yield f"data: {json.dumps({'error': 'Project reindex already in progress'})}\n\n"
+            yield f"data: {json.dumps({'error': 'Project reindex already in progress', 'done': True})}\n\n"
         except ConversationNotFoundError:
-            yield f"data: {json.dumps({'error': 'Conversation not found'})}\n\n"
+            yield f"data: {json.dumps({'error': 'Conversation not found', 'done': True})}\n\n"
         except LLMGenerationError as exc:
-            yield f"data: {json.dumps({'error': str(exc)})}\n\n"
+            yield f"data: {json.dumps({'error': str(exc), 'done': True})}\n\n"
+        finally:
+            producer.cancel()
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 

--- a/server/tests/e2e/test_chat_endpoints.py
+++ b/server/tests/e2e/test_chat_endpoints.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import AsyncIterator
+from unittest.mock import patch
 from uuid import uuid4
 
 from httpx import AsyncClient
@@ -215,6 +217,43 @@ class TestChatEndpoints:
             first_chunk = done_events[0]["chunks"][0]
             assert "content" in first_chunk
             assert "document_file_name" in first_chunk
+
+    async def test_stream_message_emits_error_event_with_done_on_llm_failure(
+        self, client: AsyncClient
+    ) -> None:
+        # Given
+        headers, project_id = await self._create_project(client)
+
+        async def failing_execute_stream(self: object, **kwargs: object) -> AsyncIterator[object]:
+            raise LLMGenerationError("LLM unavailable")
+            yield  # makes this an async generator (unreachable)
+
+        with patch(
+            "raggae.application.use_cases.chat.send_message.SendMessage.execute_stream",
+            new=failing_execute_stream,
+        ):
+            # When
+            async with client.stream(
+                "POST",
+                f"/api/v1/projects/{project_id}/chat/messages/stream",
+                json={"message": "hello", "limit": 3},
+                headers=headers,
+            ) as response:
+                payload = ""
+                async for chunk in response.aiter_text():
+                    payload += chunk
+
+        # Then
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        data_events = [
+            line.removeprefix("data: ").strip() for line in payload.splitlines() if line.startswith("data: ")
+        ]
+        parsed_events = [json.loads(raw) for raw in data_events if raw]
+        error_events = [e for e in parsed_events if "error" in e]
+        assert len(error_events) == 1
+        assert error_events[0]["done"] is True
+        assert "LLM unavailable" in error_events[0]["error"]
 
     async def test_stream_message_other_user_project_returns_404(
         self,

--- a/server/tests/e2e/test_stats_endpoints.py
+++ b/server/tests/e2e/test_stats_endpoints.py
@@ -105,9 +105,7 @@ class TestStatsEndpoints:
         assert "multi_turn_conversations_rate_percent" in impact
         assert "average_sources_per_answer" in impact
 
-    async def test_e2e_stats_north_star_equals_reliable_answers_total(
-        self, client: AsyncClient
-    ) -> None:
+    async def test_e2e_stats_north_star_equals_reliable_answers_total(self, client: AsyncClient) -> None:
         # Given
         headers = await self._auth_headers(client)
 
@@ -118,9 +116,7 @@ class TestStatsEndpoints:
         data = response.json()
         assert data["north_star_reliable_answers"] == data["impact"]["reliable_answers_total"]
 
-    async def test_e2e_stats_returns_zero_values_on_empty_database(
-        self, client: AsyncClient
-    ) -> None:
+    async def test_e2e_stats_returns_zero_values_on_empty_database(self, client: AsyncClient) -> None:
         # Given — empty in-memory database (default test setup)
         headers = await self._auth_headers(client)
 


### PR DESCRIPTION
## Problème

La génération SSE présentait plusieurs fragilités : stream non fermé après erreur backend, aucun keepalive pour les proxies lents, indicateur visuel invisible avant le premier token, fallback non-stream dangereux (risque de doublon), et pas de possibilité d'annuler.

## Solution

Corrections ciblées sur les points critiques de l'issue #38 (hors refactoring execute/execute_stream, hors timeout explicite).

## Implémentation

**Backend (`chat.py`) :**
- Chaque `except` émet désormais `{"error": "...", "done": true}` — le client sait que le stream est terminé
- Keepalive via `asyncio.Queue` + `asyncio.wait_for(timeout=15s)` : un `{"ping": true}` est émis toutes les 15s si aucun token n'arrive, maintenant la connexion sur nginx/Vercel

**Frontend :**
- `api.ts` : ajout de `StreamErrorEvent` et `StreamPingEvent` dans `StreamEvent`
- `chat.ts` : `streamMessage()` accepte un `AbortSignal` optionnel ; détecte `{"error": ...}` et lève `StreamServerError` ; ignore les pings ; expose `StreamAbortedError` pour distinguer annulation et erreur
- `use-chat.ts` : `AbortController` par appel ; fallback `sendMessage()` supprimé ; `cancel()` exposé ; erreur affichée dans l'état (`error`)
- `chat-panel.tsx` : condition `StreamingIndicator` corrigée (`sending || (streaming && pas de tokens)`) ; message d'erreur affiché ; `onStop={cancel}` passé à `MessageInput`
- `message-input.tsx` : prop `onStop` ajouté ; le bouton carré appelle `onStop` au lieu de `onSend` quand `isThinking`

## Recette

1. Envoyer un message dans un projet — vérifier que l'indicateur "..." apparaît immédiatement et persiste jusqu'au premier token
2. Cliquer sur le bouton carré pendant la génération — vérifier que la génération s'arrête
3. Simuler une erreur backend (ex. désactiver le LLM) — vérifier qu'un message d'erreur s'affiche et que l'UI ne reste pas bloquée
4. Vérifier qu'aucun doublon de message n'est créé en cas d'erreur réseau