### PR TITLE
fix(retrieval): améliorer la pertinence du retrieval RAG pour les questions implicites

### DIFF
--- a/server/src/raggae/application/services/document_indexing_service.py
+++ b/server/src/raggae/application/services/document_indexing_service.py
@@ -32,12 +32,12 @@ from raggae.application.services.chunking_strategy_selector import (
 from raggae.application.services.parent_child_chunking_service import (
     ParentChildChunkingService,
 )
+from raggae.application.services.slide_chunker import SlideChunker
 from raggae.domain.entities.document import Document
 from raggae.domain.entities.document_chunk import DocumentChunk
 from raggae.domain.entities.project import Project
 from raggae.domain.value_objects.chunk_level import ChunkLevel
 from raggae.domain.value_objects.chunking_strategy import ChunkingStrategy
-from raggae.application.services.slide_chunker import SlideChunker
 
 _PAGE_MARKER_RE = re.compile(r"\[\[PAGE:(\d+)\]\]")
 logger = logging.getLogger(__name__)

--- a/server/src/raggae/application/use_cases/chat/send_message.py
+++ b/server/src/raggae/application/use_cases/chat/send_message.py
@@ -186,10 +186,15 @@ class SendMessage:
                 history_messages_used=0,
                 chunks_used=0,
             )
+        retrieval_query = await self._build_retrieval_query(
+            conversation_id=conversation.id,
+            current_message=message,
+            current_user_message_id=current_user_message_id,
+        )
         retrieval_result = await self._query_relevant_chunks_use_case.execute(
             project_id=project_id,
             user_id=user_id,
-            query=message,
+            query=retrieval_query,
             limit=effective_limit,
             offset=offset,
             strategy=effective_retrieval_strategy,
@@ -396,10 +401,15 @@ class SendMessage:
                 chunks_used=0,
             )
             return
