### PR TITLE
fix(project): autoriser le PATCH partiel d'un projet

### DIFF
--- a/server/src/raggae/application/use_cases/project/update_project.py
+++ b/server/src/raggae/application/use_cases/project/update_project.py
@@ -98,9 +98,9 @@ class UpdateProject:
         self,
         project_id: UUID,
         user_id: UUID,
-        name: str,
-        description: str,
-        system_prompt: str,
+        name: str | None = None,
+        description: str | None = None,
+        system_prompt: str | None = None,
         chunking_strategy: ChunkingStrategy | None = None,
         parent_child_chunking: bool | None = None,
         embedding_backend: str | None = None,
@@ -121,7 +121,7 @@ class UpdateProject:
         reranker_model: str | None = None,
         reranker_candidate_multiplier: int | None = None,
     ) -> ProjectDTO:
-        if len(system_prompt) > MAX_PROJECT_SYSTEM_PROMPT_LENGTH:
+        if system_prompt is not None and len(system_prompt) > MAX_PROJECT_SYSTEM_PROMPT_LENGTH:
             raise ProjectSystemPromptTooLongError(
                 f"System prompt exceeds {MAX_PROJECT_SYSTEM_PROMPT_LENGTH} characters"
             )
@@ -274,9 +274,9 @@ class UpdateProject:
         next_reranker_backend = project.reranker_backend if reranker_backend is None else reranker_backend
         updated_project = replace(
             project,
-            name=name,
-            description=description,
-            system_prompt=system_prompt,
+            name=project.name if name is None else name,
+            description=project.description if description is None else description,
+            system_prompt=project.system_prompt if system_prompt is None else system_prompt,
             chunking_strategy=project.chunking_strategy if chunking_strategy is None else chunking_strategy,
             parent_child_chunking=project.parent_child_chunking
             if parent_child_chunking is None

--- a/server/src/raggae/presentation/api/v1/schemas/project_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/project_schemas.py
@@ -67,9 +67,9 @@ class CreateProjectRequest(BaseModel):
 
 
 class UpdateProjectRequest(BaseModel):
-    name: str = Field(..., min_length=1)
-    description: str = ""
-    system_prompt: str = Field(default="", max_length=MAX_PROJECT_SYSTEM_PROMPT_LENGTH)
+    name: str | None = Field(default=None, min_length=1)
+    description: str | None = None
+    system_prompt: str | None = Field(default=None, max_length=MAX_PROJECT_SYSTEM_PROMPT_LENGTH)
     chunking_strategy: ChunkingStrategy | None = None
     parent_child_chunking: bool | None = None
     embedding_backend: str | None = None

--- a/server/tests/unit/application/use_cases/project/test_update_project.py
+++ b/server/tests/unit/application/use_cases/project/test_update_project.py
@@ -1198,3 +1198,35 @@ class TestUpdateProject:
 
         # Then — update works even without snapshot repo
         assert result.name == "New name"
+
+    async def test_update_project_partial_only_system_prompt_keeps_other_fields(
+        self,
+        use_case: UpdateProject,
+        mock_project_repository: AsyncMock,
+    ) -> None:
+        # Given
+        project_id = uuid4()
+        user_id = uuid4()
+        project = Project(
+            id=project_id,
+            user_id=user_id,
+            name="Original name",
+            description="Original description",
+            system_prompt="Original prompt",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+        mock_project_repository.find_by_id.return_value = project
+
+        # When — only system_prompt is provided
+        result = await use_case.execute(
+            project_id=project_id,
+            user_id=user_id,
+            system_prompt="Updated prompt",
+        )
+
+        # Then — name and description are preserved
+        assert result.system_prompt == "Updated prompt"
+        assert result.name == "Original name"
+        assert result.description == "Original description"
+        mock_project_repository.save.assert_called_once()


### PR DESCRIPTION
## Problème

Depuis la décomposition des settings en organisms autonomes (`ProjectInstructionsPanel`, `ProjectGeneralPanel`, `ProjectAdvancedPanel`), chaque panneau n'envoie plus que les champs qu'il gère lors du PATCH. Par exemple, `ProjectInstructionsPanel` envoie uniquement `{ system_prompt: "..." }`.

Le backend retournait 422 car :
- `UpdateProjectRequest.name` était déclaré requis (`Field(..., min_length=1)`)
- `UpdateProject.execute()` exigeait `name: str` et `description: str` comme arguments positionnels
- L'absence de ces champs dans la requête partielle déclenchait la validation Pydantic avant même d'atteindre le use case

## Solution

Rendre les champs `name`, `description` et `system_prompt` optionnels (`| None = None`) dans le schéma Pydantic et dans le use case. Quand un champ est `None`, la valeur existante du projet est conservée (pattern "merge patch").

## Implémentation

- `server/src/raggae/presentation/api/v1/schemas/project_schemas.py` : `UpdateProjectRequest.name`, `.description`, `.system_prompt` → `... | None = None`
- `server/src/raggae/application/use_cases/project/update_project.py` : signature de `execute()` rendue optionnelle + `replace()` utilise les valeurs courantes quand `None` + validation `system_prompt` uniquement si non-`None`
- `server/tests/unit/application/use_cases/project/test_update_project.py` : nouveau test `test_update_project_partial_only_system_prompt_keeps_other_fields`

## Recette

1. Ouvrir les settings d'un projet → onglet **Instructions**
2. Modifier le system prompt et cliquer **Save**
3. Vérifier qu'il n'y a plus d'erreur 422
4. Vérifier que le nom et la description du projet sont inchangés après la sauvegarde