### PR TITLE
feat(sidebar): sélecteur de projet pour démarrer une nouvelle conversation

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -534,6 +534,8 @@
     "noProjects": "No projects",
     "projectMenu": "Project menu {projectName}",
     "newConversation": "New conversation",
+    "searchProjects": "Search a project...",
+    "noProjectsFound": "No project found",
     "chat": "Chat",
     "settings": "Settings",
     "snapshots": "History",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -534,6 +534,8 @@
     "noProjects": "Aucun projet",
     "projectMenu": "Menu du projet {projectName}",
     "newConversation": "Nouvelle conversation",
+    "searchProjects": "Rechercher un projet...",
+    "noProjectsFound": "Aucun projet trouvé",
     "chat": "Chat",
     "settings": "Paramètres",
     "snapshots": "Historique",

--- a/client/src/components/organisms/sidebar/new-conversation-picker.tsx
+++ b/client/src/components/organisms/sidebar/new-conversation-picker.tsx
@@ -74,8 +74,8 @@ export function NewConversationPicker({ showIcon = false }: NewConversationPicke
                 className={cn(
                   "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
                   isCurrent
-                    ? "bg-accent text-accent-foreground font-medium"
-                    : "hover:bg-accent hover:text-accent-foreground",
+                    ? "bg-accent text-accent-foreground font-medium cursor-pointer"
+                    : "hover:bg-accent hover:text-accent-foreground cursor-pointer",
                 )}
                 aria-label={project.name}
               >

--- a/client/src/components/organisms/sidebar/new-conversation-picker.tsx
+++ b/client/src/components/organisms/sidebar/new-conversation-picker.tsx
@@ -41,7 +41,7 @@ export function NewConversationPicker({ showIcon = false }: NewConversationPicke
         <button
           type="button"
           className={cn(
-            "flex w-full items-center gap-3 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            "flex w-full cursor-pointer items-center gap-3 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
             "text-muted-foreground hover:bg-muted hover:text-foreground",
           )}
           aria-label={t("newConversation")}

--- a/client/src/components/organisms/sidebar/new-conversation-picker.tsx
+++ b/client/src/components/organisms/sidebar/new-conversation-picker.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Check, MessageSquarePlus, Search } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import { useSidebarData } from "./use-sidebar-data";
+
+interface NewConversationPickerProps {
+  showIcon?: boolean;
+}
+
+export function NewConversationPicker({ showIcon = false }: NewConversationPickerProps) {
+  const t = useTranslations("sidebar");
+  const router = useRouter();
+  const pathname = usePathname();
+  const { allProjects } = useSidebarData();
+
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const currentProjectId = pathname.match(/^\/projects\/([^/]+)/)?.[1] ?? null;
+
+  const filteredProjects = allProjects.filter((p) =>
+    p.name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  function handleSelect(projectId: string) {
+    router.push(`/projects/${projectId}/chat`);
+    setOpen(false);
+    setSearch("");
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex w-full items-center gap-3 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+            "text-muted-foreground hover:bg-muted hover:text-foreground",
+          )}
+          aria-label={t("newConversation")}
+        >
+          {showIcon && <MessageSquarePlus size={16} />}
+          {t("newConversation")}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 p-2" align="start">
+        <div className="mb-1 flex items-center gap-2 rounded-md border px-2 py-1">
+          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("searchProjects")}
+            className="h-6 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+          />
+        </div>
+        <ScrollArea className="max-h-60">
+          {filteredProjects.length === 0 && (
+            <p className="px-2 py-1.5 text-xs text-muted-foreground">{t("noProjectsFound")}</p>
+          )}
+          {filteredProjects.map((project) => {
+            const isCurrent = project.id === currentProjectId;
+            return (
+              <button
+                key={project.id}
+                type="button"
+                onClick={() => handleSelect(project.id)}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm",
+                  isCurrent
+                    ? "bg-accent text-accent-foreground font-medium"
+                    : "hover:bg-accent hover:text-accent-foreground",
+                )}
+                aria-label={project.name}
+              >
+                {isCurrent ? (
+                  <Check className="h-3 w-3 shrink-0" />
+                ) : (
+                  <span className="h-3 w-3 shrink-0" />
+                )}
+                <span className="truncate">{project.name}</span>
+              </button>
+            );
+          })}
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/client/src/components/organisms/sidebar/sidebar-nav.tsx
+++ b/client/src/components/organisms/sidebar/sidebar-nav.tsx
@@ -3,6 +3,7 @@
 import { Building2, FolderOpen, Mail } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { SidebarNavLink } from "@/components/atoms/sidebar/sidebar-nav-link";
