### PR TITLE
feat(chat): mettre en favori une conversation (issue #28)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -493,6 +493,7 @@
       "deleteTitle": "Delete Conversation",
       "deleteConfirm": "Are you sure you want to delete this conversation?",
       "favorites": "My Favorites",
+      "noFavorites": "No favorite conversations yet",
       "addToFavorites": "Add to favorites",
       "removeFromFavorites": "Remove from favorites"
     }

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -491,7 +491,10 @@
       "renameDescription": "Enter a new name for this conversation.",
       "renamePlaceholder": "Conversation name",
       "deleteTitle": "Delete Conversation",
-      "deleteConfirm": "Are you sure you want to delete this conversation?"
+      "deleteConfirm": "Are you sure you want to delete this conversation?",
+      "favorites": "My Favorites",
+      "addToFavorites": "Add to favorites",
+      "removeFromFavorites": "Remove from favorites"
     }
   },
   "documents": {

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -493,7 +493,7 @@
       "deleteTitle": "Supprimer la conversation",
       "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?",
       "favorites": "Mes favoris",
-      "noFavorites": "Aucune conversation favorite pour le moment",
+      "noFavorites": "Aucun favori pour le moment",
       "addToFavorites": "Ajouter aux favoris",
       "removeFromFavorites": "Retirer des favoris"
     }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -493,6 +493,7 @@
       "deleteTitle": "Supprimer la conversation",
       "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?",
       "favorites": "Mes favoris",
+      "noFavorites": "Aucune conversation favorite pour le moment",
       "addToFavorites": "Ajouter aux favoris",
       "removeFromFavorites": "Retirer des favoris"
     }

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -491,7 +491,10 @@
       "renameDescription": "Saisissez un nouveau nom pour cette conversation.",
       "renamePlaceholder": "Nom de la conversation",
       "deleteTitle": "Supprimer la conversation",