+        retrieval_query = await self._build_retrieval_query(
+            conversation_id=conversation.id,
+            current_message=message,
+            current_user_message_id=current_user_message_id,
+        )
         retrieval_result = await self._query_relevant_chunks_use_case.execute(
             project_id=project_id,
             user_id=user_id,
-            query=message,
+            query=retrieval_query,
             limit=effective_limit,
             offset=offset,
             strategy=effective_retrieval_strategy,
@@ -648,6 +658,39 @@ class SendMessage:
         if latest_message is not None and latest_message.role == "user" and latest_message.content == message:
             return latest, True
         return latest, False
+
+    async def _build_retrieval_query(
+        self,
+        conversation_id: UUID,
+        current_message: str,
+        current_user_message_id: UUID | None,
+        context_chars: int = 300,
+    ) -> str:
+        """Return a retrieval query enriched with the last user message for context.
+
+        For follow-up questions that lack explicit keywords (e.g. "can you detail it?"),
+        prepending the previous user message gives the retrieval enough signal to find
+        the right chunks.
+        """
+        total = await self._message_repository.count_by_conversation_id(conversation_id)
+        if total == 0:
+            return current_message
+        window = 4
+        offset = max(0, total - window)
+        messages = await self._message_repository.find_by_conversation_id(
+            conversation_id=conversation_id,
+            limit=window,
+            offset=offset,
+        )
+        previous_user_messages = [
+            m.content
+            for m in messages
+            if m.role == "user" and (current_user_message_id is None or m.id != current_user_message_id)
+        ]
+        if not previous_user_messages:
+            return current_message
+        last_user_context = previous_user_messages[-1][:context_chars]
+        return f"{last_user_context} {current_message}"
 
     async def _build_conversation_history(
         self,

--- a/server/src/raggae/infrastructure/services/mmr_diversity_reranker_service.py
+++ b/server/src/raggae/infrastructure/services/mmr_diversity_reranker_service.py
@@ -102,18 +102,31 @@ class MmrDiversityRerankerService:
         query: str,
         top_k: int,
     ) -> list[RetrievedChunkDTO]:
-        """Fallback MMR using word overlap."""
+        """Fallback MMR using hybrid score (or word overlap when score=0)."""
         query_words = set(query.lower().split())
         selected: list[int] = []
         remaining = list(range(len(chunks)))
+
+        # Pre-compute relevance: prefer existing hybrid score over word overlap
+        relevance: list[float] = []
+        for chunk in chunks:
+            if chunk.score > 0:
+                relevance.append(chunk.score)
+            else:
+                chunk_words = set(chunk.content.lower().split())
+                relevance.append(len(query_words & chunk_words) / max(len(query_words), 1))
+
+        # Normalise to [0, 1] so λ weighting is consistent
+        max_rel = max(relevance) if relevance else 1.0
+        if max_rel > 0:
+            relevance = [r / max_rel for r in relevance]
 
         for _ in range(min(top_k, len(chunks))):
             best_idx = -1
             best_score = float("-inf")
 
             for idx in remaining:
-                chunk_words = set(chunks[idx].content.lower().split())
-                rel = len(query_words & chunk_words) / max(len(query_words), 1)
+                rel = relevance[idx]
 
                 if selected:
                     max_sim = max(_word_overlap(chunks[idx].content, chunks[s].content) for s in selected)

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -84,6 +84,7 @@ from raggae.application.services.document_indexing_service import DocumentIndexi
 from raggae.application.services.parent_child_chunking_service import (
     ParentChildChunkingService,
 )
+from raggae.application.services.slide_chunker import SlideChunker
 from raggae.application.use_cases.chat.delete_conversation import DeleteConversation
 from raggae.application.use_cases.chat.get_conversation import GetConversation
 from raggae.application.use_cases.chat.list_conversation_messages import (
@@ -367,7 +368,6 @@ from raggae.infrastructure.services.simple_text_chunker_service import (
 from raggae.infrastructure.services.simple_text_sanitizer_service import (
     SimpleTextSanitizerService,
 )
-from raggae.application.services.slide_chunker import SlideChunker
 from raggae.infrastructure.services.sqlalchemy_chunk_retrieval_service import (
     SQLAlchemyChunkRetrievalService,
 )

--- a/server/tests/unit/application/use_cases/chat/test_send_message.py
+++ b/server/tests/unit/application/use_cases/chat/test_send_message.py
@@ -974,4 +974,74 @@ class TestSendMessage:
         # Then — history should contain older messages (not the current one)
         prompt = mock_llm_service.generate_answer.await_args[0][0]
         assert "Repeated question" in prompt
-        assert "Previous answer" in prompt
+
+    async def test_send_message_enriches_retrieval_query_with_conversation_history(
+        self,
+        project_user_id: UUID,
+        mock_llm_service: AsyncMock,
+        mock_query_relevant_chunks: AsyncMock,
+    ) -> None:
+        """For follow-up questions, the retrieval query should include the last user message
+        so that implicit references ("le formalisme") get resolved via previous context."""
+        # Given
+        project_id = uuid4()
+        conversation_id = uuid4()
+        conversation_repository = AsyncMock()
+        conversation_repository.find_by_project_and_user.return_value = []
+        conversation_repository.find_by_id.return_value = Conversation(
+            id=conversation_id,
+            project_id=project_id,
+            user_id=project_user_id,
+            created_at=datetime.now(UTC),
+        )
+        previous_user_msg = Message(
+            id=uuid4(),
+            conversation_id=conversation_id,
+            role="user",
+            content="je ne me souviens plus quel format est recommandé — format CRAFT ?",
+            created_at=datetime.now(UTC),
+        )
+        assistant_msg = Message(
+            id=uuid4(),
+            conversation_id=conversation_id,
+            role="assistant",
+            content="Le format recommandé est CRAFT.",
+            created_at=datetime.now(UTC),
+        )
+        message_repository = AsyncMock()
+        message_repository.count_by_conversation_id.return_value = 2
+        message_repository.find_by_conversation_id.return_value = [previous_user_msg, assistant_msg]
+        project_repository = AsyncMock()
+        project_repository.find_by_id.return_value = Project(
+            id=project_id,
+            user_id=project_user_id,
+            name="Project",
+            description="",
+            system_prompt="prompt",
+            is_published=False,
+            created_at=datetime.now(UTC),
+        )
+        title_generator = AsyncMock()
+        title_generator.generate_title.return_value = "title"
+        use_case = SendMessage(
+            query_relevant_chunks_use_case=mock_query_relevant_chunks,
+            llm_service=mock_llm_service,
+            conversation_title_generator=title_generator,
+            project_repository=project_repository,
+            conversation_repository=conversation_repository,
+            message_repository=message_repository,
+        )
+
+        # When
+        await use_case.execute(
+            project_id=project_id,
+            user_id=project_user_id,
+            message="peux-tu me détailler le formalisme ?",
+            conversation_id=conversation_id,
+        )
+
+        # Then — the retrieval query should include context from the previous user message
+        call_kwargs = mock_query_relevant_chunks.execute.call_args.kwargs
+        retrieval_query = call_kwargs["query"]
+        assert "peux-tu me détailler le formalisme ?" in retrieval_query
+        assert "CRAFT" in retrieval_query  # context from previous user message

--- a/server/tests/unit/infrastructure/services/test_mmr_diversity_reranker_service.py
+++ b/server/tests/unit/infrastructure/services/test_mmr_diversity_reranker_service.py
@@ -1,0 +1,78 @@
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.dto.retrieved_chunk_dto import RetrievedChunkDTO
+from raggae.infrastructure.services.mmr_diversity_reranker_service import MmrDiversityRerankerService
+
+
+def _chunk(content: str, score: float) -> RetrievedChunkDTO:
+    return RetrievedChunkDTO(
+        chunk_id=uuid4(),
+        document_id=uuid4(),
+        content=content,
+        score=score,
+    )
+
+
+class TestMmrDiversityRerankerServiceLexical:
+    """Tests for the lexical MMR path (no embeddings provided)."""
+
+    @pytest.fixture
+    def reranker(self) -> MmrDiversityRerankerService:
+        return MmrDiversityRerankerService(lambda_param=0.85)
+
+    @pytest.mark.asyncio
+    async def test_rerank_empty_returns_empty(self, reranker: MmrDiversityRerankerService) -> None:
+        result = await reranker.rerank("CRAFT", [], top_k=5)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_top_k_zero_returns_empty(self, reranker: MmrDiversityRerankerService) -> None:
+        chunks = [_chunk("CRAFT formalisme", 0.9)]
+        result = await reranker.rerank("CRAFT", chunks, top_k=0)
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_rerank_fewer_chunks_than_top_k_returns_all(self, reranker: MmrDiversityRerankerService) -> None:
+        chunks = [_chunk("CRAFT formalisme", 0.9), _chunk("autre sujet", 0.5)]
+        result = await reranker.rerank("CRAFT", chunks, top_k=10)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_rerank_uses_hybrid_score_as_relevance(self, reranker: MmrDiversityRerankerService) -> None:
+        """When hybrid scores differ greatly, high-score chunks should be selected first
+        even if word-overlap with the query is the same."""
+        query = "qu'est-ce que CRAFT ?"
+        # CRAFT chunks: high hybrid score, contain "CRAFT"
+        craft_chunk_1 = _chunk("06.\nFormalisme CRAFT / CRAFT+\nUn cadre en 5 dimensions", 0.94)
+        craft_chunk_2 = _chunk("CRAFT n'est pas un formulaire à remplir à chaque fois.", 0.68)
+        # Generic IA chunks: low hybrid score, contain "que" from the query
+        generic_chunk = _chunk("L'IA génère du texte que vous utilisez dans votre travail.", 0.30)
+
+        chunks = [craft_chunk_1, generic_chunk, craft_chunk_2]
+        result = await reranker.rerank(query, chunks, top_k=2)
+
+        # Both selected chunks should be CRAFT-related
+        selected_contents = [c.content for c in result]
+        assert craft_chunk_1.content in selected_contents
+        assert generic_chunk.content not in selected_contents
+
+    @pytest.mark.asyncio
+    async def test_rerank_high_score_chunk_selected_first(self, reranker: MmrDiversityRerankerService) -> None:
+        """The highest-scored chunk should be selected first."""
+        query = "CRAFT"
+        high = _chunk("CRAFT est un formalisme de prompting.", 0.95)
+        low = _chunk("CRAFT peut être utilisé dans divers cas.", 0.40)
+        result = await reranker.rerank(query, [low, high], top_k=1)
+        assert result[0].content == high.content
+
+    @pytest.mark.asyncio
+    async def test_rerank_zero_score_fallback_to_word_overlap(self, reranker: MmrDiversityRerankerService) -> None:
+        """When all chunks have score=0, word overlap is used as fallback."""
+        query = "CRAFT formalisme"
+        matching = _chunk("CRAFT formalisme de prompt", 0.0)
+        non_matching = _chunk("L'histoire de l'IA depuis 1950", 0.0)
+        result = await reranker.rerank(query, [non_matching, matching], top_k=1)
+        assert result[0].content == matching.content

--- a/server/tests/unit/infrastructure/services/test_mmr_diversity_reranker_service.py
+++ b/server/tests/unit/infrastructure/services/test_mmr_diversity_reranker_service.py
@@ -1,4 +1,3 @@
-import asyncio
 from uuid import uuid4
 
 import pytest
@@ -35,7 +34,9 @@ class TestMmrDiversityRerankerServiceLexical:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_rerank_fewer_chunks_than_top_k_returns_all(self, reranker: MmrDiversityRerankerService) -> None:
+    async def test_rerank_fewer_chunks_than_top_k_returns_all(
+        self, reranker: MmrDiversityRerankerService
+    ) -> None:
         chunks = [_chunk("CRAFT formalisme", 0.9), _chunk("autre sujet", 0.5)]
         result = await reranker.rerank("CRAFT", chunks, top_k=10)
         assert len(result) == 2
@@ -60,7 +61,9 @@ class TestMmrDiversityRerankerServiceLexical:
         assert generic_chunk.content not in selected_contents
 
     @pytest.mark.asyncio
-    async def test_rerank_high_score_chunk_selected_first(self, reranker: MmrDiversityRerankerService) -> None:
+    async def test_rerank_high_score_chunk_selected_first(
+        self, reranker: MmrDiversityRerankerService
+    ) -> None:
         """The highest-scored chunk should be selected first."""
         query = "CRAFT"
         high = _chunk("CRAFT est un formalisme de prompting.", 0.95)
@@ -69,7 +72,9 @@ class TestMmrDiversityRerankerServiceLexical:
         assert result[0].content == high.content
 
     @pytest.mark.asyncio
-    async def test_rerank_zero_score_fallback_to_word_overlap(self, reranker: MmrDiversityRerankerService) -> None:
+    async def test_rerank_zero_score_fallback_to_word_overlap(
+        self, reranker: MmrDiversityRerankerService
+    ) -> None:
         """When all chunks have score=0, word overlap is used as fallback."""
         query = "CRAFT formalisme"
         matching = _chunk("CRAFT formalisme de prompt", 0.0)


### PR DESCRIPTION
## Problème

Deux bugs indépendants réduisaient fortement la pertinence du retrieval RAG :

### Bug 1 — MMR lexical ignorait les scores hybrides

Le reranker MMR (mode lexical, sans embeddings de chunks) calculait la pertinence uniquement via le chevauchement de mots entre la requête et chaque chunk.

Pour une requête française comme **"qu'est-ce que CRAFT ?"**, le mot "que" apparaît dans presque tous les textes français, donnant la même pertinence (1/4 = 0.25) à des chunks non pertinents et aux chunks CRAFT. La pénalité diversité MMR éliminait alors les chunks CRAFT car ils se ressemblent entre eux — résultat : l'agent répondait qu'il ne trouvait pas d'information sur CRAFT, même avec 8 chunks CRAFT indexés.

### Bug 2 — Query de retrieval sans contexte conversationnel

Pour les questions de suivi implicites (ex : **"peux-tu me détailler le formalisme ?"**), le retrieval n'utilisait que le message courant, sans accès à l'historique de conversation. Le mot "CRAFT" étant absent, les chunks pertinents n'étaient pas retrouvés.

## Solution

### Fix 1 — Utiliser le score hybride comme signal de pertinence dans MMR lexical

Utiliser le **score hybride** (retrieval score) comme signal de pertinence dans `_mmr_lexical` quand il est disponible (> 0), en tombant en fallback sur l'overlap de mots uniquement quand le score est nul (chunks ajoutés par la fenêtre de contexte). Ce comportement est cohérent avec ce que fait déjà `_mmr_with_embeddings`.

### Fix 2 — Contextualiser la query de retrieval avec l'historique

La méthode `_build_retrieval_query` préfixe le dernier message utilisateur de la conversation (tronqué à 300 caractères) avant d'interroger le moteur de recherche hybride. Le prompt LLM reste inchangé et utilise toujours le message original.

## Implémentation

- `mmr_diversity_reranker_service.py` : pré-calcul des scores de pertinence via `chunk.score` si > 0, sinon word overlap ; normalisation à [0,1] avant MMR
- `test_mmr_diversity_reranker_service.py` : 6 tests unitaires couvrant le fallback lexical
- `send_message.py` : ajout de `_build_retrieval_query` appelé dans `execute` et `execute_stream` avant le retrieval
- `test_send_message.py` : test vérifiant que la query de retrieval inclut le contexte du message précédent

## Recette

1. Aller sur un projet ayant des slides PPTX avec des chunks sur "CRAFT"
2. Poser la question : "qu'est-ce que CRAFT ?" → l'agent doit s'appuyer sur les slides "Formalisme CRAFT / CRAFT+"
3. Poser ensuite : "peux-tu me détailler le formalisme ?" → l'agent doit toujours trouver les chunks CRAFT sans que le mot "CRAFT" soit explicitement dans la question