### PR TITLE
feat(chat): limiter la largeur de la zone de conversation à 800px

### DIFF
--- a/client/src/components/molecules/chat/message-input.tsx
+++ b/client/src/components/molecules/chat/message-input.tsx
@@ -72,7 +72,7 @@ export function MessageInput({
           disabled={disabled}
           className={cn(
             "w-full resize-none bg-transparent pb-2",
-            "text-sm leading-relaxed placeholder:text-muted-foreground",
+            "text-base leading-relaxed placeholder:text-muted-foreground",
             "outline-none",
             "max-h-40 overflow-y-auto",
             "disabled:cursor-not-allowed disabled:opacity-50",

--- a/client/src/components/organisms/chat/chat-panel.tsx
+++ b/client/src/components/organisms/chat/chat-panel.tsx
@@ -146,7 +146,7 @@ export function ChatPanel({
         />
 
         <div className="absolute bottom-0 left-0 right-0 z-10 bg-background">
-          <div className="mx-auto w-full max-w-[800px] px-4">
+          <div className="mx-auto w-full max-w-190 px-4">
           <SourcesBar sources={streamedSourceDocuments} onSourceClick={handleSourceClick} />
           {disabled && (
             <p className="mb-2 text-xs text-amber-700">

--- a/client/src/components/organisms/chat/chat-panel.tsx
+++ b/client/src/components/organisms/chat/chat-panel.tsx
@@ -145,7 +145,8 @@ export function ChatPanel({
           onSourceClick={handleSourceClick}
         />
 
-        <div className="absolute bottom-0 left-0 right-0 z-10 px-4 bg-background">
+        <div className="absolute bottom-0 left-0 right-0 z-10 bg-background">
+          <div className="mx-auto w-full max-w-[800px] px-4">
           <SourcesBar sources={streamedSourceDocuments} onSourceClick={handleSourceClick} />
           {disabled && (
             <p className="mb-2 text-xs text-amber-700">
@@ -159,6 +160,7 @@ export function ChatPanel({
             isThinking={!disabled && state !== "idle"}
             hasMessages={messages.length > 0}
           />
+          </div>
         </div>
       </div>
 

--- a/client/src/components/organisms/chat/message-list.tsx
+++ b/client/src/components/organisms/chat/message-list.tsx
@@ -87,7 +87,7 @@ export function MessageList({
   return (
     <div className="relative h-full min-h-0">
       <ScrollArea className="h-full" ref={scrollRef}>
-        <div className="mx-auto w-full max-w-[800px] space-y-4 px-4 pt-4 pb-36">
+        <div className="mx-auto w-full max-w-190 space-y-4 px-4 pt-4 pb-36">
           {messages.map((msg) => (
             <div key={msg.id} className="space-y-2">
               <MessageBubble

--- a/client/src/components/organisms/chat/message-list.tsx
+++ b/client/src/components/organisms/chat/message-list.tsx
@@ -87,7 +87,7 @@ export function MessageList({
   return (
     <div className="relative h-full min-h-0">
       <ScrollArea className="h-full" ref={scrollRef}>
-        <div className="space-y-4 px-8 pt-4 pb-36">
+        <div className="mx-auto w-full max-w-[800px] space-y-4 px-4 pt-4 pb-36">
           {messages.map((msg) => (
             <div key={msg.id} className="space-y-2">
               <MessageBubble

--- a/client/src/components/templates/workspace-template.tsx
+++ b/client/src/components/templates/workspace-template.tsx
@@ -13,7 +13,7 @@ type WorkspaceTemplateProps = {
 
 export function WorkspaceTemplate({ breadcrumb, actions, children }: WorkspaceTemplateProps) {
   return (
-    <div className="-m-6 flex h-[calc(100vh-3.5rem)] flex-col">
+    <div className="-m-6 flex h-screen flex-col">
       <div className="flex h-14 shrink-0 items-center justify-between border-b px-6">
         <div className="flex items-center gap-2 text-sm">
           {breadcrumb.map((item, index) => (


### PR DESCRIPTION
## Problème
La zone de messages et le champ de saisie s'étendaient sur toute la largeur disponible, rendant la lecture inconfortable sur grands écrans.

## Solution
Centrer le contenu de la conversation avec une largeur maximale de 800px, en s'inspirant du design de Claude.

## Implémentation
- `organisms/chat/message-list.tsx` : ajout de `mx-auto w-full max-w-[800px]` sur le conteneur des messages
- `organisms/chat/chat-panel.tsx` : ajout d'un wrapper `mx-auto w-full max-w-[800px]` autour de la barre de sources et du `MessageInput`

## Recette
- Naviguer sur `/projects/:id/chat`
- Vérifier que les messages et l'input sont centrés et ne dépassent pas 800px de large
- Vérifier que la mise en page reste correcte sur petits écrans (responsive)