### PR TITLE
feat(conversations): page de liste des conversations et menu contextuel mobile

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -629,6 +629,7 @@
     "menuLabel": "Conversation options",
     "renameTitle": "Rename conversation",
     "deleteTitle": "Delete conversation",
-    "selectConversation": "Select {title}"
+    "selectConversation": "Select {title}",
+    "deleteError": "An error occurred while deleting some conversations."
   }
 }

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -625,6 +625,10 @@
     "selectedCount": "{count} selected",
     "deleteSelected": "Delete ({count})",
     "bulkDeleteTitle": "Delete {count} conversation(s)",
-    "bulkDeleteConfirm": "This action is irreversible. The {count} selected conversation(s) will be permanently deleted."
+    "bulkDeleteConfirm": "This action is irreversible. The {count} selected conversation(s) will be permanently deleted.",
+    "menuLabel": "Conversation options",
+    "renameTitle": "Rename conversation",
+    "deleteTitle": "Delete conversation",
+    "selectConversation": "Select {title}"
   }
 }

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -550,7 +550,8 @@
     "snapshots": "History",
     "githubProject": "GitHub project",
     "sourceCode": "Source code",
-    "stats": "Statistics"
+    "stats": "Statistics",
+    "conversations": "Conversations"
   },
   "layout": {
     "themeToggle": {
@@ -614,5 +615,11 @@
       "message": "An unexpected error occurred",
       "retry": "Try again"
     }
+  },
+  "conversations": {
+    "title": "Conversations",
+    "empty": "No conversations yet.",
+    "startNew": "Start a conversation",
+    "new": "New conversation"
   }
 }

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -620,6 +620,11 @@
     "title": "Conversations",
     "empty": "No conversations yet.",
     "startNew": "Start a conversation",
-    "new": "New conversation"
+    "new": "New conversation",
+    "selectAll": "Select all",
+    "selectedCount": "{count} selected",
+    "deleteSelected": "Delete ({count})",
+    "bulkDeleteTitle": "Delete {count} conversation(s)",
+    "bulkDeleteConfirm": "This action is irreversible. The {count} selected conversation(s) will be permanently deleted."
   }
 }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -620,6 +620,11 @@
     "title": "Conversations",
     "empty": "Aucune conversation pour le moment.",
     "startNew": "Démarrer une conversation",
-    "new": "Nouvelle conversation"
+    "new": "Nouvelle conversation",
+    "selectAll": "Tout sélectionner",
+    "selectedCount": "{count} sélectionnée(s)",
+    "deleteSelected": "Supprimer ({count})",
+    "bulkDeleteTitle": "Supprimer {count} conversation(s)",
+    "bulkDeleteConfirm": "Cette action est irréversible. Les {count} conversation(s) sélectionnée(s) seront définitivement supprimées."
   }
 }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -550,7 +550,8 @@
     "snapshots": "Historique",
     "githubProject": "Projet GitHub",
     "sourceCode": "Code source",
-    "stats": "Statistiques"
+    "stats": "Statistiques",
+    "conversations": "Conversations"
   },
   "layout": {
     "themeToggle": {
@@ -614,5 +615,11 @@
       "message": "Une erreur inattendue est survenue",
       "retry": "Réessayer"
     }
+  },
+  "conversations": {
+    "title": "Conversations",
+    "empty": "Aucune conversation pour le moment.",
+    "startNew": "Démarrer une conversation",
+    "new": "Nouvelle conversation"
   }
 }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -629,6 +629,7 @@
     "menuLabel": "Options de la conversation",
     "renameTitle": "Renommer la conversation",
     "deleteTitle": "Supprimer la conversation",
-    "selectConversation": "Sélectionner {title}"
+    "selectConversation": "Sélectionner {title}",
+    "deleteError": "Une erreur est survenue lors de la suppression de certaines conversations."
   }
 }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -625,6 +625,10 @@
     "selectedCount": "{count} sélectionnée(s)",
     "deleteSelected": "Supprimer ({count})",
     "bulkDeleteTitle": "Supprimer {count} conversation(s)",
-    "bulkDeleteConfirm": "Cette action est irréversible. Les {count} conversation(s) sélectionnée(s) seront définitivement supprimées."
+    "bulkDeleteConfirm": "Cette action est irréversible. Les {count} conversation(s) sélectionnée(s) seront définitivement supprimées.",
+    "menuLabel": "Options de la conversation",
+    "renameTitle": "Renommer la conversation",
+    "deleteTitle": "Supprimer la conversation",
+    "selectConversation": "Sélectionner {title}"
   }
 }

--- a/client/src/app/(dashboard)/projects/[projectId]/conversations/page.tsx
+++ b/client/src/app/(dashboard)/projects/[projectId]/conversations/page.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { ConversationsTemplate } from "@/components/templates/project/conversations-template";
+
+export default function ConversationsPage() {
+  const params = useParams<{ projectId: string }>();
+  return <ConversationsTemplate projectId={params.projectId} />;
+}

