### PR TITLE
fix(hooks): corriger erreur TypeScript useConversation dans chat-template

### DIFF
--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -29,7 +29,7 @@ export function useConversations(projectId: string, limit = 50) {
   });
 }
 
-export function useConversation(projectId: string, conversationId: string) {
+export function useConversation(projectId: string | undefined, conversationId: string | undefined) {
   const { token } = useAuth();
 
   return useQuery({


### PR DESCRIPTION
## Problème
La CI frontend était cassée à cause d'une erreur TypeScript dans `chat-template.tsx` : le hook `useConversation` avait une signature `(projectId: string, conversationId: string)` mais était appelé avec des valeurs potentiellement `undefined`.

## Solution
Mettre à jour la signature de `useConversation` pour accepter `string | undefined` sur les deux paramètres, en cohérence avec le guard `enabled: !!projectId && !!conversationId` déjà présent dans le corps du hook.

## Implémentation
- `client/src/lib/hooks/use-chat.ts` : signature `useConversation(projectId: string | undefined, conversationId: string | undefined)`

## Recette
- `cd client && npx vitest run` → 293 tests passent
- La CI frontend ne doit plus lever d'erreur TypeScript sur `chat-template.tsx`