-      "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?"
+      "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cette conversation ?",
+      "favorites": "Mes favoris",
+      "addToFavorites": "Ajouter aux favoris",
+      "removeFromFavorites": "Retirer des favoris"
     }
   },
   "documents": {

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -75,7 +75,7 @@ export function ConversationItem({
               className="cursor-pointer gap-2 text-destructive focus:text-destructive"
               onSelect={() => setDeleteDialogOpen(true)}
             >
-              <Trash2 className="h-4 w-4" />
+              <Trash2 className="h-4 w-4 text-destructive" />
               {t("deleteTitle")}
             </DropdownMenuItem>
           </DropdownMenuContent>

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { MoreVertical, Pencil, Trash2 } from "lucide-react";
+import { MoreVertical, Pencil, Star, Trash2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,9 +21,16 @@ interface ConversationItemProps {
   projectId: string;
   onDelete: (id: string) => void;
   onRename: (id: string, title: string) => void;
+  onToggleFavorite: (id: string) => void;
 }
 
-export function ConversationItem({ conversation, projectId, onDelete, onRename }: ConversationItemProps) {
+export function ConversationItem({
+  conversation,
+  projectId,
+  onDelete,
+  onRename,
+  onToggleFavorite,
+}: ConversationItemProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const isActive = useConversationActive(conversation.id);
@@ -50,6 +57,13 @@ export function ConversationItem({ conversation, projectId, onDelete, onRename }
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem
+              className="cursor-pointer gap-2"
+              onSelect={() => onToggleFavorite(conversation.id)}
+            >
+              <Star className={cn("h-4 w-4", conversation.is_favorite && "fill-yellow-400 text-yellow-400")} />
+              {conversation.is_favorite ? t("removeFromFavorites") : t("addToFavorites")}
+            </DropdownMenuItem>
             <DropdownMenuItem
               className="cursor-pointer gap-2"
               onSelect={() => setRenameDialogOpen(true)}

--- a/client/src/components/molecules/sidebar/conversation-item.tsx
+++ b/client/src/components/molecules/sidebar/conversation-item.tsx
@@ -61,7 +61,7 @@ export function ConversationItem({
               className="cursor-pointer gap-2"
               onSelect={() => onToggleFavorite(conversation.id)}
             >
-              <Star className={cn("h-4 w-4", conversation.is_favorite && "fill-yellow-400 text-yellow-400")} />
+              <Star className={cn("h-4 w-4", conversation.is_favorite && "fill-current")} />
               {conversation.is_favorite ? t("removeFromFavorites") : t("addToFavorites")}
             </DropdownMenuItem>
             <DropdownMenuItem

--- a/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
+++ b/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
@@ -1,10 +1,45 @@
 "use client";
 
-import Link from "next/link";
-import { Star } from "lucide-react";
+import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { SidebarSectionHeader } from "@/components/atoms/sidebar/sidebar-section-header";
-import { useFavoriteConversations } from "@/lib/hooks/use-chat";
+import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
+import {
+  useFavoriteConversations,
+  useDeleteConversation,
+  useRenameConversation,
+  useToggleFavoriteConversation,
+} from "@/lib/hooks/use-chat";
+import type { FavoriteConversationResponse } from "@/lib/types/api";
+
+interface FavoriteConversationItemProps {
+  conversation: FavoriteConversationResponse;
+}
+
+function FavoriteConversationItem({ conversation }: FavoriteConversationItemProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { mutate: deleteConversation } = useDeleteConversation(conversation.project_id);
+  const { mutate: renameConversation } = useRenameConversation(conversation.project_id);
+  const { mutate: toggleFavorite } = useToggleFavoriteConversation(conversation.project_id);
+
+  const handleDelete = (conversationId: string) => {
+    deleteConversation(conversationId);
+    if (pathname.includes(conversationId)) {
+      router.push(`/projects/${conversation.project_id}/chat`);
+    }
+  };
+
+  return (
+    <ConversationItem
+      conversation={conversation}
+      projectId={conversation.project_id}
+      onDelete={handleDelete}
+      onRename={(id, title) => renameConversation({ conversationId: id, title })}
+      onToggleFavorite={(id) => toggleFavorite(id)}
+    />
+  );
+}
 
 export function FavoriteConversationsSection() {
   const t = useTranslations("chat.sidebar");
@@ -19,17 +54,7 @@ export function FavoriteConversationsSection() {
       <SidebarSectionHeader title={t("favorites")} />
       <div className="space-y-0.5">
         {favorites.map((conversation) => (
-          <Link
-            key={conversation.id}
-            href={`/projects/${conversation.project_id}/chat/${conversation.id}`}
-            className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-muted transition-colors"
-          >
-            <Star className="h-3 w-3 shrink-0 fill-yellow-400 text-yellow-400" />
-            <div className="min-w-0 flex-1">
-              <p className="truncate">{conversation.title ?? t("newConversation")}</p>
-              <p className="truncate text-xs text-muted-foreground">{conversation.project_name}</p>
-            </div>
-          </Link>
+          <FavoriteConversationItem key={conversation.id} conversation={conversation} />
         ))}
       </div>
     </div>

--- a/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
+++ b/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { Star } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { SidebarSectionHeader } from "@/components/atoms/sidebar/sidebar-section-header";
+import { useFavoriteConversations } from "@/lib/hooks/use-chat";
+
+export function FavoriteConversationsSection() {
+  const t = useTranslations("chat.sidebar");
+  const { data: favorites } = useFavoriteConversations();
+
+  if (!favorites || favorites.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-2 border-t pt-2">
+      <SidebarSectionHeader title={t("favorites")} />
+      <div className="space-y-0.5">
+        {favorites.map((conversation) => (
+          <Link
+            key={conversation.id}
+            href={`/projects/${conversation.project_id}/chat/${conversation.id}`}
+            className="flex items-center gap-2 rounded-md px-3 py-1.5 text-sm hover:bg-muted transition-colors"
+          >
+            <Star className="h-3 w-3 shrink-0 fill-yellow-400 text-yellow-400" />
+            <div className="min-w-0 flex-1">
+              <p className="truncate">{conversation.title ?? t("newConversation")}</p>
+              <p className="truncate text-xs text-muted-foreground">{conversation.project_name}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
+++ b/client/src/components/organisms/sidebar/favorite-conversations-section.tsx
@@ -43,20 +43,22 @@ function FavoriteConversationItem({ conversation }: FavoriteConversationItemProp
 
 export function FavoriteConversationsSection() {
   const t = useTranslations("chat.sidebar");
-  const { data: favorites } = useFavoriteConversations();
+  const { data: favorites, isLoading } = useFavoriteConversations();
 
-  if (!favorites || favorites.length === 0) {
-    return null;
-  }
+  const isEmpty = !isLoading && (!favorites || favorites.length === 0);
 
   return (
     <div className="mt-2 border-t pt-2">
       <SidebarSectionHeader title={t("favorites")} />
-      <div className="space-y-0.5">
-        {favorites.map((conversation) => (
-          <FavoriteConversationItem key={conversation.id} conversation={conversation} />
-        ))}
-      </div>
+      {isEmpty ? (
+        <p className="px-3 py-1 text-xs text-muted-foreground">{t("noFavorites")}</p>
+      ) : (
+        <div className="space-y-0.5">
+          {favorites?.map((conversation) => (
+            <FavoriteConversationItem key={conversation.id} conversation={conversation} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/organisms/sidebar/index.ts
+++ b/client/src/components/organisms/sidebar/index.ts
@@ -1,2 +1,3 @@
 export { Sidebar } from "./sidebar";
 export { MobileSidebar } from "./mobile-sidebar";
+export { FavoriteConversationsSection } from "./favorite-conversations-section";

--- a/client/src/components/organisms/sidebar/project-conversation-list.tsx
+++ b/client/src/components/organisms/sidebar/project-conversation-list.tsx
@@ -3,7 +3,12 @@
 import { useRouter, usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { ConversationItem } from "@/components/molecules/sidebar/conversation-item";
-import { useConversations, useDeleteConversation, useRenameConversation } from "@/lib/hooks/use-chat";
+import {
+  useConversations,
+  useDeleteConversation,
+  useRenameConversation,
+  useToggleFavoriteConversation,
+} from "@/lib/hooks/use-chat";
 
 interface ProjectConversationListProps {
   projectId: string;
@@ -16,6 +21,7 @@ export function ProjectConversationList({ projectId }: ProjectConversationListPr
   const { data: conversations, isLoading } = useConversations(projectId, 10);
   const { mutate: deleteConversation } = useDeleteConversation(projectId);
   const { mutate: renameConversation } = useRenameConversation(projectId);
+  const { mutate: toggleFavorite } = useToggleFavoriteConversation(projectId);
 
   const recent = conversations ?? [];
 
@@ -47,6 +53,7 @@ export function ProjectConversationList({ projectId }: ProjectConversationListPr
           projectId={projectId}
           onDelete={handleDelete}
           onRename={(id, title) => renameConversation({ conversationId: id, title })}
+          onToggleFavorite={(id) => toggleFavorite(id)}
         />
       ))}
     </div>

--- a/client/src/components/organisms/sidebar/sidebar.tsx
+++ b/client/src/components/organisms/sidebar/sidebar.tsx
@@ -7,6 +7,7 @@ import { ProjectsSection } from "./projects-section";
 import { OrganizationSection } from "./organization-section";
 import { UserMenu } from "./user-menu";
 import { useSidebarData } from "./use-sidebar-data";
+import { FavoriteConversationsSection } from "./favorite-conversations-section";
 
 export function Sidebar() {
   const t = useTranslations("sidebar");
@@ -23,6 +24,7 @@ export function Sidebar() {
       <SidebarLogo />
       <nav className="flex-1 space-y-1 overflow-y-auto p-3">
         <SidebarNav showIcons />
+        <FavoriteConversationsSection />
         <ProjectsSection
           variant="desktop"
           title={t("myProjects")}

--- a/client/src/components/templates/project/chat-template.tsx
+++ b/client/src/components/templates/project/chat-template.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { Star } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { WorkspaceTemplate } from "@/components/templates/workspace-template";
 import { ChatPanel } from "@/components/organisms/chat/chat-panel";
-import { useConversation } from "@/lib/hooks/use-chat";
+import { Button } from "@/components/ui/button";
+import { useConversation, useToggleFavoriteConversation } from "@/lib/hooks/use-chat";
 import { useProject } from "@/lib/hooks/use-projects";
-import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
 
 type ChatTemplateProps = {
   projectId: string;
@@ -18,23 +20,43 @@ export function ChatTemplate({ projectId, conversationId }: ChatTemplateProps) {
     conversationId ? projectId : undefined,
     conversationId ?? undefined,
   );
+  const { mutate: toggleFavorite } = useToggleFavoriteConversation(projectId);
   const isProjectReindexing = project?.reindex_status === "in_progress";
-  const t = useTranslations("projects.chatPage");
+  const t = useTranslations("chat.sidebar");
+  const tChat = useTranslations("projects.chatPage");
 
   const breadcrumb = [
     { label: project?.name ?? "" },
     ...(conversation?.title ? [{ label: conversation.title }] : []),
   ];
 
+  const actions = conversationId ? (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8"
+      aria-label={conversation?.is_favorite ? t("removeFromFavorites") : t("addToFavorites")}
+      title={conversation?.is_favorite ? t("removeFromFavorites") : t("addToFavorites")}
+      onClick={() => toggleFavorite(conversationId)}
+    >
+      <Star
+        className={cn(
+          "h-4 w-4",
+          conversation?.is_favorite && "fill-yellow-400 text-yellow-400",
+        )}
+      />
+    </Button>
+  ) : undefined;
+
   return (
-    <WorkspaceTemplate breadcrumb={breadcrumb}>
+    <WorkspaceTemplate breadcrumb={breadcrumb} actions={actions}>
       <ChatPanel
         projectId={projectId}
         conversationId={conversationId}
         disabled={isProjectReindexing}
         disabledMessage={
           isProjectReindexing
-            ? t("reindexingMessage", {
+            ? tChat("reindexingMessage", {
                 progress: project?.reindex_progress,
                 total: project?.reindex_total,
               })

--- a/client/src/components/templates/project/chat-template.tsx
+++ b/client/src/components/templates/project/chat-template.tsx
@@ -42,7 +42,7 @@ export function ChatTemplate({ projectId, conversationId }: ChatTemplateProps) {
       <Star
         className={cn(
           "h-4 w-4",
-          conversation?.is_favorite && "fill-yellow-400 text-yellow-400",
+          conversation?.is_favorite && "fill-current",
         )}
       />
     </Button>

--- a/client/src/lib/api/chat.ts
+++ b/client/src/lib/api/chat.ts
@@ -1,6 +1,7 @@
 import type {
   ConversationDetailResponse,
   ConversationResponse,
+  FavoriteConversationResponse,
   MessageResponse,
   SendMessageRequest,
   SendMessageResponse,
@@ -161,6 +162,28 @@ export function listMessages(
 ): Promise<MessageResponse[]> {
   return apiFetch<MessageResponse[]>(
     `/projects/${projectId}/chat/conversations/${conversationId}/messages?limit=${limit}&offset=${offset}`,
+    { token },
+  );
+}
+
+export function toggleFavoriteConversation(
+  token: string,
+  projectId: string,
+  conversationId: string,
+): Promise<ConversationResponse> {
+  return apiFetch<ConversationResponse>(
+    `/projects/${projectId}/chat/conversations/${conversationId}/favorite`,
+    { method: "PATCH", token },
+  );
+}
+
+export function listFavoriteConversations(
+  token: string,
+  limit = 50,
+  offset = 0,
+): Promise<FavoriteConversationResponse[]> {
+  return apiFetch<FavoriteConversationResponse[]>(
+    `/users/me/conversations/favorites?limit=${limit}&offset=${offset}`,
     { token },
   );
 }

--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -7,9 +7,11 @@ import {
   deleteConversation,
   getConversation,
   listConversations,
+  listFavoriteConversations,
   listMessages,
   renameConversation,
   streamMessage,
+  toggleFavoriteConversation,
 } from "@/lib/api/chat";
 import type {
   RetrievedChunkResponse,
@@ -74,6 +76,30 @@ export function useDeleteConversation(projectId: string) {
         queryKey: ["conversations", projectId],
       });
     },
+  });
+}
+
+export function useToggleFavoriteConversation(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (conversationId: string) =>
+      toggleFavoriteConversation(token!, projectId, conversationId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["conversations", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["favorite-conversations"] });
+    },
+  });
+}
+
+export function useFavoriteConversations(limit = 50) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: ["favorite-conversations", limit],
+    queryFn: () => listFavoriteConversations(token!, limit),
+    enabled: !!token,
   });
 }
 

--- a/client/src/lib/hooks/use-chat.ts
+++ b/client/src/lib/hooks/use-chat.ts
@@ -60,6 +60,8 @@ export function useRenameConversation(projectId: string) {
       renameConversation(token!, projectId, conversationId, title),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["conversations", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["conversation"] });
+      queryClient.invalidateQueries({ queryKey: ["favorite-conversations"] });
     },
   });
 }
@@ -72,9 +74,8 @@ export function useDeleteConversation(projectId: string) {
     mutationFn: (conversationId: string) =>
       deleteConversation(token!, projectId, conversationId),
     onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: ["conversations", projectId],
-      });
+      queryClient.invalidateQueries({ queryKey: ["conversations", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["favorite-conversations"] });
     },
   });
 }
@@ -89,6 +90,7 @@ export function useToggleFavoriteConversation(projectId: string) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["conversations", projectId] });
       queryClient.invalidateQueries({ queryKey: ["favorite-conversations"] });
+      queryClient.invalidateQueries({ queryKey: ["conversation"] });
     },
   });
 }

--- a/client/src/lib/types/api.ts
+++ b/client/src/lib/types/api.ts
@@ -317,11 +317,16 @@ export interface ConversationResponse {
   user_id: string;
   created_at: string;
   title: string | null;
+  is_favorite: boolean;
 }
 
 export interface ConversationDetailResponse extends ConversationResponse {
   message_count: number;
   last_message: MessageResponse | null;
+}
+
+export interface FavoriteConversationResponse extends ConversationResponse {
+  project_name: string;
 }
 
 // Streaming SSE events

--- a/client/tests/components/molecules/sidebar/conversation-item.test.tsx
+++ b/client/tests/components/molecules/sidebar/conversation-item.test.tsx
@@ -15,6 +15,7 @@ const conversation: ConversationResponse = {
   user_id: "user-1",
   created_at: "2024-01-15T10:00:00Z",
   title: "Test conversation",
+  is_favorite: false,
 };
 
 const defaultProps = {
@@ -22,6 +23,7 @@ const defaultProps = {
   projectId: "proj-1",
   onDelete: vi.fn(),
   onRename: vi.fn(),
+  onToggleFavorite: vi.fn(),
 };
 
 describe("ConversationItem", () => {

--- a/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/desktop-project-item.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(() => ({ data: [], isLoading: false })),
   useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useToggleFavoriteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({

--- a/client/tests/components/organisms/sidebar/favorite-conversations-section.test.tsx
+++ b/client/tests/components/organisms/sidebar/favorite-conversations-section.test.tsx
@@ -1,0 +1,90 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FavoriteConversationsSection } from "@/components/organisms/sidebar/favorite-conversations-section";
+import { renderWithProviders } from "../../../helpers/render";
+import type { FavoriteConversationResponse } from "@/lib/types/api";
+
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/projects/proj-1"),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("@/lib/hooks/use-chat", () => ({
+  useFavoriteConversations: vi.fn(),
+  useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useToggleFavoriteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({ token: "fake-token" })),
+}));
+
+const { useFavoriteConversations, useToggleFavoriteConversation } = await import(
+  "@/lib/hooks/use-chat"
+);
+
+const favorite: FavoriteConversationResponse = {
+  id: "conv-1",
+  project_id: "proj-1",
+  project_name: "My Project",
+  user_id: "user-1",
+  created_at: "2024-01-15T10:00:00Z",
+  title: "Favorite Conversation",
+  is_favorite: true,
+};
+
+describe("FavoriteConversationsSection", () => {
+  beforeEach(() => {
+    vi.mocked(useFavoriteConversations).mockReturnValue({
+      data: [favorite],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFavoriteConversations>);
+  });
+
+  it("should render nothing when favorites list is empty", () => {
+    vi.mocked(useFavoriteConversations).mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useFavoriteConversations>);
+    const { container } = renderWithProviders(<FavoriteConversationsSection />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render the conversation title", () => {
+    renderWithProviders(<FavoriteConversationsSection />);
+    expect(screen.getByText("Favorite Conversation")).toBeInTheDocument();
+  });
+
+  it("should not render the project name", () => {
+    renderWithProviders(<FavoriteConversationsSection />);
+    expect(screen.queryByText("My Project")).not.toBeInTheDocument();
+  });
+
+  it("should open rename dialog when rename is clicked in context menu", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<FavoriteConversationsSection />);
+    await user.click(screen.getByRole("button", { name: /conversation options/i }));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const renameItem = menuItems.find((item) => item.textContent?.match(/renommer|rename/i));
+    await user.click(renameItem!);
+    expect(await screen.findByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("should call toggleFavorite when remove from favorites is clicked", async () => {
+    const toggleFn = vi.fn();
+    vi.mocked(useToggleFavoriteConversation).mockReturnValue({
+      mutate: toggleFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof useToggleFavoriteConversation>);
+
+    const user = userEvent.setup();
+    renderWithProviders(<FavoriteConversationsSection />);
+    await user.click(screen.getByRole("button", { name: /conversation options/i }));
+    const menuItems = await screen.findAllByRole("menuitem");
+    const favoriteItem = menuItems.find((item) => item.textContent?.match(/retirer|remove/i));
+    await user.click(favoriteItem!);
+    expect(toggleFn).toHaveBeenCalledWith("conv-1");
+  });
+});

--- a/client/tests/components/organisms/sidebar/favorite-conversations-section.test.tsx
+++ b/client/tests/components/organisms/sidebar/favorite-conversations-section.test.tsx
@@ -43,13 +43,22 @@ describe("FavoriteConversationsSection", () => {
     } as unknown as ReturnType<typeof useFavoriteConversations>);
   });
 
-  it("should render nothing when favorites list is empty", () => {
+  it("should render an empty state message when favorites list is empty", () => {
     vi.mocked(useFavoriteConversations).mockReturnValue({
       data: [],
       isLoading: false,
     } as unknown as ReturnType<typeof useFavoriteConversations>);
-    const { container } = renderWithProviders(<FavoriteConversationsSection />);
-    expect(container).toBeEmptyDOMElement();
+    renderWithProviders(<FavoriteConversationsSection />);
+    expect(screen.getByText(/no favorite conversations yet/i)).toBeInTheDocument();
+  });
+
+  it("should not render the empty state message while loading", () => {
+    vi.mocked(useFavoriteConversations).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as unknown as ReturnType<typeof useFavoriteConversations>);
+    renderWithProviders(<FavoriteConversationsSection />);
+    expect(screen.queryByText(/no favorite conversations yet/i)).not.toBeInTheDocument();
   });
 
   it("should render the conversation title", () => {

--- a/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
+++ b/client/tests/components/organisms/sidebar/mobile-project-item.test.tsx
@@ -13,6 +13,7 @@ vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(() => ({ data: [], isLoading: false })),
   useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useToggleFavoriteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({

--- a/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
+++ b/client/tests/components/organisms/sidebar/project-conversation-list.test.tsx
@@ -14,6 +14,7 @@ vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(),
   useDeleteConversation: vi.fn(),
   useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useToggleFavoriteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({
@@ -29,6 +30,7 @@ const makeConversation = (id: string, title: string | null, createdAt: string): 
   user_id: "user-1",
   created_at: createdAt,
   title,
+  is_favorite: false,
 });
 
 const conversations = [

--- a/client/tests/components/organisms/sidebar/sidebar.test.tsx
+++ b/client/tests/components/organisms/sidebar/sidebar.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/components/organisms/sidebar/use-sidebar-data", () => ({
 vi.mock("@/lib/hooks/use-chat", () => ({
   useConversations: vi.fn(() => ({ data: [], isLoading: false })),
   useDeleteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRenameConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useToggleFavoriteConversation: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useFavoriteConversations: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 
 vi.mock("@/lib/hooks/use-auth", () => ({

--- a/server/alembic/versions/20260427_41_add_conversation_is_favorite.py
+++ b/server/alembic/versions/20260427_41_add_conversation_is_favorite.py
@@ -1,0 +1,34 @@
+"""add is_favorite to conversations
+
+Revision ID: 20260427_41
+Revises: 20260425_40
+Create Date: 2026-04-27
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260427_41"
+down_revision: str | None = "20260425_40"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("is_favorite", sa.Boolean(), nullable=False, server_default="false"),
+    )
+    op.create_index(
+        "ix_conversations_user_favorite",
+        "conversations",
+        ["user_id", "is_favorite"],
+        postgresql_where=sa.text("is_favorite = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_user_favorite", table_name="conversations")
+    op.drop_column("conversations", "is_favorite")

--- a/server/src/raggae/application/dto/conversation_detail_dto.py
+++ b/server/src/raggae/application/dto/conversation_detail_dto.py
@@ -12,5 +12,6 @@ class ConversationDetailDTO:
     user_id: UUID
     created_at: datetime
     title: str | None
+    is_favorite: bool
     message_count: int
     last_message: MessageDTO | None

--- a/server/src/raggae/application/dto/conversation_dto.py
+++ b/server/src/raggae/application/dto/conversation_dto.py
@@ -12,6 +12,7 @@ class ConversationDTO:
     user_id: UUID
     created_at: datetime
     title: str | None
+    is_favorite: bool = False
 
     @classmethod
     def from_entity(cls, conversation: Conversation) -> "ConversationDTO":
@@ -21,4 +22,5 @@ class ConversationDTO:
             user_id=conversation.user_id,
             created_at=conversation.created_at,
             title=conversation.title,
+            is_favorite=conversation.is_favorite,
         )

--- a/server/src/raggae/application/dto/favorite_conversation_dto.py
+++ b/server/src/raggae/application/dto/favorite_conversation_dto.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from raggae.domain.entities.conversation import Conversation
+
+
+@dataclass
+class FavoriteConversationResult:
+    """Résultat enrichi d'une conversation favorite avec le nom du projet associé."""
+
+    conversation: Conversation
+    project_name: str

--- a/server/src/raggae/application/interfaces/repositories/conversation_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/conversation_repository.py
@@ -4,6 +4,14 @@ from uuid import UUID
 from raggae.domain.entities.conversation import Conversation
 
 
+class FavoriteConversationResult:
+    """Conversation with its project name, for cross-project favorites listing."""
+
+    def __init__(self, conversation: Conversation, project_name: str) -> None:
+        self.conversation = conversation
+        self.project_name = project_name
+
+
 class ConversationRepository(Protocol):
     """Interface for conversation persistence."""
 
@@ -24,3 +32,12 @@ class ConversationRepository(Protocol):
     async def delete(self, conversation_id: UUID) -> None: ...
 
     async def update_title(self, conversation_id: UUID, title: str) -> None: ...
+
+    async def toggle_favorite(self, conversation_id: UUID) -> Conversation: ...
+
+    async def find_favorites_by_user(
+        self,
+        user_id: UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FavoriteConversationResult]: ...

--- a/server/src/raggae/application/interfaces/repositories/conversation_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/conversation_repository.py
@@ -1,15 +1,8 @@
 from typing import Protocol
 from uuid import UUID
 
+from raggae.application.dto.favorite_conversation_dto import FavoriteConversationResult
 from raggae.domain.entities.conversation import Conversation
-
-
-class FavoriteConversationResult:
-    """Conversation with its project name, for cross-project favorites listing."""
-
-    def __init__(self, conversation: Conversation, project_name: str) -> None:
-        self.conversation = conversation
-        self.project_name = project_name
 
 
 class ConversationRepository(Protocol):

--- a/server/src/raggae/application/use_cases/chat/get_conversation.py
+++ b/server/src/raggae/application/use_cases/chat/get_conversation.py
@@ -64,6 +64,7 @@ class GetConversation:
             user_id=conversation.user_id,
             created_at=conversation.created_at,
             title=conversation.title,
+            is_favorite=conversation.is_favorite,
             message_count=message_count,
             last_message=MessageDTO.from_entity(latest) if latest is not None else None,
         )

--- a/server/src/raggae/application/use_cases/chat/list_favorite_conversations.py
+++ b/server/src/raggae/application/use_cases/chat/list_favorite_conversations.py
@@ -1,0 +1,25 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.conversation_repository import (
+    ConversationRepository,
+    FavoriteConversationResult,
+)
+
+
+class ListFavoriteConversations:
+    """Use Case: List all favorite conversations for the current user across all projects."""
+
+    def __init__(self, conversation_repository: ConversationRepository) -> None:
+        self._conversation_repository = conversation_repository
+
+    async def execute(
+        self,
+        user_id: UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FavoriteConversationResult]:
+        return await self._conversation_repository.find_favorites_by_user(
+            user_id=user_id,
+            limit=limit,
+            offset=offset,
+        )

--- a/server/src/raggae/application/use_cases/chat/list_favorite_conversations.py
+++ b/server/src/raggae/application/use_cases/chat/list_favorite_conversations.py
@@ -1,9 +1,7 @@
 from uuid import UUID
 
-from raggae.application.interfaces.repositories.conversation_repository import (
-    ConversationRepository,
-    FavoriteConversationResult,
-)
+from raggae.application.dto.favorite_conversation_dto import FavoriteConversationResult
+from raggae.application.interfaces.repositories.conversation_repository import ConversationRepository
 
 
 class ListFavoriteConversations:

--- a/server/src/raggae/application/use_cases/chat/toggle_favorite_conversation.py
+++ b/server/src/raggae/application/use_cases/chat/toggle_favorite_conversation.py
@@ -1,0 +1,23 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.conversation_repository import ConversationRepository
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.exceptions.conversation_exceptions import (
+    ConversationAccessDeniedError,
+    ConversationNotFoundError,
+)
+
+
+class ToggleFavoriteConversation:
+    """Use Case: Toggle the favorite status of a conversation owned by the user."""
+
+    def __init__(self, conversation_repository: ConversationRepository) -> None:
+        self._conversation_repository = conversation_repository
+
+    async def execute(self, conversation_id: UUID, user_id: UUID) -> Conversation:
+        conversation = await self._conversation_repository.find_by_id(conversation_id)
+        if conversation is None:
+            raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
+        if conversation.user_id != user_id:
+            raise ConversationAccessDeniedError(f"User {user_id} does not own conversation {conversation_id}")
+        return await self._conversation_repository.toggle_favorite(conversation_id)

--- a/server/src/raggae/domain/entities/conversation.py
+++ b/server/src/raggae/domain/entities/conversation.py
@@ -12,3 +12,4 @@ class Conversation:
     user_id: UUID
     created_at: datetime
     title: str | None = None
+    is_favorite: bool = False

--- a/server/src/raggae/domain/exceptions/conversation_exceptions.py
+++ b/server/src/raggae/domain/exceptions/conversation_exceptions.py
@@ -1,2 +1,6 @@
 class ConversationNotFoundError(Exception):
     """Raised when a conversation cannot be found."""
+
+
+class ConversationAccessDeniedError(Exception):
+    """Raised when a user tries to access a conversation they do not own."""

--- a/server/src/raggae/infrastructure/database/models/conversation_model.py
+++ b/server/src/raggae/infrastructure/database/models/conversation_model.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, text
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,3 +26,13 @@ class ConversationModel(Base):
     )
     title: Mapped[str | None] = mapped_column(String(255), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    is_favorite: Mapped[bool] = mapped_column(Boolean(), nullable=False, server_default="false")
+
+    __table_args__ = (
+        Index(
+            "ix_conversations_user_favorite",
+            "user_id",
+            "is_favorite",
+            postgresql_where=text("is_favorite = true"),
+        ),
+    )

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_conversation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_conversation_repository.py
@@ -2,7 +2,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
-from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
+from raggae.application.dto.favorite_conversation_dto import FavoriteConversationResult
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 
@@ -10,8 +10,9 @@ from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoun
 class InMemoryConversationRepository:
     """In-memory conversation repository for testing."""
 
-    def __init__(self) -> None:
+    def __init__(self, project_names: dict[UUID, str] | None = None) -> None:
         self._conversations: dict[UUID, Conversation] = {}
+        self._project_names: dict[UUID, str] = project_names or {}
 
     async def create(self, project_id: UUID, user_id: UUID) -> Conversation:
         created = Conversation(
@@ -73,7 +74,10 @@ class InMemoryConversationRepository:
         offset: int = 0,
     ) -> list[FavoriteConversationResult]:
         favorites = [
-            FavoriteConversationResult(conversation=c, project_name="")
+            FavoriteConversationResult(
+                conversation=c,
+                project_name=self._project_names.get(c.project_id, ""),
+            )
             for c in self._conversations.values()
             if c.user_id == user_id and c.is_favorite
         ]

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_conversation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_conversation_repository.py
@@ -2,7 +2,9 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
 
+from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
 from raggae.domain.entities.conversation import Conversation
+from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 
 
 class InMemoryConversationRepository:
@@ -55,3 +57,25 @@ class InMemoryConversationRepository:
         if conversation is None:
             return
         self._conversations[conversation_id] = replace(conversation, title=title)
+
+    async def toggle_favorite(self, conversation_id: UUID) -> Conversation:
+        conversation = self._conversations.get(conversation_id)
+        if conversation is None:
+            raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
+        updated = replace(conversation, is_favorite=not conversation.is_favorite)
+        self._conversations[conversation_id] = updated
+        return updated
+
+    async def find_favorites_by_user(
+        self,
+        user_id: UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FavoriteConversationResult]:
+        favorites = [
+            FavoriteConversationResult(conversation=c, project_name="")
+            for c in self._conversations.values()
+            if c.user_id == user_id and c.is_favorite
+        ]
+        favorites.sort(key=lambda r: r.conversation.created_at, reverse=True)
+        return favorites[offset : offset + limit]

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
@@ -4,8 +4,21 @@ from uuid import UUID, uuid4
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
 from raggae.domain.entities.conversation import Conversation
 from raggae.infrastructure.database.models.conversation_model import ConversationModel
+from raggae.infrastructure.database.models.project_model import ProjectModel
+
+
+def _to_entity(model: ConversationModel) -> Conversation:
+    return Conversation(
+        id=model.id,
+        project_id=model.project_id,
+        user_id=model.user_id,
+        created_at=model.created_at,
+        title=model.title,
+        is_favorite=model.is_favorite,
+    )
 
 
 class SQLAlchemyConversationRepository:
@@ -25,13 +38,7 @@ class SQLAlchemyConversationRepository:
             )
             session.add(model)
             await session.commit()
-            return Conversation(
-                id=model.id,
-                project_id=model.project_id,
-                user_id=model.user_id,
-                created_at=model.created_at,
-                title=model.title,
-            )
+            return _to_entity(model)
 
     async def get_or_create(self, project_id: UUID, user_id: UUID) -> Conversation:
         async with self._session_factory() as session:
@@ -48,13 +55,7 @@ class SQLAlchemyConversationRepository:
                 .first()
             )
             if existing is not None:
-                return Conversation(
-                    id=existing.id,
-                    project_id=existing.project_id,
-                    user_id=existing.user_id,
-                    created_at=existing.created_at,
-                    title=existing.title,
-                )
+                return _to_entity(existing)
 
             model = ConversationModel(
                 id=uuid4(),
@@ -65,26 +66,14 @@ class SQLAlchemyConversationRepository:
             )
             session.add(model)
             await session.commit()
-            return Conversation(
-                id=model.id,
-                project_id=model.project_id,
-                user_id=model.user_id,
-                created_at=model.created_at,
-                title=model.title,
-            )
+            return _to_entity(model)
 
     async def find_by_id(self, conversation_id: UUID) -> Conversation | None:
         async with self._session_factory() as session:
             model = await session.get(ConversationModel, conversation_id)
             if model is None:
                 return None
-            return Conversation(
-                id=model.id,
-                project_id=model.project_id,
-                user_id=model.user_id,
-                created_at=model.created_at,
-                title=model.title,
-            )
+            return _to_entity(model)
 
     async def find_by_project_and_user(
         self,
@@ -106,16 +95,7 @@ class SQLAlchemyConversationRepository:
                     .limit(limit)
                 )
             ).scalars()
-            return [
-                Conversation(
-                    id=model.id,
-                    project_id=model.project_id,
-                    user_id=model.user_id,
-                    created_at=model.created_at,
-                    title=model.title,
-                )
-                for model in models
-            ]
+            return [_to_entity(model) for model in models]
 
     async def delete(self, conversation_id: UUID) -> None:
         async with self._session_factory() as session:
@@ -129,3 +109,42 @@ class SQLAlchemyConversationRepository:
                 return
             model.title = title
             await session.commit()
+
+    async def toggle_favorite(self, conversation_id: UUID) -> Conversation:
+        async with self._session_factory() as session:
+            model = await session.get(ConversationModel, conversation_id)
+            if model is None:
+                from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
+
+                raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
+            model.is_favorite = not model.is_favorite
+            await session.commit()
+            return _to_entity(model)
+
+    async def find_favorites_by_user(
+        self,
+        user_id: UUID,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[FavoriteConversationResult]:
+        async with self._session_factory() as session:
+            rows = (
+                await session.execute(
+                    select(ConversationModel, ProjectModel.name)
+                    .join(ProjectModel, ConversationModel.project_id == ProjectModel.id)
+                    .where(
+                        ConversationModel.user_id == user_id,
+                        ConversationModel.is_favorite.is_(True),
+                    )
+                    .order_by(ConversationModel.created_at.desc())
+                    .offset(offset)
+                    .limit(limit)
+                )
+            ).all()
+            return [
+                FavoriteConversationResult(
+                    conversation=_to_entity(conv_model),
+                    project_name=project_name,
+                )
+                for conv_model, project_name in rows
+            ]

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
@@ -113,7 +113,7 @@ class SQLAlchemyConversationRepository:
 
     async def toggle_favorite(self, conversation_id: UUID) -> Conversation:
         async with self._session_factory() as session:
-            model = await session.get(ConversationModel, conversation_id)
+            model = await session.get(ConversationModel, conversation_id, with_for_update=True)
             if model is None:
                 raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
             model.is_favorite = not model.is_favorite

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_conversation_repository.py
@@ -4,8 +4,9 @@ from uuid import UUID, uuid4
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
+from raggae.application.dto.favorite_conversation_dto import FavoriteConversationResult
 from raggae.domain.entities.conversation import Conversation
+from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
 from raggae.infrastructure.database.models.conversation_model import ConversationModel
 from raggae.infrastructure.database.models.project_model import ProjectModel
 
@@ -114,8 +115,6 @@ class SQLAlchemyConversationRepository:
         async with self._session_factory() as session:
             model = await session.get(ConversationModel, conversation_id)
             if model is None:
-                from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
-
                 raise ConversationNotFoundError(f"Conversation {conversation_id} not found")
             model.is_favorite = not model.is_favorite
             await session.commit()

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -91,8 +91,10 @@ from raggae.application.use_cases.chat.list_conversation_messages import (
     ListConversationMessages,
 )
 from raggae.application.use_cases.chat.list_conversations import ListConversations
+from raggae.application.use_cases.chat.list_favorite_conversations import ListFavoriteConversations
 from raggae.application.use_cases.chat.query_relevant_chunks import QueryRelevantChunks
 from raggae.application.use_cases.chat.send_message import SendMessage
+from raggae.application.use_cases.chat.toggle_favorite_conversation import ToggleFavoriteConversation
 from raggae.application.use_cases.chat.update_conversation import UpdateConversation
 from raggae.application.use_cases.document.delete_document import DeleteDocument
 from raggae.application.use_cases.document.get_document_file import GetDocumentFile
@@ -881,6 +883,14 @@ def get_update_conversation_use_case() -> UpdateConversation:
         conversation_repository=_conversation_repository,
         organization_member_repository=_organization_member_repository,
     )
+
+
+def get_toggle_favorite_conversation_use_case() -> ToggleFavoriteConversation:
+    return ToggleFavoriteConversation(conversation_repository=_conversation_repository)
+
+
+def get_list_favorite_conversations_use_case() -> ListFavoriteConversations:
+    return ListFavoriteConversations(conversation_repository=_conversation_repository)
 
 
 def get_create_organization_use_case() -> CreateOrganization:

--- a/server/src/raggae/presentation/api/v1/endpoints/chat.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/chat.py
@@ -15,9 +15,13 @@ from raggae.application.use_cases.chat.list_conversation_messages import (
 )
 from raggae.application.use_cases.chat.list_conversations import ListConversations
 from raggae.application.use_cases.chat.send_message import SendMessage
+from raggae.application.use_cases.chat.toggle_favorite_conversation import ToggleFavoriteConversation
 from raggae.application.use_cases.chat.update_conversation import UpdateConversation
 from raggae.application.use_cases.project.get_project import GetProject
-from raggae.domain.exceptions.conversation_exceptions import ConversationNotFoundError
+from raggae.domain.exceptions.conversation_exceptions import (
+    ConversationAccessDeniedError,
+    ConversationNotFoundError,
+)
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
 from raggae.domain.exceptions.project_exceptions import (
     ProjectNotFoundError,
@@ -32,6 +36,7 @@ from raggae.presentation.api.dependencies import (
     get_list_conversation_messages_use_case,
     get_list_conversations_use_case,
     get_send_message_use_case,
+    get_toggle_favorite_conversation_use_case,
     get_update_conversation_use_case,
 )
 from raggae.presentation.api.v1.schemas.chat_schemas import (
@@ -324,6 +329,7 @@ async def list_conversations(
             user_id=conversation.user_id,
             created_at=conversation.created_at,
             title=conversation.title,
+            is_favorite=conversation.is_favorite,
         )
         for conversation in conversations
     ]
@@ -359,6 +365,7 @@ async def get_conversation(
         user_id=conversation.user_id,
         created_at=conversation.created_at,
         title=conversation.title,
+        is_favorite=conversation.is_favorite,
         message_count=conversation.message_count,
         last_message=(
             MessageResponse(
@@ -424,3 +431,36 @@ async def update_conversation(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Conversation not found",
         ) from None
+
+
+@router.patch("/conversations/{conversation_id}/favorite")
+async def toggle_favorite_conversation(
+    project_id: UUID,
+    conversation_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ToggleFavoriteConversation, Depends(get_toggle_favorite_conversation_use_case)],
+) -> ConversationResponse:
+    try:
+        conversation = await use_case.execute(
+            conversation_id=conversation_id,
+            user_id=user_id,
+        )
+    except ConversationNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found",
+        ) from None
+    except ConversationAccessDeniedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Access denied",
+        ) from None
+
+    return ConversationResponse(
+        id=conversation.id,
+        project_id=conversation.project_id,
+        user_id=conversation.user_id,
+        created_at=conversation.created_at,
+        title=conversation.title,
+        is_favorite=conversation.is_favorite,
+    )

--- a/server/src/raggae/presentation/api/v1/endpoints/users.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/users.py
@@ -1,0 +1,39 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from raggae.application.use_cases.chat.list_favorite_conversations import ListFavoriteConversations
+from raggae.presentation.api.dependencies import (
+    get_current_user_id,
+    get_list_favorite_conversations_use_case,
+)
+from raggae.presentation.api.v1.schemas.chat_schemas import FavoriteConversationResponse
+
+router = APIRouter(
+    prefix="/users",
+    tags=["users"],
+    dependencies=[Depends(get_current_user_id)],
+)
+
+
+@router.get("/me/conversations/favorites")
+async def list_favorite_conversations(
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ListFavoriteConversations, Depends(get_list_favorite_conversations_use_case)],
+    limit: int = 50,
+    offset: int = 0,
+) -> list[FavoriteConversationResponse]:
+    results = await use_case.execute(user_id=user_id, limit=limit, offset=offset)
+    return [
+        FavoriteConversationResponse(
+            id=result.conversation.id,
+            project_id=result.conversation.project_id,
+            user_id=result.conversation.user_id,
+            created_at=result.conversation.created_at,
+            title=result.conversation.title,
+            is_favorite=result.conversation.is_favorite,
+            project_name=result.project_name,
+        )
+        for result in results
+    ]

--- a/server/src/raggae/presentation/api/v1/schemas/chat_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/chat_schemas.py
@@ -52,6 +52,7 @@ class ConversationResponse(BaseModel):
     user_id: UUID
     created_at: datetime
     title: str | None
+    is_favorite: bool
 
 
 class ConversationDetailResponse(BaseModel):
@@ -60,8 +61,13 @@ class ConversationDetailResponse(BaseModel):
     user_id: UUID
     created_at: datetime
     title: str | None
+    is_favorite: bool
     message_count: int
     last_message: MessageResponse | None
+
+
+class FavoriteConversationResponse(ConversationResponse):
+    project_name: str
 
 
 class UpdateConversationRequest(BaseModel):

--- a/server/src/raggae/presentation/main.py
+++ b/server/src/raggae/presentation/main.py
@@ -25,6 +25,7 @@ from raggae.presentation.api.v1.endpoints.project_snapshots import (
 )
 from raggae.presentation.api.v1.endpoints.projects import router as projects_router
 from raggae.presentation.api.v1.endpoints.stats import router as stats_router
+from raggae.presentation.api.v1.endpoints.users import router as users_router
 
 logging.getLogger("raggae").setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
@@ -80,6 +81,7 @@ app.include_router(model_catalog_router, prefix="/api/v1")
 app.include_router(model_credentials_router, prefix="/api/v1")
 app.include_router(org_model_credentials_router, prefix="/api/v1")
 app.include_router(stats_router, prefix="/api/v1")
+app.include_router(users_router, prefix="/api/v1")
 
 
 @app.get("/health")

--- a/server/tests/e2e/test_chat_endpoints.py
+++ b/server/tests/e2e/test_chat_endpoints.py
@@ -685,3 +685,139 @@ class TestChatEndpoints:
 
         # Then
         assert response.status_code == 404
+
+    async def test_toggle_favorite_by_owner_returns_200_and_is_favorite_true(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        # Given
+        headers, project_id = await self._create_project(client)
+        send_response = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "hello", "limit": 3},
+            headers=headers,
+        )
+        conversation_id = send_response.json()["conversation_id"]
+
+        # When
+        response = await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{conversation_id}/favorite",
+            headers=headers,
+        )
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert data["is_favorite"] is True
+
+    async def test_toggle_favorite_twice_returns_is_favorite_false(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        # Given
+        headers, project_id = await self._create_project(client)
+        send_response = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "hello", "limit": 3},
+            headers=headers,
+        )
+        conversation_id = send_response.json()["conversation_id"]
+        await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{conversation_id}/favorite",
+            headers=headers,
+        )
+
+        # When
+        response = await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{conversation_id}/favorite",
+            headers=headers,
+        )
+
+        # Then
+        assert response.status_code == 200
+        assert response.json()["is_favorite"] is False
+
+    async def test_toggle_favorite_by_other_user_returns_403(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        # Given
+        owner_headers, project_id = await self._create_project(client)
+        send_response = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "hello", "limit": 3},
+            headers=owner_headers,
+        )
+        conversation_id = send_response.json()["conversation_id"]
+        other_headers = await self._auth_headers(client)
+
+        # When
+        response = await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{conversation_id}/favorite",
+            headers=other_headers,
+        )
+
+        # Then
+        assert response.status_code == 403
+
+    async def test_list_favorite_conversations_returns_favorites_cross_projects(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        # Given
+        headers, project_id = await self._create_project(client)
+        send_response = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "hello", "limit": 3},
+            headers=headers,
+        )
+        conversation_id = send_response.json()["conversation_id"]
+        await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{conversation_id}/favorite",
+            headers=headers,
+        )
+
+        # When
+        response = await client.get("/api/v1/users/me/conversations/favorites", headers=headers)
+
+        # Then
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["id"] == conversation_id
+        assert data[0]["is_favorite"] is True
+
+    async def test_list_favorite_conversations_sorted_by_created_at_desc(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        # Given
+        headers, project_id = await self._create_project(client)
+        first = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "first", "limit": 3, "start_new_conversation": True},
+            headers=headers,
+        )
+        second = await client.post(
+            f"/api/v1/projects/{project_id}/chat/messages",
+            json={"message": "second", "limit": 3, "start_new_conversation": True},
+            headers=headers,
+        )
+        first_id = first.json()["conversation_id"]
+        second_id = second.json()["conversation_id"]
+        await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{first_id}/favorite",
+            headers=headers,
+        )
+        await client.patch(
+            f"/api/v1/projects/{project_id}/chat/conversations/{second_id}/favorite",
+            headers=headers,
+        )
+
+        # When
+        response = await client.get("/api/v1/users/me/conversations/favorites", headers=headers)
+
+        # Then
+        assert response.status_code == 200
+        ids = [item["id"] for item in response.json()]
+        assert ids.index(second_id) < ids.index(first_id)

--- a/server/tests/unit/application/use_cases/chat/test_list_favorite_conversations.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_favorite_conversations.py
@@ -2,7 +2,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
-from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
+from raggae.application.dto.favorite_conversation_dto import FavoriteConversationResult
 from raggae.application.use_cases.chat.list_favorite_conversations import ListFavoriteConversations
 from raggae.domain.entities.conversation import Conversation
 

--- a/server/tests/unit/application/use_cases/chat/test_list_favorite_conversations.py
+++ b/server/tests/unit/application/use_cases/chat/test_list_favorite_conversations.py
@@ -1,0 +1,56 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from raggae.application.interfaces.repositories.conversation_repository import FavoriteConversationResult
+from raggae.application.use_cases.chat.list_favorite_conversations import ListFavoriteConversations
+from raggae.domain.entities.conversation import Conversation
+
+
+class TestListFavoriteConversations:
+    async def test_returns_favorites_for_user(self) -> None:
+        # Given
+        user_id = uuid4()
+        conv1 = Conversation(
+            id=uuid4(),
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=True,
+        )
+        conv2 = Conversation(
+            id=uuid4(),
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=True,
+        )
+        conversation_repository = AsyncMock()
+        conversation_repository.find_favorites_by_user.return_value = [
+            FavoriteConversationResult(conversation=conv1, project_name="Project A"),
+            FavoriteConversationResult(conversation=conv2, project_name="Project B"),
+        ]
+        use_case = ListFavoriteConversations(conversation_repository=conversation_repository)
+
+        # When
+        results = await use_case.execute(user_id=user_id, limit=50, offset=0)
+
+        # Then
+        assert len(results) == 2
+        assert results[0].project_name == "Project A"
+        assert results[1].project_name == "Project B"
+        conversation_repository.find_favorites_by_user.assert_awaited_once_with(
+            user_id=user_id, limit=50, offset=0
+        )
+
+    async def test_returns_empty_list_when_no_favorites(self) -> None:
+        # Given
+        conversation_repository = AsyncMock()
+        conversation_repository.find_favorites_by_user.return_value = []
+        use_case = ListFavoriteConversations(conversation_repository=conversation_repository)
+
+        # When
+        results = await use_case.execute(user_id=uuid4(), limit=50, offset=0)
+
+        # Then
+        assert results == []

--- a/server/tests/unit/application/use_cases/chat/test_toggle_favorite_conversation.py
+++ b/server/tests/unit/application/use_cases/chat/test_toggle_favorite_conversation.py
@@ -1,0 +1,94 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.chat.toggle_favorite_conversation import ToggleFavoriteConversation
+from raggae.domain.entities.conversation import Conversation
+from raggae.domain.exceptions.conversation_exceptions import (
+    ConversationAccessDeniedError,
+    ConversationNotFoundError,
+)
+
+
+class TestToggleFavoriteConversation:
+    async def test_toggle_favorite_sets_is_favorite_to_true(self) -> None:
+        # Given
+        user_id = uuid4()
+        conversation_id = uuid4()
+        conversation_repository = AsyncMock()
+        conversation_repository.find_by_id.return_value = Conversation(
+            id=conversation_id,
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=False,
+        )
+        conversation_repository.toggle_favorite.return_value = Conversation(
+            id=conversation_id,
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=True,
+        )
+        use_case = ToggleFavoriteConversation(conversation_repository=conversation_repository)
+
+        # When
+        result = await use_case.execute(conversation_id=conversation_id, user_id=user_id)
+
+        # Then
+        assert result.is_favorite is True
+        conversation_repository.toggle_favorite.assert_awaited_once_with(conversation_id)
+
+    async def test_toggle_favorite_sets_is_favorite_to_false(self) -> None:
+        # Given
+        user_id = uuid4()
+        conversation_id = uuid4()
+        conversation_repository = AsyncMock()
+        conversation_repository.find_by_id.return_value = Conversation(
+            id=conversation_id,
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=True,
+        )
+        conversation_repository.toggle_favorite.return_value = Conversation(
+            id=conversation_id,
+            project_id=uuid4(),
+            user_id=user_id,
+            created_at=datetime.now(UTC),
+            is_favorite=False,
+        )
+        use_case = ToggleFavoriteConversation(conversation_repository=conversation_repository)
+
+        # When
+        result = await use_case.execute(conversation_id=conversation_id, user_id=user_id)
+
+        # Then
+        assert result.is_favorite is False
+
+    async def test_toggle_favorite_unknown_conversation_raises_error(self) -> None:
+        # Given
+        conversation_repository = AsyncMock()
+        conversation_repository.find_by_id.return_value = None
+        use_case = ToggleFavoriteConversation(conversation_repository=conversation_repository)
+
+        # When / Then
+        with pytest.raises(ConversationNotFoundError):
+            await use_case.execute(conversation_id=uuid4(), user_id=uuid4())
+
+    async def test_toggle_favorite_non_owner_raises_access_denied(self) -> None:
+        # Given
+        conversation_repository = AsyncMock()
+        conversation_repository.find_by_id.return_value = Conversation(
+            id=uuid4(),
+            project_id=uuid4(),
+            user_id=uuid4(),
+            created_at=datetime.now(UTC),
+        )
+        use_case = ToggleFavoriteConversation(conversation_repository=conversation_repository)
+
+        # When / Then
+        with pytest.raises(ConversationAccessDeniedError):
+            await use_case.execute(conversation_id=uuid4(), user_id=uuid4())

--- a/server/tests/unit/domain/entities/test_conversation.py
+++ b/server/tests/unit/domain/entities/test_conversation.py
@@ -1,0 +1,31 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from raggae.domain.entities.conversation import Conversation
+
+
+class TestConversation:
+    def test_is_favorite_defaults_to_false(self) -> None:
+        # Given / When
+        conversation = Conversation(
+            id=uuid4(),
+            project_id=uuid4(),
+            user_id=uuid4(),
+            created_at=datetime.now(UTC),
+        )
+
+        # Then
+        assert conversation.is_favorite is False
+
+    def test_is_favorite_can_be_set_to_true(self) -> None:
+        # Given / When
+        conversation = Conversation(
+            id=uuid4(),
+            project_id=uuid4(),
+            user_id=uuid4(),
+            created_at=datetime.now(UTC),
+            is_favorite=True,
+        )
+
+        # Then
+        assert conversation.is_favorite is True


### PR DESCRIPTION
## Problème
Les utilisateurs ne peuvent pas identifier rapidement leurs conversations importantes. Il n'existe aucun moyen de mettre en avant certaines conversations dans la sidebar.

## Solution
Ajout d'un système de favoris : chaque conversation peut être marquée comme favorite via un bouton étoile. Les favoris sont affichés dans une section dédiée « MES FAVORIS » en haut de la sidebar, au-dessus des projets.

## Implémentation

**Backend (TDD)**
- `Conversation` entity : ajout du champ `is_favorite: bool`
- Migration Alembic : colonne `is_favorite` + index partiel sur les favoris actifs
- Repository : `toggle_favorite()` et `find_favorites_by_user()` (SQLAlchemy + in-memory)
- Use cases : `ToggleFavoriteConversation` (avec vérification d'accès) et `ListFavoriteConversations`
- Endpoint `PATCH /projects/{id}/chat/conversations/{id}/favorite` → 200 avec `is_favorite` retourné
- Endpoint `GET /users/me/conversations/favorites` → liste cross-projets triée DESC
- `ConversationResponse` et `ConversationDetailResponse` exposent désormais `is_favorite`

**Frontend**
- Hook `useToggleFavoriteConversation` et `useFavoriteConversations` (React Query)
- Bouton étoile dans le menu contextuel de chaque conversation (sidebar)
- Bouton étoile dans la barre d'actions du template de chat
- Organisme `FavoriteConversationsSection` affiché au-dessus de « MES PROJETS » si au moins un favori existe
- Traductions i18n FR/EN ajoutées

## Recette
1. Créer une conversation et envoyer un message
2. Dans la sidebar, ouvrir le menu de la conversation (⋯) → « Ajouter aux favoris »
3. Vérifier que la conversation apparaît dans « MES FAVORIS » en haut de la sidebar
4. Cliquer à nouveau → « Retirer des favoris » → la section disparaît si c'était le seul favori
5. Depuis la page de chat, cliquer sur l'étoile dans la barre du haut → même comportement
6. Vérifier qu'un autre utilisateur ne peut pas toggler les favoris d'une conversation qui ne lui appartient pas (403)