--- a/client/src/components/atoms/conversation/delete-conversation-dialog.tsx
+++ b/client/src/components/atoms/conversation/delete-conversation-dialog.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface DeleteConversationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}
+
+export function DeleteConversationDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+}: DeleteConversationDialogProps) {
+  const t = useTranslations("chat.sidebar");
+  const tCommon = useTranslations("common");
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{t("deleteTitle")}</DialogTitle>
+          <DialogDescription>{t("deleteConfirm")}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {tCommon("cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {tCommon("delete")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/atoms/conversation/rename-conversation-dialog.tsx
+++ b/client/src/components/atoms/conversation/rename-conversation-dialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+
+interface RenameConversationDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialTitle: string;
+  onConfirm: (title: string) => void;
+}
+
+export function RenameConversationDialog({
+  open,
+  onOpenChange,
+  initialTitle,
+  onConfirm,
+}: RenameConversationDialogProps) {
+  const [value, setValue] = useState(initialTitle);
+  const t = useTranslations("chat.sidebar");
+  const tCommon = useTranslations("common");
+
+  useEffect(() => {
+    if (open) setValue(initialTitle);
+  }, [open, initialTitle]);
+
+  function handleConfirm() {
+    const trimmed = value.trim();
+    if (trimmed) onConfirm(trimmed);
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>{t("renameTitle")}</DialogTitle>
+          <DialogDescription>{t("renameDescription")}</DialogDescription>
+        </DialogHeader>
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder={t("renamePlaceholder")}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleConfirm();
+          }}
+          autoFocus
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {tCommon("cancel")}
+          </Button>
+          <Button onClick={handleConfirm} disabled={!value.trim()}>
+            {tCommon("save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/molecules/project/conversation-page-item.tsx
+++ b/client/src/components/molecules/project/conversation-page-item.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -29,6 +30,8 @@ interface ConversationPageItemProps {
   projectId: string;
   onDelete: (id: string) => void;
   onRename: (id: string, title: string) => void;
+  isSelected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }
 
 export function ConversationPageItem({
@@ -36,6 +39,8 @@ export function ConversationPageItem({
   projectId,
   onDelete,
   onRename,
+  isSelected = false,
+  onToggleSelect,
 }: ConversationPageItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
@@ -58,7 +63,15 @@ export function ConversationPageItem({
 
   return (
     <>
-      <div className={cn("group flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50")}>
+      <div className={cn("group flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50", isSelected && "bg-muted/50 border-primary/40")}>
+        {onToggleSelect && (
+          <Checkbox
+            checked={isSelected}
+            onCheckedChange={() => onToggleSelect(conversation.id)}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Sélectionner ${title}`}
+          />
+        )}
         <Link
           href={`/projects/${projectId}/chat/${conversation.id}`}
           className="flex flex-1 items-center gap-4 min-w-0"

--- a/client/src/components/molecules/project/conversation-page-item.tsx
+++ b/client/src/components/molecules/project/conversation-page-item.tsx
@@ -31,6 +31,7 @@ interface ConversationPageItemProps {
   onDelete: (id: string) => void;
   onRename: (id: string, title: string) => void;
   isSelected?: boolean;
+  anySelected?: boolean;
   onToggleSelect?: (id: string) => void;
 }
 
@@ -40,6 +41,7 @@ export function ConversationPageItem({
   onDelete,
   onRename,
   isSelected = false,
+  anySelected = false,
   onToggleSelect,
 }: ConversationPageItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -70,11 +72,12 @@ export function ConversationPageItem({
             onCheckedChange={() => onToggleSelect(conversation.id)}
             onClick={(e) => e.stopPropagation()}
             aria-label={`Sélectionner ${title}`}
+            className={cn(!anySelected && !isSelected && "opacity-0 group-hover:opacity-100 transition-opacity")}
           />
         )}
         <Link
           href={`/projects/${projectId}/chat/${conversation.id}`}
-          className="flex flex-1 items-center gap-4 min-w-0"
+          className="flex flex-1 items-center gap-4 min-w-0 -my-3 py-3"
         >
           <span className="flex-1 truncate font-medium">{title}</span>
           <span className="shrink-0 text-xs text-muted-foreground">

--- a/client/src/components/molecules/project/conversation-page-item.tsx
+++ b/client/src/components/molecules/project/conversation-page-item.tsx
@@ -7,20 +7,13 @@ import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
+import { RenameConversationDialog } from "@/components/atoms/conversation/rename-conversation-dialog";
+import { DeleteConversationDialog } from "@/components/atoms/conversation/delete-conversation-dialog";
 import { cn } from "@/lib/utils";
 import { formatDateTime } from "@/lib/utils/format";
 import type { ConversationResponse } from "@/lib/types/api";
@@ -46,22 +39,9 @@ export function ConversationPageItem({
 }: ConversationPageItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const [renameValue, setRenameValue] = useState("");
   const t = useTranslations("chat.sidebar");
-  const tCommon = useTranslations("common");
 
   const title = conversation.title ?? formatDateTime(conversation.created_at);
-
-  function handleRenameOpen() {
-    setRenameValue(conversation.title ?? "");
-    setRenameDialogOpen(true);
-  }
-
-  function handleRenameConfirm() {
-    const trimmed = renameValue.trim();
-    if (trimmed) onRename(conversation.id, trimmed);
-    setRenameDialogOpen(false);
-  }
 
   return (
     <>
@@ -98,7 +78,7 @@ export function ConversationPageItem({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem className="cursor-pointer gap-2" onSelect={handleRenameOpen}>
+            <DropdownMenuItem className="cursor-pointer gap-2" onSelect={() => setRenameDialogOpen(true)}>
               <Pencil className="h-4 w-4" />
               {t("renameTitle")}
             </DropdownMenuItem>
@@ -113,52 +93,18 @@ export function ConversationPageItem({
         </DropdownMenu>
       </div>
 
-      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{t("renameTitle")}</DialogTitle>
-            <DialogDescription>{t("renameDescription")}</DialogDescription>
-          </DialogHeader>
-          <Input
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            placeholder={t("renamePlaceholder")}
-            onKeyDown={(e) => { if (e.key === "Enter") handleRenameConfirm(); }}
-            autoFocus
-          />
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setRenameDialogOpen(false)}>
-              {tCommon("cancel")}
-            </Button>
-            <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>
-              {tCommon("save")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <RenameConversationDialog
+        open={renameDialogOpen}
+        onOpenChange={setRenameDialogOpen}
+        initialTitle={conversation.title ?? ""}
+        onConfirm={(title) => onRename(conversation.id, title)}
+      />
 
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{t("deleteTitle")}</DialogTitle>
-            <DialogDescription>{t("deleteConfirm")}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
-              {tCommon("cancel")}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                onDelete(conversation.id);
-                setDeleteDialogOpen(false);
-              }}
-            >
-              {tCommon("delete")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteConversationDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onConfirm={() => onDelete(conversation.id)}
+      />
     </>
   );
 }

--- a/client/src/components/molecules/project/conversation-page-item.tsx
+++ b/client/src/components/molecules/project/conversation-page-item.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { formatDateTime } from "@/lib/utils/format";
+import type { ConversationResponse } from "@/lib/types/api";
+
+interface ConversationPageItemProps {
+  conversation: ConversationResponse;
+  projectId: string;
+  onDelete: (id: string) => void;
+  onRename: (id: string, title: string) => void;
+}
+
+export function ConversationPageItem({
+  conversation,
+  projectId,
+  onDelete,
+  onRename,
+}: ConversationPageItemProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [renameDialogOpen, setRenameDialogOpen] = useState(false);
+  const [renameValue, setRenameValue] = useState("");
+  const t = useTranslations("chat.sidebar");
+  const tCommon = useTranslations("common");
+
+  const title = conversation.title ?? formatDateTime(conversation.created_at);
+
+  function handleRenameOpen() {
+    setRenameValue(conversation.title ?? "");
+    setRenameDialogOpen(true);
+  }
+
+  function handleRenameConfirm() {
+    const trimmed = renameValue.trim();
+    if (trimmed) onRename(conversation.id, trimmed);
+    setRenameDialogOpen(false);
+  }
+
+  return (
+    <>
+      <div className={cn("group flex items-center gap-3 rounded-lg border px-4 py-3 transition-colors hover:bg-muted/50")}>
+        <Link
+          href={`/projects/${projectId}/chat/${conversation.id}`}
+          className="flex flex-1 items-center gap-4 min-w-0"
+        >
+          <span className="flex-1 truncate font-medium">{title}</span>
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {formatDateTime(conversation.created_at)}
+          </span>
+        </Link>
+
+        <DropdownMenu modal={false}>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100 focus:opacity-100"
+              aria-label={t("menuLabel")}
+              onClick={(e) => e.preventDefault()}
+            >
+              <MoreVertical className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem className="cursor-pointer gap-2" onSelect={handleRenameOpen}>
+              <Pencil className="h-4 w-4" />
+              {t("renameTitle")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer gap-2 text-destructive focus:text-destructive"
+              onSelect={() => setDeleteDialogOpen(true)}
+            >
+              <Trash2 className="h-4 w-4" />
+              {t("deleteTitle")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("renameTitle")}</DialogTitle>
+            <DialogDescription>{t("renameDescription")}</DialogDescription>
+          </DialogHeader>
+          <Input
+            value={renameValue}
+            onChange={(e) => setRenameValue(e.target.value)}
+            placeholder={t("renamePlaceholder")}
+            onKeyDown={(e) => { if (e.key === "Enter") handleRenameConfirm(); }}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRenameDialogOpen(false)}>
+              {tCommon("cancel")}
+            </Button>
+            <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>
+              {tCommon("save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("deleteTitle")}</DialogTitle>
+            <DialogDescription>{t("deleteConfirm")}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
+              {tCommon("cancel")}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                onDelete(conversation.id);
+                setDeleteDialogOpen(false);
+              }}
+            >
+              {tCommon("delete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/client/src/components/molecules/project/conversation-page-item.tsx
+++ b/client/src/components/molecules/project/conversation-page-item.tsx
@@ -39,7 +39,7 @@ export function ConversationPageItem({
 }: ConversationPageItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const t = useTranslations("chat.sidebar");
+  const t = useTranslations("conversations");
 
   const title = conversation.title ?? formatDateTime(conversation.created_at);
 
@@ -51,7 +51,7 @@ export function ConversationPageItem({
             checked={isSelected}
             onCheckedChange={() => onToggleSelect(conversation.id)}
             onClick={(e) => e.stopPropagation()}
-            aria-label={`Sélectionner ${title}`}
+            aria-label={t("selectConversation", { title })}
             className={cn(!anySelected && !isSelected && "opacity-0 group-hover:opacity-100 transition-opacity")}
           />
         )}

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -5,21 +5,14 @@ import { MoreVertical, Pencil, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
 import { ConversationLink, useConversationActive } from "@/components/atoms/sidebar/conversation-link";
+import { RenameConversationDialog } from "@/components/atoms/conversation/rename-conversation-dialog";
+import { DeleteConversationDialog } from "@/components/atoms/conversation/delete-conversation-dialog";
 import { cn } from "@/lib/utils";
 import type { ConversationResponse } from "@/lib/types/api";
 
@@ -33,23 +26,8 @@ interface ConversationItemProps {
 export function ConversationItem({ conversation, projectId, onDelete, onRename }: ConversationItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
-  const [renameValue, setRenameValue] = useState("");
   const isActive = useConversationActive(conversation.id);
   const t = useTranslations("chat.sidebar");
-  const tCommon = useTranslations("common");
-
-  function handleRenameOpen() {
-    setRenameValue(conversation.title ?? "");
-    setRenameDialogOpen(true);
-  }
-
-  function handleRenameConfirm() {
-    const trimmed = renameValue.trim();
-    if (trimmed) {
-      onRename(conversation.id, trimmed);
-    }
-    setRenameDialogOpen(false);
-  }
 
   return (
     <>
@@ -74,7 +52,7 @@ export function ConversationItem({ conversation, projectId, onDelete, onRename }
           <DropdownMenuContent align="end">
             <DropdownMenuItem
               className="cursor-pointer gap-2"
-              onSelect={handleRenameOpen}
+              onSelect={() => setRenameDialogOpen(true)}
             >
               <Pencil className="h-4 w-4" />
               {t("renameTitle")}
@@ -90,54 +68,18 @@ export function ConversationItem({ conversation, projectId, onDelete, onRename }
         </DropdownMenu>
       </div>
 
-      <Dialog open={renameDialogOpen} onOpenChange={setRenameDialogOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{t("renameTitle")}</DialogTitle>
-            <DialogDescription>{t("renameDescription")}</DialogDescription>
-          </DialogHeader>
-          <Input
-            value={renameValue}
-            onChange={(e) => setRenameValue(e.target.value)}
-            placeholder={t("renamePlaceholder")}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleRenameConfirm();
-            }}
-            autoFocus
-          />
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setRenameDialogOpen(false)}>
-              {tCommon("cancel")}
-            </Button>
-            <Button onClick={handleRenameConfirm} disabled={!renameValue.trim()}>
-              {tCommon("save")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <RenameConversationDialog
+        open={renameDialogOpen}
+        onOpenChange={setRenameDialogOpen}
+        initialTitle={conversation.title ?? ""}
+        onConfirm={(title) => onRename(conversation.id, title)}
+      />
 
-      <Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
-        <DialogContent showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>{t("deleteTitle")}</DialogTitle>
-            <DialogDescription>{t("deleteConfirm")}</DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)}>
-              {tCommon("cancel")}
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={() => {
-                onDelete(conversation.id);
-                setDeleteDialogOpen(false);
-              }}
-            >
-              {tCommon("delete")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+      <DeleteConversationDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+        onConfirm={() => onDelete(conversation.id)}
+      />
     </>
   );
 }

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -126,6 +126,7 @@ export function ConversationList({ projectId }: ConversationListProps) {
                 onDelete={handleDelete}
                 onRename={(id, title) => renameConversation({ conversationId: id, title })}
                 isSelected={selected.has(conversation.id)}
+                anySelected={selected.size > 0}
                 onToggleSelect={handleToggleSelect}
               />
             ))}

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -20,6 +20,8 @@ import {
 import { ConversationPageItem } from "@/components/molecules/project/conversation-page-item";
 import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
 
+const CONVERSATIONS_PAGE_LIMIT = 100;
+
 interface ConversationListProps {
   projectId: string;
 }
@@ -29,7 +31,7 @@ export function ConversationList({ projectId }: ConversationListProps) {
   const tCommon = useTranslations("common");
   const router = useRouter();
   const pathname = usePathname();
-  const { data: conversations, isLoading } = useConversations(projectId, 100);
+  const { data: conversations, isLoading } = useConversations(projectId, CONVERSATIONS_PAGE_LIMIT);
   const { mutate: deleteConversation } = useDeleteConversation(projectId);
   const { mutate: renameConversation } = useRenameConversation(projectId);
 

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -68,9 +69,17 @@ export function ConversationList({ projectId }: ConversationListProps) {
   const handleBulkDelete = () => {
     const ids = Array.from(selected);
     const currentInPath = ids.find((id) => pathname.includes(id));
+    let errorCount = 0;
+
     for (const id of ids) {
-      deleteConversation(id);
+      deleteConversation(id, {
+        onError: () => {
+          errorCount += 1;
+          if (errorCount === 1) toast.error(t("deleteError"));
+        },
+      });
     }
+
     setSelected(new Set());
     setBulkDeleteOpen(false);
     if (currentInPath) {

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -1,10 +1,21 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
+import { Trash2 } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { ConversationPageItem } from "@/components/molecules/project/conversation-page-item";
 import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
 
@@ -14,20 +25,58 @@ interface ConversationListProps {
 
 export function ConversationList({ projectId }: ConversationListProps) {
   const t = useTranslations("conversations");
+  const tCommon = useTranslations("common");
   const router = useRouter();
   const pathname = usePathname();
   const { data: conversations, isLoading } = useConversations(projectId, 100);
   const { mutate: deleteConversation } = useDeleteConversation(projectId);
   const { mutate: renameConversation } = useRenameConversation(projectId);
 
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+
+  const list = conversations ?? [];
+
   const handleDelete = (conversationId: string) => {
     deleteConversation(conversationId);
+    setSelected((prev) => { const next = new Set(prev); next.delete(conversationId); return next; });
     if (pathname.includes(conversationId)) {
       router.push(`/projects/${projectId}/chat`);
     }
   };
 
-  const list = conversations ?? [];
+  const handleToggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const allSelected = list.length > 0 && selected.size === list.length;
+  const someSelected = selected.size > 0 && !allSelected;
+
+  const handleToggleAll = () => {
+    if (allSelected || someSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(list.map((c) => c.id)));
+    }
+  };
+
+  const handleBulkDelete = () => {
+    const ids = Array.from(selected);
+    const currentInPath = ids.find((id) => pathname.includes(id));
+    for (const id of ids) {
+      deleteConversation(id);
+    }
+    setSelected(new Set());
+    setBulkDeleteOpen(false);
+    if (currentInPath) {
+      router.push(`/projects/${projectId}/chat`);
+    }
+  };
 
   return (
     <div className="mx-auto w-full max-w-190 px-4">
@@ -45,18 +94,61 @@ export function ConversationList({ projectId }: ConversationListProps) {
           </Button>
         </div>
       ) : (
-        <div className="flex flex-col gap-2">
-          {list.map((conversation) => (
-            <ConversationPageItem
-              key={conversation.id}
-              conversation={conversation}
-              projectId={projectId}
-              onDelete={handleDelete}
-              onRename={(id, title) => renameConversation({ conversationId: id, title })}
+        <>
+          <div className="mb-3 flex items-center gap-3 border-b pb-3">
+            <Checkbox
+              checked={allSelected ? true : someSelected ? "indeterminate" : false}
+              onCheckedChange={handleToggleAll}
+              aria-label={t("selectAll")}
             />
-          ))}
-        </div>
+            <span className="text-sm text-muted-foreground">
+              {selected.size > 0 ? t("selectedCount", { count: selected.size }) : t("selectAll")}
+            </span>
+            {selected.size > 0 && (
+              <Button
+                variant="destructive"
+                size="sm"
+                className="ml-auto gap-1.5"
+                onClick={() => setBulkDeleteOpen(true)}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                {t("deleteSelected", { count: selected.size })}
+              </Button>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            {list.map((conversation) => (
+              <ConversationPageItem
+                key={conversation.id}
+                conversation={conversation}
+                projectId={projectId}
+                onDelete={handleDelete}
+                onRename={(id, title) => renameConversation({ conversationId: id, title })}
+                isSelected={selected.has(conversation.id)}
+                onToggleSelect={handleToggleSelect}
+              />
+            ))}
+          </div>
+        </>
       )}
+
+      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <DialogContent showCloseButton={false}>
+          <DialogHeader>
+            <DialogTitle>{t("bulkDeleteTitle", { count: selected.size })}</DialogTitle>
+            <DialogDescription>{t("bulkDeleteConfirm", { count: selected.size })}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setBulkDeleteOpen(false)}>
+              {tCommon("cancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleBulkDelete}>
+              {tCommon("delete")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -95,7 +95,7 @@ export function ConversationList({ projectId }: ConversationListProps) {
         </div>
       ) : (
         <>
-          <div className="mb-3 flex items-center gap-3 border-b pb-3">
+          <div className="mb-3 flex items-center gap-3 border-b pb-3 px-4">
             <Checkbox
               checked={allSelected ? true : someSelected ? "indeterminate" : false}
               onCheckedChange={handleToggleAll}

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -5,7 +5,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
+import { ConversationPageItem } from "@/components/molecules/project/conversation-page-item";
 import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
 
 interface ConversationListProps {
@@ -51,9 +51,9 @@ export function ConversationList({ projectId }: ConversationListProps) {
   }
 
   return (
-    <div className="space-y-0.5">
+    <div className="flex flex-col gap-2">
       {list.map((conversation) => (
-        <ConversationItem
+        <ConversationPageItem
           key={conversation.id}
           conversation={conversation}
           projectId={projectId}

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
+import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
+
+interface ConversationListProps {
+  projectId: string;
+}
+
+export function ConversationList({ projectId }: ConversationListProps) {
+  const t = useTranslations("conversations");
+  const router = useRouter();
+  const pathname = usePathname();
+  const { data: conversations, isLoading } = useConversations(projectId, 100);
+  const { mutate: deleteConversation } = useDeleteConversation(projectId);
+  const { mutate: renameConversation } = useRenameConversation(projectId);
+
+  const handleDelete = (conversationId: string) => {
+    deleteConversation(conversationId);
+    if (pathname.includes(conversationId)) {
+      router.push(`/projects/${projectId}/chat`);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-10" />
+        ))}
+      </div>
+    );
+  }
+
+  const list = conversations ?? [];
+
+  if (list.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-muted-foreground mb-4">{t("empty")}</p>
+        <Button asChild>
+          <Link href={`/projects/${projectId}/chat`}>{t("startNew")}</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {list.map((conversation) => (
+        <ConversationItem
+          key={conversation.id}
+          conversation={conversation}
+          projectId={projectId}
+          onDelete={handleDelete}
+          onRename={(id, title) => renameConversation({ conversationId: id, title })}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/organisms/project/conversation-list.tsx
+++ b/client/src/components/organisms/project/conversation-list.tsx
@@ -27,40 +27,36 @@ export function ConversationList({ projectId }: ConversationListProps) {
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <Skeleton key={i} className="h-10" />
-        ))}
-      </div>
-    );
-  }
-
   const list = conversations ?? [];
 
-  if (list.length === 0) {
-    return (
-      <div className="text-center py-12">
-        <p className="text-muted-foreground mb-4">{t("empty")}</p>
-        <Button asChild>
-          <Link href={`/projects/${projectId}/chat`}>{t("startNew")}</Link>
-        </Button>
-      </div>
-    );
-  }
-
   return (
-    <div className="flex flex-col gap-2">
-      {list.map((conversation) => (
-        <ConversationPageItem
-          key={conversation.id}
-          conversation={conversation}
-          projectId={projectId}
-          onDelete={handleDelete}
-          onRename={(id, title) => renameConversation({ conversationId: id, title })}
-        />
-      ))}
+    <div className="mx-auto w-full max-w-190 px-4">
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10" />
+          ))}
+        </div>
+      ) : list.length === 0 ? (
+        <div className="text-center py-12">
+          <p className="text-muted-foreground mb-4">{t("empty")}</p>
+          <Button asChild>
+            <Link href={`/projects/${projectId}/chat`}>{t("startNew")}</Link>
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {list.map((conversation) => (
+            <ConversationPageItem
+              key={conversation.id}
+              conversation={conversation}
+              projectId={projectId}
+              onDelete={handleDelete}
+              onRename={(id, title) => renameConversation({ conversationId: id, title })}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/organisms/sidebar/desktop-project-item.tsx
+++ b/client/src/components/organisms/sidebar/desktop-project-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { ChevronRight, MessageSquarePlus, MoreVertical, Settings } from "lucide-react";
+import { ChevronRight, MessageSquare, MessageSquarePlus, MoreVertical, Settings } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Collapsible } from "radix-ui";
@@ -73,6 +73,12 @@ export function DesktopProjectItem({ project, canAccessSettings = true }: Deskto
               <Link href={`/projects/${project.id}/chat`}>
                 <MessageSquarePlus className="h-4 w-4" />
                 {t("newConversation")}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link href={`/projects/${project.id}/conversations`}>
+                <MessageSquare className="h-4 w-4" />
+                {t("conversations")}
               </Link>
             </DropdownMenuItem>
             {canAccessSettings && (

--- a/client/src/components/organisms/sidebar/mobile-project-item.tsx
+++ b/client/src/components/organisms/sidebar/mobile-project-item.tsx
@@ -1,41 +1,94 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, MessageSquare, MessageSquarePlus, MoreVertical, Settings } from "lucide-react";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import type { ProjectResponse } from "@/lib/types/api";
 import { ProjectConversationList } from "./project-conversation-list";
 
 interface MobileProjectItemProps {
   project: ProjectResponse;
+  canAccessSettings?: boolean;
 }
 
-export function MobileProjectItem({ project }: MobileProjectItemProps) {
+export function MobileProjectItem({ project, canAccessSettings = true }: MobileProjectItemProps) {
   const [isOpen, setIsOpen] = useState(false);
   const pathname = usePathname();
+  const t = useTranslations("sidebar");
   const isActive = pathname.startsWith(`/projects/${project.id}`);
 
   return (
     <div>
-      <button
-        type="button"
-        onClick={() => setIsOpen((prev) => !prev)}
+      <div
         className={cn(
-          "flex w-full cursor-pointer items-center gap-1 truncate rounded-md px-3 py-2 text-sm transition-colors",
-          isActive
-            ? "bg-primary/10 text-primary"
-            : "text-muted-foreground hover:bg-muted hover:text-foreground",
+          "group flex items-center gap-1 rounded-md px-1 py-1 text-sm transition-colors",
+          isActive ? "" : "hover:bg-muted",
         )}
-        title={project.name}
       >
-        {isOpen ? (
-          <ChevronDown className="h-3 w-3 shrink-0" />
-        ) : (
-          <ChevronRight className="h-3 w-3 shrink-0" />
-        )}
-        <span className="truncate">{project.name}</span>
-      </button>
+        <button
+          type="button"
+          onClick={() => setIsOpen((prev) => !prev)}
+          className={cn(
+            "flex min-w-0 flex-1 cursor-pointer items-center gap-1 truncate rounded-md px-2 text-left",
+            isActive ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground",
+          )}
+          title={project.name}
+        >
+          {isOpen ? (
+            <ChevronDown className="h-3 w-3 shrink-0" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0" />
+          )}
+          <span className="truncate">{project.name}</span>
+        </button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn(
+                "h-5 w-5 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100",
+                !isActive && "hover:bg-primary/10",
+              )}
+              aria-label={t("projectMenu", { projectName: project.name })}
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link href={`/projects/${project.id}/chat`}>
+                <MessageSquarePlus className="h-4 w-4" />
+                {t("newConversation")}
+              </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem asChild className="cursor-pointer">
+              <Link href={`/projects/${project.id}/conversations`}>
+                <MessageSquare className="h-4 w-4" />
+                {t("conversations")}
+              </Link>
+            </DropdownMenuItem>
+            {canAccessSettings && (
+              <DropdownMenuItem asChild className="cursor-pointer">
+                <Link href={`/projects/${project.id}/settings`}>
+                  <Settings className="h-4 w-4" />
+                  {t("settings")}
+                </Link>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
       {isOpen && (
         <div className="ml-2 mt-0.5">
           <ProjectConversationList projectId={project.id} />

--- a/client/src/components/organisms/sidebar/projects-section.tsx
+++ b/client/src/components/organisms/sidebar/projects-section.tsx
@@ -53,7 +53,11 @@ export function ProjectsSection({
               canAccessSettings={canAccessSettings}
             />
           ) : (
-            <MobileProjectItem key={project.id} project={project} />
+            <MobileProjectItem
+              key={project.id}
+              project={project}
+              canAccessSettings={canAccessSettings}
+            />
           ),
         )}
     </div>

--- a/client/src/components/templates/project/conversations-template.tsx
+++ b/client/src/components/templates/project/conversations-template.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import Link from "next/link";
+import { MessageSquarePlus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { PageTemplate } from "@/components/templates/page-template";
+import { ConversationList } from "@/components/organisms/project/conversation-list";
+import { useProject } from "@/lib/hooks/use-projects";
+
+type ConversationsTemplateProps = {
+  projectId: string;
+};
+
+export function ConversationsTemplate({ projectId }: ConversationsTemplateProps) {
+  const { data: project } = useProject(projectId);
+  const t = useTranslations("conversations");
+
+  return (
+    <PageTemplate
+      title={project?.name ?? ""}
+      description={t("title")}
+      actions={
+        <Button asChild>
+          <Link href={`/projects/${projectId}/chat`}>
+            <MessageSquarePlus className="mr-2 h-4 w-4" />
+            {t("new")}
+          </Link>
+        </Button>
+      }
+    >
+      <ConversationList projectId={projectId} />
+    </PageTemplate>
+  );
+}

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -14,7 +14,7 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer h-4 w-4 shrink-0 rounded border border-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        "peer h-4 w-4 shrink-0 cursor-pointer rounded border border-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
         className,
       )}
       {...props}

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import { Checkbox as CheckboxPrimitive } from "radix-ui"
+import { Check } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Checkbox({
+  className,
+  ...props
+}: React.ComponentProps<typeof CheckboxPrimitive.Root>) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer h-4 w-4 shrink-0 rounded border border-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+        <Check className="h-3 w-3" />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import { Checkbox as CheckboxPrimitive } from "radix-ui"
-import { Check } from "lucide-react"
+import { Check, Minus } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
@@ -14,13 +14,14 @@ function Checkbox({
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer h-4 w-4 shrink-0 cursor-pointer rounded border border-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+        "group peer h-4 w-4 shrink-0 cursor-pointer rounded border border-primary shadow-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground data-[state=indeterminate]:bg-primary data-[state=indeterminate]:text-primary-foreground",
         className,
       )}
       {...props}
     >
       <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
-        <Check className="h-3 w-3" />
+        <Check className="h-3 w-3 group-data-[state=indeterminate]:hidden" />
+        <Minus className="hidden h-3 w-3 group-data-[state=indeterminate]:flex" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   )

--- a/client/tests/components/molecules/project/conversation-page-item.test.tsx
+++ b/client/tests/components/molecules/project/conversation-page-item.test.tsx
@@ -1,0 +1,75 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationPageItem } from "@/components/molecules/project/conversation-page-item";
+import { formatDateTime } from "@/lib/utils/format";
+import { renderWithProviders } from "../../../helpers/render";
+import type { ConversationResponse } from "@/lib/types/api";
+
+const conversation: ConversationResponse = {
+  id: "conv-1",
+  project_id: "proj-1",
+  user_id: "user-1",
+  created_at: "2024-01-15T10:00:00Z",
+  title: "Ma conversation",
+};
+
+const defaultProps = {
+  conversation,
+  projectId: "proj-1",
+  onDelete: vi.fn(),
+  onRename: vi.fn(),
+};
+
+describe("ConversationPageItem", () => {
+  it("should render the conversation title as a link", () => {
+    renderWithProviders(<ConversationPageItem {...defaultProps} />);
+    const link = screen.getByRole("link", { name: /ma conversation/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/projects/proj-1/chat/conv-1");
+  });
+
+  it("should render the formatted date when title is null", () => {
+    const untitled = { ...conversation, title: null };
+    renderWithProviders(<ConversationPageItem {...defaultProps} conversation={untitled} />);
+    const expected = formatDateTime(untitled.created_at);
+    expect(screen.getAllByText(expected).length).toBeGreaterThan(0);
+  });
+
+  it("should open rename dialog and call onRename on confirm", async () => {
+    const user = userEvent.setup();
+    const onRename = vi.fn();
+    renderWithProviders(<ConversationPageItem {...defaultProps} onRename={onRename} />);
+    await user.click(screen.getByRole("button"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    await user.click(menuItems.find((i) => i.textContent?.match(/renommer|rename/i))!);
+    await screen.findByRole("dialog");
+    const input = screen.getByRole("textbox");
+    await user.clear(input);
+    await user.type(input, "Nouveau titre");
+    await user.click(screen.getByRole("button", { name: /enregistrer|save/i }));
+    expect(onRename).toHaveBeenCalledWith("conv-1", "Nouveau titre");
+  });
+
+  it("should open delete dialog and call onDelete on confirm", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    renderWithProviders(<ConversationPageItem {...defaultProps} onDelete={onDelete} />);
+    await user.click(screen.getByRole("button"));
+    const menuItems = await screen.findAllByRole("menuitem");
+    await user.click(menuItems.find((i) => i.textContent?.match(/supprimer|delete/i))!);
+    await screen.findByRole("dialog");
+    await user.click(screen.getByRole("button", { name: /supprimer|delete/i }));
+    expect(onDelete).toHaveBeenCalledWith("conv-1");
+  });
+
+  it("should call onToggleSelect when checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggleSelect = vi.fn();
+    renderWithProviders(
+      <ConversationPageItem {...defaultProps} onToggleSelect={onToggleSelect} />,
+    );
+    await user.click(screen.getByRole("checkbox"));
+    expect(onToggleSelect).toHaveBeenCalledWith("conv-1");
+  });
+});

--- a/client/tests/components/organisms/project/conversation-list.test.tsx
+++ b/client/tests/components/organisms/project/conversation-list.test.tsx
@@ -1,0 +1,103 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ConversationList } from "@/components/organisms/project/conversation-list";
+import { renderWithProviders } from "../../../helpers/render";
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/projects/proj-1/conversations",
+}));
+
+const { mockDeleteConversation, mockRenameConversation, mockUseConversations } = vi.hoisted(() => ({
+  mockDeleteConversation: vi.fn(),
+  mockRenameConversation: vi.fn(),
+  mockUseConversations: vi.fn(() => ({
+    data: [
+      { id: "c1", title: "First conv", created_at: "2026-01-01T10:00:00Z" },
+      { id: "c2", title: "Second conv", created_at: "2026-01-02T10:00:00Z" },
+      { id: "c3", title: null, created_at: "2026-01-03T10:00:00Z" },
+    ],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useConversations: mockUseConversations,
+  useDeleteConversation: vi.fn(() => ({ mutate: mockDeleteConversation })),
+  useRenameConversation: vi.fn(() => ({ mutate: mockRenameConversation })),
+}));
+
+describe("ConversationList", () => {
+  it("should render conversation titles", () => {
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    expect(screen.getByText("First conv")).toBeInTheDocument();
+    expect(screen.getByText("Second conv")).toBeInTheDocument();
+  });
+
+  it("should show a 'select all' checkbox in the toolbar", () => {
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    expect(screen.getByRole("checkbox", { name: /select all/i })).toBeInTheDocument();
+  });
+
+  it("should show individual checkboxes for each conversation", () => {
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    expect(screen.getAllByRole("checkbox")).toHaveLength(4); // 1 select-all + 3 items
+  });
+
+  it("should select a conversation when its checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it("should show bulk delete button when at least one item is selected", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    const checkboxes = screen.getAllByRole("checkbox");
+    await user.click(checkboxes[1]);
+    expect(screen.getByRole("button", { name: /delete \(1\)/i })).toBeInTheDocument();
+  });
+
+  it("should select all when select-all checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    await user.click(screen.getByRole("checkbox", { name: /select all/i }));
+    expect(screen.getByText(/3 selected/i)).toBeInTheDocument();
+  });
+
+  it("should deselect all when select-all is clicked again", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    await user.click(screen.getByRole("checkbox", { name: /select all/i }));
+    await user.click(screen.getByRole("checkbox", { name: /select all/i }));
+    expect(screen.queryByText(/selected/i)).not.toBeInTheDocument();
+  });
+
+  it("should open bulk delete dialog when delete button is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    await user.click(screen.getByRole("checkbox", { name: /select all/i }));
+    await user.click(screen.getByRole("button", { name: /delete \(3\)/i }));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should call deleteConversation for each selected item on bulk delete confirm", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    await user.click(screen.getByRole("checkbox", { name: /select all/i }));
+    await user.click(screen.getByRole("button", { name: /delete \(3\)/i }));
+    await user.click(screen.getByRole("button", { name: /^delete$/i }));
+    expect(mockDeleteConversation).toHaveBeenCalledTimes(3);
+  });
+
+  it("should show empty state when there are no conversations", () => {
+    mockUseConversations.mockReturnValueOnce({ data: [], isLoading: false });
+    renderWithProviders(<ConversationList projectId="proj-1" />);
+    expect(screen.getByText(/no conversations/i)).toBeInTheDocument();
+  });
+});

--- a/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
@@ -60,6 +60,6 @@ describe("MobileProjectItem", () => {
   it("should apply active styles when pathname is under the project", () => {
     vi.mocked(usePathname).mockReturnValue("/projects/proj-1/chat/conv-1");
     renderWithProviders(<MobileProjectItem project={project} />);
-    expect(screen.getByRole("button", { name: "My Project" })).toHaveClass("text-primary");
+    expect(screen.getByRole("button", { name: "My Project" })).toHaveClass("font-semibold");
   });
 });

--- a/client/tests/components/organisms/sidebar/projects-section.test.tsx
+++ b/client/tests/components/organisms/sidebar/projects-section.test.tsx
@@ -52,12 +52,12 @@ describe("ProjectsSection", () => {
     expect(screen.getByRole("button", { name: "Project Beta" })).toBeInTheDocument();
   });
 
-  it("should render project toggle buttons in mobile variant without dropdown", () => {
+  it("should render project toggle buttons in mobile variant with contextual menu", () => {
     renderWithProviders(
       <ProjectsSection {...baseProps} variant="mobile" projects={projects} />,
     );
     expect(screen.getByRole("button", { name: "Project Alpha" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /project menu/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /project menu/i })).toHaveLength(2);
   });
 
   it("should show the create button when canCreate is true", () => {


### PR DESCRIPTION
## Problème

La page `/projects` ne permettait pas d'accéder à la liste complète des conversations d'un projet. Seul un collapse limité à 10 items dans la sidebar (desktop uniquement) était disponible.

Closes #51

## Solution

Ajout d'une entrée « Conversations » dans le menu contextuel des items sidebar (desktop et mobile) qui pointe vers une nouvelle page dédiée `/projects/{projectId}/conversations`.

## Implémentation

**Sidebar**
- `DesktopProjectItem` : entrée « Conversations » (icône `MessageSquare`) ajoutée entre « Nouvelle conversation » et « Paramètres »
- `MobileProjectItem` : refactorisé pour adopter le même layout que le desktop avec un menu contextuel ⋮ (Nouvelle conversation / Conversations / Paramètres)
- `ProjectsSection` : transmet `canAccessSettings` au `MobileProjectItem`

**Nouvelle page**
- Organisme `ConversationList` : récupère toutes les conversations (limit 100), réutilise `ConversationItem` pour le renommage et la suppression, état vide avec CTA « Démarrer une conversation »
- Template `ConversationsTemplate` : `PageTemplate` avec le nom du projet comme titre, « Conversations » comme description et bouton « Nouvelle conversation »
- Route `/projects/[projectId]/conversations/page.tsx`

**Tests**
- Mise à jour de `mobile-project-item.test.tsx` : style actif (`font-semibold`) et présence du menu ⋮
- Mise à jour de `projects-section.test.tsx` : vérifie la présence du menu contextuel en variante mobile

## Recette

1. Ouvrir la sidebar desktop → survoler un projet → cliquer sur ⋮
2. Vérifier la présence des entrées « Nouvelle conversation », « Conversations », « Paramètres »
3. Cliquer « Conversations » → naviguer vers `/projects/{id}/conversations`
4. Vérifier la liste de toutes les conversations, triées par date
5. Renommer une conversation depuis la page → vérifier la mise à jour
6. Supprimer une conversation depuis la page → vérifier la suppression
7. Sur un projet sans conversation → vérifier l'état vide avec le CTA
8. Sur mobile : survoler un projet → vérifier la présence du menu ⋮ avec les mêmes entrées