+import { NewConversationPicker } from "./new-conversation-picker";
 
 interface SidebarNavProps {
   showIcons?: boolean;
@@ -20,6 +21,7 @@ export function SidebarNav({ showIcons = false, matchPrefix = false }: SidebarNa
 
   return (
     <div className="space-y-1">
+      <NewConversationPicker showIcon={showIcons} />
       {navItems.map((item) => (
         <SidebarNavLink
           key={item.href}

--- a/client/src/components/organisms/sidebar/use-sidebar-data.ts
+++ b/client/src/components/organisms/sidebar/use-sidebar-data.ts
@@ -64,6 +64,7 @@ export function useSidebarData() {
 
   return {
     personalProjects,
+    allProjects,
     isLoadingProjects,
     sortedOrganizations,
     organizationProjectsMap,

--- a/client/src/components/ui/popover.tsx
+++ b/client/src/components/ui/popover.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground z-50 w-72 rounded-md border p-0 shadow-md outline-none",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/client/tests/components/organisms/sidebar/new-conversation-picker.test.tsx
+++ b/client/tests/components/organisms/sidebar/new-conversation-picker.test.tsx
@@ -1,0 +1,102 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NewConversationPicker } from "@/components/organisms/sidebar/new-conversation-picker";
+import { renderWithProviders } from "../../../helpers/render";
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+const mockPush = vi.fn();
+let mockPathname = "/projects";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/components/organisms/sidebar/use-sidebar-data", () => ({
+  useSidebarData: () => ({
+    allProjects: [
+      { id: "proj-1", name: "Alpha Project", organization_id: null },
+      { id: "proj-2", name: "Beta Project", organization_id: "org-1" },
+    ],
+    personalProjects: [],
+    isLoadingProjects: false,
+    sortedOrganizations: [],
+    organizationProjectsMap: new Map(),
+    editableOrganizationIds: new Set(),
+  }),
+}));
+
+describe("NewConversationPicker", () => {
+  it("should render the trigger button", () => {
+    renderWithProviders(<NewConversationPicker />);
+    expect(
+      screen.getByRole("button", { name: /new conversation/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should open the project list on trigger click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationPicker />);
+
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /alpha project/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /beta project/i })).toBeInTheDocument();
+  });
+
+  it("should filter projects by search text", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationPicker />);
+
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+    await user.type(screen.getByRole("textbox"), "alpha");
+
+    expect(screen.getByRole("button", { name: /alpha project/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /beta project/i })).not.toBeInTheDocument();
+  });
+
+  it("should show empty message when no project matches the filter", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationPicker />);
+
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+    await user.type(screen.getByRole("textbox"), "zzz");
+
+    expect(screen.queryByRole("button", { name: /alpha project/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/no project found/i)).toBeInTheDocument();
+  });
+
+  it("should navigate to /projects/{id}/chat on project click and close the popover", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationPicker />);
+
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+    await user.click(screen.getByRole("button", { name: /alpha project/i }));
+
+    expect(mockPush).toHaveBeenCalledWith("/projects/proj-1/chat");
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  it("should highlight the current project when pathname matches", async () => {
+    mockPathname = "/projects/proj-1/chat";
+    const user = userEvent.setup();
+    renderWithProviders(<NewConversationPicker />);
+
+    await user.click(screen.getByRole("button", { name: /new conversation/i }));
+
+    const alphaBtn = screen.getByRole("button", { name: /alpha project/i });
+    expect(alphaBtn).toHaveClass("bg-accent");
+    const betaBtn = screen.getByRole("button", { name: /beta project/i });
+    expect(betaBtn).not.toHaveClass("bg-accent");
+
+    mockPathname = "/projects";
+  });
+});

