### PR TITLE
feat(templates): description + CTA sur les pages projets et organisations

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -119,6 +119,7 @@
   },
   "projects": {
     "title": "Projects",
+    "description": "Create and manage your RAG agents.",
     "new": "New project",
     "empty": "No projects yet.",
     "namePlaceholder": "Project name",
@@ -344,6 +345,7 @@
   },
   "organizations": {
     "title": "Organizations",
+    "description": "Manage your teams and shared workspaces.",
     "new": "New organization",
     "list": {
       "createTitle": "Create organization",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -119,6 +119,7 @@
   },
   "projects": {
     "title": "Projets",
+    "description": "Créez et gérez vos agents RAG.",
     "new": "Nouveau projet",
     "empty": "Aucun projet pour le moment.",
     "namePlaceholder": "Nom du projet",
@@ -344,6 +345,7 @@
   },
   "organizations": {
     "title": "Organisations",
+    "description": "Gérez vos équipes et espaces de travail partagés.",
     "new": "Nouvelle organisation",
     "list": {
       "createTitle": "Créer une organisation",

--- a/client/src/components/organisms/organization/organization-list.tsx
+++ b/client/src/components/organisms/organization/organization-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useQueries } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
@@ -13,7 +14,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,6 +25,8 @@ import { useCreateOrganization, useOrganizations } from "@/lib/hooks/use-organiz
 export function OrganizationList() {
   const t = useTranslations("organizations");
   const tCommon = useTranslations("common");
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { token, user } = useAuth();
   const { data, isLoading, error } = useOrganizations();
   const sortedOrganizations = [...(data ?? [])].sort((a, b) =>
@@ -47,7 +49,9 @@ export function OrganizationList() {
       .map((organization) => organization.id),
   );
   const createOrganization = useCreateOrganization();
+  const shouldOpenFromQuery = searchParams.get("create") === "1";
   const [open, setOpen] = useState(false);
+  const effectiveOpen = open || shouldOpenFromQuery;
   const [name, setName] = useState("");
   const [slug, setSlug] = useState("");
   const [description, setDescription] = useState("");
@@ -67,10 +71,15 @@ export function OrganizationList() {
 
   return (
     <div className="space-y-6">
-      <Dialog open={open} onOpenChange={setOpen}>
-        <DialogTrigger asChild>
-          <Button>{t("list.createTitle")}</Button>
-        </DialogTrigger>
+      <Dialog
+        open={effectiveOpen}
+        onOpenChange={(isOpen) => {
+          setOpen(isOpen);
+          if (!isOpen && shouldOpenFromQuery) {
+            router.replace("/organizations");
+          }
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>{t("list.createTitle")}</DialogTitle>
@@ -109,6 +118,7 @@ export function OrganizationList() {
                   {
                     onSuccess: () => {
                       setOpen(false);
+                      if (shouldOpenFromQuery) router.replace("/organizations");
                       setName("");
                       setSlug("");
                       setDescription("");

--- a/client/src/components/organisms/project/project-list.tsx
+++ b/client/src/components/organisms/project/project-list.tsx
@@ -11,7 +11,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -54,20 +53,16 @@ export function ProjectList() {
 
   return (
     <div>
-      <div className="mb-6 flex justify-end">
-        <Dialog
-          open={effectiveCreateOpen}
-          onOpenChange={(open) => {
-            setCreateOpen(open);
-            if (!open && shouldOpenFromQuery) {
-              router.replace("/projects");
-            }
-          }}
-        >
-          <DialogTrigger asChild>
-            <Button>{t("new")}</Button>
-          </DialogTrigger>
-          <DialogContent>
+      <Dialog
+        open={effectiveCreateOpen}
+        onOpenChange={(open) => {
+          setCreateOpen(open);
+          if (!open && shouldOpenFromQuery) {
+            router.replace("/projects");
+          }
+        }}
+      >
+        <DialogContent>
             <DialogHeader>
               <DialogTitle>{t("list.createTitle")}</DialogTitle>
             </DialogHeader>
@@ -119,9 +114,8 @@ export function ProjectList() {
                 {createProject.isPending ? tCommon("creating") : t("list.createTitle")}
               </Button>
             </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
+        </DialogContent>
+      </Dialog>
 
       {projects && projects.length === 0 ? (
         <div className="text-center py-12">

--- a/client/src/components/templates/organization/organizations-template.tsx
+++ b/client/src/components/templates/organization/organizations-template.tsx
@@ -1,13 +1,24 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
 import { PageTemplate } from "@/components/templates/page-template";
 import { OrganizationList } from "@/components/organisms/organization/organization-list";
 
 export function OrganizationsTemplate() {
   const t = useTranslations("organizations");
+  const router = useRouter();
   return (
-    <PageTemplate title={t("title")}>
+    <PageTemplate
+      title={t("title")}
+      description={t("description")}
+      actions={
+        <Button onClick={() => router.push("/organizations?create=1")}>
+          {t("new")}
+        </Button>
+      }
+    >
       <OrganizationList />
     </PageTemplate>
   );

--- a/client/src/components/templates/project/projects-template.tsx
+++ b/client/src/components/templates/project/projects-template.tsx
@@ -1,13 +1,24 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
 import { PageTemplate } from "@/components/templates/page-template";
 import { ProjectList } from "@/components/organisms/project/project-list";
 
 export function ProjectsTemplate() {
   const t = useTranslations("projects");
+  const router = useRouter();
   return (
-    <PageTemplate title={t("title")}>
+    <PageTemplate
+      title={t("title")}
+      description={t("description")}
+      actions={
+        <Button onClick={() => router.push("/projects?create=1")}>
+          {t("new")}
+        </Button>
+      }
+    >
       <ProjectList />
     </PageTemplate>
   );

--- a/client/tests/components/organisms/organization/organization-list.test.tsx
+++ b/client/tests/components/organisms/organization/organization-list.test.tsx
@@ -11,8 +11,9 @@ vi.mock("@/lib/hooks/use-auth", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
   usePathname: () => "/organizations",
+  useSearchParams: () => ({ get: () => null }),
 }));
 
 const mockOrgs = [
@@ -40,15 +41,17 @@ describe("OrganizationList", () => {
     expect(await screen.findByText(/no organizations/i)).toBeInTheDocument();
   });
 
-  it("should open create dialog when button is clicked", async () => {
+  it("should open create dialog when ?create=1 is in the URL", async () => {
+    vi.mock("next/navigation", () => ({
+      useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+      usePathname: () => "/organizations",
+      useSearchParams: () => ({ get: (key: string) => (key === "create" ? "1" : null) }),
+    }));
     server.use(
       http.get("/api/v1/organizations", () => HttpResponse.json(mockOrgs)),
       http.get("/api/v1/organizations/:id/members", () => HttpResponse.json([])),
     );
-    const user = userEvent.setup();
     renderWithProviders(<OrganizationList />);
-    await screen.findByText("Alpha Corp");
-    await user.click(screen.getByRole("button", { name: /create/i }));
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 });

--- a/client/tests/components/organisms/project/project-list.test.tsx
+++ b/client/tests/components/organisms/project/project-list.test.tsx
@@ -68,14 +68,15 @@ describe("ProjectList", () => {
     expect(await screen.findByText(/no projects yet/i)).toBeInTheDocument();
   });
 
-  it("should open create dialog when 'New project' button is clicked", async () => {
+  it("should open create dialog when ?create=1 is in the URL", async () => {
+    vi.mock("next/navigation", () => ({
+      useRouter: () => ({ push: mockPush, replace: mockReplace }),
+      useSearchParams: () => ({ get: (key: string) => (key === "create" ? "1" : null) }),
+    }));
     server.use(
       http.get("/api/v1/projects", () => HttpResponse.json(mockProjects)),
     );
-    const user = userEvent.setup();
     renderWithProviders(<ProjectList />);
-    await screen.findByText("Alpha");
-    await user.click(screen.getByRole("button", { name: /new project/i }));
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Problème
Les pages `/projects` et `/organizations` n'avaient pas de description courte ni de bouton CTA aligné à droite du titre, contrairement à la convention `PageTemplate` (titre + description + actions).

## Solution
- Ajout des clés i18n `projects.description` et `organizations.description` (en + fr)
- Déplacement du bouton CTA ("Nouveau projet" / "Nouvelle organisation") dans le slot `actions` du `PageTemplate`
- Les Dialogs de création restent dans les organisms, déclenchés via `?create=1` (pattern déjà en place pour ProjectList, ajouté pour OrganizationList)

## Implémentation
- `messages/en.json` + `messages/fr.json` — nouvelles clés `description`
- `organisms/project/project-list.tsx` — retire le `DialogTrigger` visible, Dialog déclenché uniquement via `?create=1`
- `organisms/organization/organization-list.tsx` — ajoute support `?create=1` + retire `DialogTrigger`
- `templates/project/projects-template.tsx` — `description` + bouton `actions`
- `templates/organization/organizations-template.tsx` — `description` + bouton `actions`
- Tests organisms mis à jour (dialog via URL plutôt que via bouton inline)

## Recette
1. `/projects` — titre "Projets", description courte, bouton "Nouveau projet" à droite du titre → clique → dialog de création s'ouvre
2. `/organizations` — titre "Organisations", description courte, bouton "Nouvelle organisation" → clique → dialog s'ouvre
3. Fermer le dialog remet l'URL propre (sans `?create=1`)