### PR TITLE
feat(projects): ajouter un menu contextuel (...) pour accéder aux paramètres d'un projet

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -131,7 +131,8 @@
       "createFirst": "Create your first project"
     },
     "card": {
-      "created": "Created"
+      "created": "Created",
+      "settings": "Settings"
     },
     "page": {
       "chatTitle": "Chat",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -131,7 +131,8 @@
       "createFirst": "Créer votre premier projet"
     },
     "card": {
-      "created": "Créé le"
+      "created": "Créé le",
+      "settings": "Paramètres"
     },
     "page": {
       "chatTitle": "Chat",

--- a/client/src/components/molecules/project/project-card.tsx
+++ b/client/src/components/molecules/project/project-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { MoreVertical, Settings } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   Card,
@@ -8,6 +10,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
 import type { ProjectResponse } from "@/lib/types/api";
 import { formatDate } from "@/lib/utils/format";
 
@@ -18,20 +27,44 @@ interface ProjectCardProps {
 export function ProjectCard({ project }: ProjectCardProps) {
   const t = useTranslations("projects");
   const tCommon = useTranslations("common");
+  const router = useRouter();
 
   return (
-    <Link href={`/projects/${project.id}/chat`} className="h-full">
-      <Card className="h-full transition-colors hover:bg-muted/50">
-        <CardHeader className="flex h-full flex-col">
-          <CardTitle className="text-lg">{project.name}</CardTitle>
-          <CardDescription className="line-clamp-3">
-            {project.description || tCommon("noDescription")}
-          </CardDescription>
-          <p className="mt-auto pt-2 text-xs text-muted-foreground">
-            {t("card.created")} {formatDate(project.created_at)}
-          </p>
-        </CardHeader>
-      </Card>
-    </Link>
+    <div className="relative h-full">
+      <Link href={`/projects/${project.id}/chat`} className="h-full">
+        <Card className="h-full transition-colors hover:bg-muted/50">
+          <CardHeader className="flex h-full flex-col pr-10">
+            <CardTitle className="text-lg">{project.name}</CardTitle>
+            <CardDescription className="line-clamp-3">
+              {project.description || tCommon("noDescription")}
+            </CardDescription>
+            <p className="mt-auto pt-2 text-xs text-muted-foreground">
+              {t("card.created")} {formatDate(project.created_at)}
+            </p>
+          </CardHeader>
+        </Card>
+      </Link>
+
+      <div className="absolute right-2 top-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={(e) => e.preventDefault()}
+            >
+              <MoreVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => router.push(`/projects/${project.id}/settings`)}>
+              <Settings className="mr-2 size-4" />
+              {t("card.settings")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Problème
Depuis la page /projects, il n'était pas possible d'accéder aux paramètres d'un projet sans passer par la page chat.

## Solution
Ajouter un menu contextuel (⋮) en overlay dans le coin supérieur droit de chaque ProjectCard, avec un item « Paramètres » qui navigue vers `/projects/:id/settings`.

## Implémentation
- `molecules/project/project-card.tsx` : restructuration pour isoler le `Link` du bouton menu ; ajout d'un `DropdownMenu` avec `MoreVertical` et un item Settings
- `messages/en.json` + `messages/fr.json` : ajout de la clé `projects.card.settings`

## Recette
- Naviguer sur `/projects`
- Survoler une carte projet → le bouton ⋮ apparaît en haut à droite
- Cliquer sur ⋮ → menu avec « Paramètres »
- Cliquer sur « Paramètres » → redirection vers `/projects/:id/settings`
- Cliquer ailleurs sur la carte → redirection vers `/projects/:id/chat` (comportement inchangé)