--- a/client/tests/components/organisms/sidebar/sidebar-nav.test.tsx
+++ b/client/tests/components/organisms/sidebar/sidebar-nav.test.tsx
@@ -5,6 +5,18 @@ import { renderWithProviders } from "../../../helpers/render";
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/projects",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/components/organisms/sidebar/use-sidebar-data", () => ({
+  useSidebarData: () => ({
+    allProjects: [],
+    personalProjects: [],
+    isLoadingProjects: false,
+    sortedOrganizations: [],
+    organizationProjectsMap: new Map(),
+    editableOrganizationIds: new Set(),
+  }),
 }));
 
 describe("SidebarNav", () => {
@@ -19,5 +31,12 @@ describe("SidebarNav", () => {
     renderWithProviders(<SidebarNav />);
     expect(screen.getByRole("link", { name: /projects/i })).toHaveClass("bg-primary/10");
     expect(screen.getByRole("link", { name: /organizations/i })).not.toHaveClass("bg-primary/10");
+  });
+
+  it("should render the new conversation picker button", () => {
+    renderWithProviders(<SidebarNav />);
+    expect(
+      screen.getByRole("button", { name: /new conversation/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/client/tests/components/organisms/sidebar/sidebar.test.tsx
+++ b/client/tests/components/organisms/sidebar/sidebar.test.tsx
@@ -15,6 +15,10 @@ vi.mock("@/components/organisms/sidebar/use-sidebar-data", () => ({
       { id: "proj-1", name: "Project One", organization_id: null },
       { id: "proj-2", name: "Project Two", organization_id: null },
     ],
+    allProjects: [
+      { id: "proj-1", name: "Project One", organization_id: null },
+      { id: "proj-2", name: "Project Two", organization_id: null },
+    ],
     isLoadingProjects: false,
     sortedOrganizations: [],
     organizationProjectsMap: new Map(),

--- a/client/tests/components/organisms/sidebar/use-sidebar-data.test.tsx
+++ b/client/tests/components/organisms/sidebar/use-sidebar-data.test.tsx
@@ -69,4 +69,12 @@ describe("useSidebarData", () => {
     const { result } = renderHook(() => useSidebarData());
     expect(result.current.isLoadingProjects).toBe(false);
   });
+
+  it("should return allProjects merging personal and org projects", () => {
+    const { result } = renderHook(() => useSidebarData());
+    // personal: p1 | org projects mocked as [] → allProjects = [p1]
+    expect(result.current.allProjects).toBeDefined();
+    expect(result.current.allProjects).toHaveLength(1);
+    expect(result.current.allProjects[0].id).toBe("p1");
+  });
 });


### PR DESCRIPTION
## Problème

Il n'existait aucun raccourci dans la sidebar pour démarrer une nouvelle conversation sans naviguer manuellement dans un projet.

## Solution

Ajout d'un bouton « Nouvelle conversation » en tête de la sidebar principale, qui ouvre un popover permettant de sélectionner le projet cible. Si l'utilisateur est déjà dans un projet, ce dernier est mis en évidence dans la liste.

## Implémentation

- **`use-sidebar-data.ts`** : expose `allProjects` (fusion projets personnels + organisations)
- **`components/ui/popover.tsx`** : atome Popover shadcn/Radix (manquant)
- **`new-conversation-picker.tsx`** : organisme auto-suffisant — popover avec filtre texte, highlight du projet courant via `usePathname()`, navigation vers `/projects/{id}/chat`
- **`sidebar-nav.tsx`** : intègre `NewConversationPicker` en tête (desktop + mobile automatiquement)
- **`messages/fr.json` + `en.json`** : clés `searchProjects` et `noProjectsFound`

Tous les composants suivent l'atomic design existant. TDD strict appliqué (RED → GREEN sur chaque composant).

## Recette

1. Ouvrir la sidebar
2. Cliquer sur « Nouvelle conversation » → le popover s'affiche avec la liste des projets
3. Saisir du texte → la liste se filtre en temps réel
4. Cliquer sur un projet → navigation vers `/projects/{id}/chat`
5. Depuis `/projects/{id}/...` → le projet courant est mis en évidence avec une coche
6. Sans projet disponible → message « Aucun projet trouvé »