### PR TITLE
feat(knowledge): visualiser les chunks d'un document indexé (#108)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -541,7 +541,18 @@
       "downloadDocument": "Download document",
       "indexedAt": "Indexed {date}",
       "deleteConfirm": "Are you sure you want to delete \"{name}\"?",
-      "unableToLoadPreview": "Unable to load preview for this document."
+      "unableToLoadPreview": "Unable to load preview for this document.",
+      "chunksAriaLabel": "View chunks",
+      "chunksTitle": "Chunks",
+      "chunksDisabledTitle": "Document must be indexed to view chunks"
+    },
+    "chunks": {
+      "title": "{count} chunk(s)",
+      "loading": "Loading chunks...",
+      "empty": "No chunks found for this document.",
+      "error": "Unable to load chunks.",
+      "chunkLabel": "Chunk #{index}",
+      "metadata": "Metadata"
     }
   },
   "sidebar": {

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -541,7 +541,18 @@
       "downloadDocument": "Télécharger le document",
       "indexedAt": "Indexé le {date}",
       "deleteConfirm": "Êtes-vous sûr de vouloir supprimer « {name} » ?",
-      "unableToLoadPreview": "Impossible de charger l'aperçu de ce document."
+      "unableToLoadPreview": "Impossible de charger l'aperçu de ce document.",
+      "chunksAriaLabel": "Voir les chunks",
+      "chunksTitle": "Chunks",
+      "chunksDisabledTitle": "Le document doit être indexé pour accéder aux chunks"
+    },
+    "chunks": {
+      "title": "{count} chunk(s)",
+      "loading": "Chargement des chunks...",
+      "empty": "Aucun chunk pour ce document.",
+      "error": "Impossible de charger les chunks.",
+      "chunkLabel": "Chunk #{index}",
+      "metadata": "Métadonnées"
     }
   },
   "sidebar": {

--- a/client/src/components/atoms/document/chunk-accordion-item.tsx
+++ b/client/src/components/atoms/document/chunk-accordion-item.tsx
@@ -2,18 +2,18 @@
 
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
-import { useTranslations } from "next-intl";
 import type { DocumentChunkResponse } from "@/lib/types/api";
 
 const PREVIEW_LENGTH = 150;
 
 interface ChunkAccordionItemProps {
   chunk: DocumentChunkResponse;
+  ariaLabel: string;
+  metadataLabel: string;
 }
 
-export function ChunkAccordionItem({ chunk }: ChunkAccordionItemProps) {
+export function ChunkAccordionItem({ chunk, ariaLabel, metadataLabel }: ChunkAccordionItemProps) {
   const [expanded, setExpanded] = useState(false);
-  const t = useTranslations("documents.chunks");
 
   const preview =
     chunk.content.length > PREVIEW_LENGTH
@@ -24,7 +24,7 @@ export function ChunkAccordionItem({ chunk }: ChunkAccordionItemProps) {
     <div className="border-b last:border-b-0">
       <button
         type="button"
-        aria-label={t("chunkLabel", { index: chunk.chunk_index })}
+        aria-label={ariaLabel}
         aria-expanded={expanded}
         className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors"
         onClick={() => setExpanded((prev) => !prev)}
@@ -54,7 +54,7 @@ export function ChunkAccordionItem({ chunk }: ChunkAccordionItemProps) {
           {chunk.metadata_json && (
             <div data-testid="chunk-metadata">
               <p className="mb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-                {t("metadata")}
+                {metadataLabel}
               </p>
               <pre className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs font-mono">
                 {JSON.stringify(chunk.metadata_json, null, 2)}

--- a/client/src/components/atoms/document/chunk-accordion-item.tsx
+++ b/client/src/components/atoms/document/chunk-accordion-item.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
+import type { DocumentChunkResponse } from "@/lib/types/api";
+
+const PREVIEW_LENGTH = 150;
+
+interface ChunkAccordionItemProps {
+  chunk: DocumentChunkResponse;
+}
+
+export function ChunkAccordionItem({ chunk }: ChunkAccordionItemProps) {
+  const [expanded, setExpanded] = useState(false);
+  const t = useTranslations("documents.chunks");
+
+  const preview =
+    chunk.content.length > PREVIEW_LENGTH
+      ? chunk.content.slice(0, PREVIEW_LENGTH) + "…"
+      : chunk.content;
+
+  return (
+    <div className="border-b last:border-b-0">
+      <button
+        type="button"
+        aria-label={t("chunkLabel", { index: chunk.chunk_index })}
+        aria-expanded={expanded}
+        className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+        onClick={() => setExpanded((prev) => !prev)}
+      >
+        <span className="shrink-0 font-mono text-xs font-semibold text-muted-foreground w-8">
+          #{chunk.chunk_index}
+        </span>
+        <span
+          data-testid="chunk-preview"
+          className="flex-1 text-sm text-muted-foreground line-clamp-2"
+        >
+          {preview}
+        </span>
+        <ChevronDown
+          className={`shrink-0 size-4 text-muted-foreground transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {expanded && (
+        <div className="px-4 pb-4 space-y-3">
+          <pre
+            data-testid="chunk-full-content"
+            className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs font-mono"
+          >
+            {chunk.content}
+          </pre>
+          {chunk.metadata_json && (
+            <div data-testid="chunk-metadata">
+              <p className="mb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+                {t("metadata")}
+              </p>
+              <pre className="whitespace-pre-wrap break-words rounded-md bg-muted p-3 text-xs font-mono">
+                {JSON.stringify(chunk.metadata_json, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/molecules/document/document-row.tsx
+++ b/client/src/components/molecules/document/document-row.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Eye, RefreshCw, Trash2 } from "lucide-react";
+import { Eye, Layers, RefreshCw, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { DocumentChunksSheet } from "@/components/organisms/document/document-chunks-sheet";
 import { getDocumentFileBlob } from "@/lib/api/documents";
 import { useAuth } from "@/lib/hooks/use-auth";
 import type {
@@ -54,6 +55,7 @@ export function DocumentRow({
   const { token } = useAuth();
   const isReindexing = reindexingId === document.id;
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [chunksOpen, setChunksOpen] = useState(false);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewType, setPreviewType] = useState<string | null>(null);
@@ -148,6 +150,17 @@ export function DocumentRow({
           title={t("previewTitle")}
         >
           <Eye />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="cursor-pointer rounded-none border-0"
+          disabled={document.status !== "indexed"}
+          onClick={() => setChunksOpen(true)}
+          aria-label={t("chunksAriaLabel")}
+          title={document.status === "indexed" ? t("chunksTitle") : t("chunksDisabledTitle")}
+        >
+          <Layers />
         </Button>
         <Button
           variant="ghost"
@@ -252,6 +265,14 @@ export function DocumentRow({
         </DialogContent>
       </Dialog>
       </div>
+
+      <DocumentChunksSheet
+        projectId={document.project_id}
+        documentId={document.id}
+        documentName={document.file_name}
+        open={chunksOpen}
+        onOpenChange={setChunksOpen}
+      />
     </div>
   );
 }

--- a/client/src/components/organisms/document/document-chunks-sheet.tsx
+++ b/client/src/components/organisms/document/document-chunks-sheet.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ChunkAccordionItem } from "@/components/atoms/document/chunk-accordion-item";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useDocumentChunks } from "@/lib/hooks/use-documents";
+
+interface DocumentChunksSheetProps {
+  projectId: string;
+  documentId: string;
+  documentName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DocumentChunksSheet({
+  projectId,
+  documentId,
+  documentName,
+  open,
+  onOpenChange,
+}: DocumentChunksSheetProps) {
+  const t = useTranslations("documents.chunks");
+  const { data, isLoading, error } = useDocumentChunks(
+    projectId,
+    open ? documentId : null,
+  );
+
+  const chunks = data?.chunks ?? [];
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-full flex-col sm:max-w-xl">
+        <SheetHeader className="border-b pb-4">
+          <SheetTitle className="truncate">{documentName}</SheetTitle>
+          {!isLoading && !error && (
+            <p className="text-sm text-muted-foreground">
+              {t("title", { count: chunks.length })}
+            </p>
+          )}
+        </SheetHeader>
+
+        <div className="flex-1 overflow-y-auto">
+          {isLoading && (
+            <p data-testid="chunks-loading" className="px-4 py-6 text-sm text-muted-foreground">
+              {t("loading")}
+            </p>
+          )}
+          {!isLoading && error && (
+            <p data-testid="chunks-error" className="px-4 py-6 text-sm text-destructive">
+              {t("error")}
+            </p>
+          )}
+          {!isLoading && !error && chunks.length === 0 && (
+            <p data-testid="chunks-empty" className="px-4 py-6 text-sm text-muted-foreground">
+              {t("empty")}
+            </p>
+          )}
+          {!isLoading && !error && chunks.length > 0 && (
+            <div>
+              {chunks.map((chunk) => (
+                <ChunkAccordionItem key={chunk.id} chunk={chunk} />
+              ))}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/client/src/components/organisms/document/document-chunks-sheet.tsx
+++ b/client/src/components/organisms/document/document-chunks-sheet.tsx
@@ -5,6 +5,7 @@ import { ChunkAccordionItem } from "@/components/atoms/document/chunk-accordion-
 import {
   Sheet,
   SheetContent,
+  SheetDescription,
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
@@ -38,11 +39,9 @@ export function DocumentChunksSheet({
       <SheetContent side="right" className="flex w-full flex-col sm:max-w-xl">
         <SheetHeader className="border-b pb-4">
           <SheetTitle className="truncate">{documentName}</SheetTitle>
-          {!isLoading && !error && (
-            <p className="text-sm text-muted-foreground">
-              {t("title", { count: chunks.length })}
-            </p>
-          )}
+          <SheetDescription>
+            {!isLoading && !error ? t("title", { count: chunks.length }) : ""}
+          </SheetDescription>
         </SheetHeader>
 
         <div className="flex-1 overflow-y-auto">
@@ -64,7 +63,12 @@ export function DocumentChunksSheet({
           {!isLoading && !error && chunks.length > 0 && (
             <div>
               {chunks.map((chunk) => (
-                <ChunkAccordionItem key={chunk.id} chunk={chunk} />
+                <ChunkAccordionItem
+                  key={chunk.id}
+                  chunk={chunk}
+                  ariaLabel={t("chunkLabel", { index: chunk.chunk_index })}
+                  metadataLabel={t("metadata")}
+                />
               ))}
             </div>
           )}

--- a/client/tests/components/atoms/document/chunk-accordion-item.test.tsx
+++ b/client/tests/components/atoms/document/chunk-accordion-item.test.tsx
@@ -14,14 +14,19 @@ const mockChunk: DocumentChunkResponse = {
   metadata_json: null,
 };
 
+const defaultProps = {
+  ariaLabel: "Chunk #0",
+  metadataLabel: "Metadata",
+};
+
 describe("ChunkAccordionItem", () => {
   it("should display chunk index", () => {
-    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} {...defaultProps} />);
     expect(screen.getByText("#0")).toBeInTheDocument();
   });
 
   it("should display truncated content preview when collapsed", () => {
-    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} {...defaultProps} />);
     const preview = screen.getByTestId("chunk-preview");
     expect(preview).toBeInTheDocument();
     expect(preview.textContent!.length).toBeLessThanOrEqual(153);
@@ -29,7 +34,7 @@ describe("ChunkAccordionItem", () => {
 
   it("should expand to show full content on click", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} {...defaultProps} />);
     await user.click(screen.getByRole("button", { name: /chunk #0/i }));
     expect(screen.getByTestId("chunk-full-content")).toBeInTheDocument();
     expect(screen.getByTestId("chunk-full-content").textContent).toBe(mockChunk.content);
@@ -37,14 +42,14 @@ describe("ChunkAccordionItem", () => {
 
   it("should collapse again on second click", async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} {...defaultProps} />);
     await user.click(screen.getByRole("button", { name: /chunk #0/i }));
     await user.click(screen.getByRole("button", { name: /chunk #0/i }));
     expect(screen.queryByTestId("chunk-full-content")).not.toBeInTheDocument();
   });
 
   it("should not display metadata section when metadata_json is null", () => {
-    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} {...defaultProps} />);
     expect(screen.queryByTestId("chunk-metadata")).not.toBeInTheDocument();
   });
 
@@ -54,14 +59,14 @@ describe("ChunkAccordionItem", () => {
       ...mockChunk,
       metadata_json: { section: "Introduction", page: 1 },
     };
-    renderWithProviders(<ChunkAccordionItem chunk={chunkWithMeta} />);
+    renderWithProviders(<ChunkAccordionItem chunk={chunkWithMeta} {...defaultProps} />);
     await user.click(screen.getByRole("button", { name: /chunk #0/i }));
     expect(screen.getByTestId("chunk-metadata")).toBeInTheDocument();
   });
 
   it("should show content without truncation for short content", () => {
     const shortChunk: DocumentChunkResponse = { ...mockChunk, content: "Short." };
-    renderWithProviders(<ChunkAccordionItem chunk={shortChunk} />);
+    renderWithProviders(<ChunkAccordionItem chunk={shortChunk} {...defaultProps} />);
     expect(screen.getByTestId("chunk-preview").textContent).toBe("Short.");
   });
 });

--- a/client/tests/components/atoms/document/chunk-accordion-item.test.tsx
+++ b/client/tests/components/atoms/document/chunk-accordion-item.test.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ChunkAccordionItem } from "@/components/atoms/document/chunk-accordion-item";
+import { renderWithProviders } from "../../../helpers/render";
+import type { DocumentChunkResponse } from "@/lib/types/api";
+
+const mockChunk: DocumentChunkResponse = {
+  id: "chunk-1",
+  document_id: "doc-1",
+  chunk_index: 0,
+  content: "This is a fairly long chunk content that should be truncated in preview mode when the accordion is collapsed but shown in full when it is expanded by the user.",
+  created_at: "2026-01-01T00:00:00Z",
+  metadata_json: null,
+};
+
+describe("ChunkAccordionItem", () => {
+  it("should display chunk index", () => {
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    expect(screen.getByText("#0")).toBeInTheDocument();
+  });
+
+  it("should display truncated content preview when collapsed", () => {
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    const preview = screen.getByTestId("chunk-preview");
+    expect(preview).toBeInTheDocument();
+    expect(preview.textContent!.length).toBeLessThanOrEqual(153);
+  });
+
+  it("should expand to show full content on click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    await user.click(screen.getByRole("button", { name: /chunk #0/i }));
+    expect(screen.getByTestId("chunk-full-content")).toBeInTheDocument();
+    expect(screen.getByTestId("chunk-full-content").textContent).toBe(mockChunk.content);
+  });
+
+  it("should collapse again on second click", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    await user.click(screen.getByRole("button", { name: /chunk #0/i }));
+    await user.click(screen.getByRole("button", { name: /chunk #0/i }));
+    expect(screen.queryByTestId("chunk-full-content")).not.toBeInTheDocument();
+  });
+
+  it("should not display metadata section when metadata_json is null", () => {
+    renderWithProviders(<ChunkAccordionItem chunk={mockChunk} />);
+    expect(screen.queryByTestId("chunk-metadata")).not.toBeInTheDocument();
+  });
+
+  it("should display metadata when metadata_json is provided and expanded", async () => {
+    const user = userEvent.setup();
+    const chunkWithMeta: DocumentChunkResponse = {
+      ...mockChunk,
+      metadata_json: { section: "Introduction", page: 1 },
+    };
+    renderWithProviders(<ChunkAccordionItem chunk={chunkWithMeta} />);
+    await user.click(screen.getByRole("button", { name: /chunk #0/i }));
+    expect(screen.getByTestId("chunk-metadata")).toBeInTheDocument();
+  });
+
+  it("should show content without truncation for short content", () => {
+    const shortChunk: DocumentChunkResponse = { ...mockChunk, content: "Short." };
+    renderWithProviders(<ChunkAccordionItem chunk={shortChunk} />);
+    expect(screen.getByTestId("chunk-preview").textContent).toBe("Short.");
+  });
+});

--- a/client/tests/components/molecules/document/document-row.test.tsx
+++ b/client/tests/components/molecules/document/document-row.test.tsx
@@ -34,6 +34,10 @@ const defaultProps = {
   reindexingId: null,
 };
 
+vi.mock("@/components/organisms/document/document-chunks-sheet", () => ({
+  DocumentChunksSheet: () => null,
+}));
+
 describe("DocumentRow", () => {
   it("should display file name", () => {
     renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
@@ -82,5 +86,22 @@ describe("DocumentRow", () => {
   it("should display status badge", () => {
     renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
     expect(screen.getByText("Indexed")).toBeInTheDocument();
+  });
+
+  it("should display chunks button", () => {
+    renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /view chunks/i })).toBeInTheDocument();
+  });
+
+  it("should enable chunks button when status is indexed", () => {
+    renderWithProviders(<DocumentRow document={mockDoc} {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /view chunks/i })).not.toBeDisabled();
+  });
+
+  it("should disable chunks button when status is not indexed", () => {
+    renderWithProviders(
+      <DocumentRow document={{ ...mockDoc, status: "uploaded" }} {...defaultProps} />,
+    );
+    expect(screen.getByRole("button", { name: /view chunks/i })).toBeDisabled();
   });
 });

--- a/client/tests/components/organisms/document/document-chunks-sheet.test.tsx
+++ b/client/tests/components/organisms/document/document-chunks-sheet.test.tsx
@@ -63,7 +63,7 @@ describe("DocumentChunksSheet", () => {
       ),
     );
     renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
-    expect(await screen.findByText(/2/)).toBeInTheDocument();
+    expect(await screen.findByText("2 chunk(s)")).toBeInTheDocument();
   });
 
   it("should display all chunks", async () => {

--- a/client/tests/components/organisms/document/document-chunks-sheet.test.tsx
+++ b/client/tests/components/organisms/document/document-chunks-sheet.test.tsx
@@ -1,0 +1,110 @@
+import { http, HttpResponse } from "msw";
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DocumentChunksSheet } from "@/components/organisms/document/document-chunks-sheet";
+import { renderWithProviders } from "../../../helpers/render";
+import { server } from "../../../helpers/msw-server";
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: () => ({ token: "mock-token" }),
+}));
+
+const mockChunksResponse = {
+  document_id: "doc-1",
+  processing_strategy: "auto",
+  chunks: [
+    {
+      id: "chunk-1",
+      document_id: "doc-1",
+      chunk_index: 0,
+      content: "First chunk content.",
+      created_at: "2026-01-01T00:00:00Z",
+      metadata_json: null,
+    },
+    {
+      id: "chunk-2",
+      document_id: "doc-1",
+      chunk_index: 1,
+      content: "Second chunk content.",
+      created_at: "2026-01-01T00:00:00Z",
+      metadata_json: null,
+    },
+  ],
+};
+
+const defaultProps = {
+  projectId: "proj-1",
+  documentId: "doc-1",
+  documentName: "report.pdf",
+  open: true,
+  onOpenChange: vi.fn(),
+};
+
+describe("DocumentChunksSheet", () => {
+  it("should not render content when closed", () => {
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} open={false} />);
+    expect(screen.queryByText("report.pdf")).not.toBeInTheDocument();
+  });
+
+  it("should display document name in sheet title", async () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", () =>
+        HttpResponse.json(mockChunksResponse),
+      ),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(await screen.findByText("report.pdf")).toBeInTheDocument();
+  });
+
+  it("should display chunk count in sheet header", async () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", () =>
+        HttpResponse.json(mockChunksResponse),
+      ),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(await screen.findByText(/2/)).toBeInTheDocument();
+  });
+
+  it("should display all chunks", async () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", () =>
+        HttpResponse.json(mockChunksResponse),
+      ),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(await screen.findByText("#0")).toBeInTheDocument();
+    expect(screen.getByText("#1")).toBeInTheDocument();
+  });
+
+  it("should show loading state while fetching", () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", async () => {
+        await new Promise(() => {});
+        return HttpResponse.json({});
+      }),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(screen.getByTestId("chunks-loading")).toBeInTheDocument();
+  });
+
+  it("should show empty state when no chunks", async () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", () =>
+        HttpResponse.json({ document_id: "doc-1", processing_strategy: null, chunks: [] }),
+      ),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(await screen.findByTestId("chunks-empty")).toBeInTheDocument();
+  });
+
+  it("should show error state when request fails", async () => {
+    server.use(
+      http.get("/api/v1/projects/proj-1/documents/doc-1/chunks", () =>
+        HttpResponse.error(),
+      ),
+    );
+    renderWithProviders(<DocumentChunksSheet {...defaultProps} />);
+    expect(await screen.findByTestId("chunks-error")).toBeInTheDocument();
+  });
+});

--- a/server/tests/unit/infrastructure/test_in_memory_project_repository.py
+++ b/server/tests/unit/infrastructure/test_in_memory_project_repository.py
@@ -1,12 +1,10 @@
 from datetime import UTC, datetime
 from uuid import uuid4
 
-import pytest
-
+from raggae.domain.entities.project import Project
 from raggae.infrastructure.database.repositories.in_memory_project_repository import (
     InMemoryProjectRepository,
 )
-from raggae.domain.entities.project import Project
 
 
 def _project(name: str, organization_id=None, user_id=None) -> Project:


### PR DESCRIPTION
## Problème

Depuis l'onglet Connaissances, il était impossible d'inspecter les chunks générés pour un document indexé. L'utilisateur ne pouvait pas vérifier la qualité du découpage ni lire le contenu textuel extrait.

## Solution

Ajout d'un bouton **Chunks** (icône `Layers`) sur chaque ligne de document, ouvrant un panneau latéral (Sheet) listant tous les chunks associés. Chaque chunk est cliquable pour révéler son contenu complet via un accordion.

## Implémentation

- **Atom** `chunk-accordion-item.tsx` — affiche un chunk : index, aperçu tronqué (150 chars), contenu complet en accordion, métadonnées si présentes
- **Organism** `document-chunks-sheet.tsx` — Sheet latérale pilotée par `useDocumentChunks`, gère chargement / erreur / liste vide
- **Molecule** `document-row.tsx` — bouton Layers toujours visible, cliquable uniquement si `status === "indexed"`
- **i18n** — clés ajoutées en `fr` et `en` dans `documents.row` et `documents.chunks`
- **TDD** — tests écrits avant chaque implémentation (red → green)

## Recette

1. Onglet Connaissances d'un agent → vérifier que le bouton Chunks (icône grilles) est visible sur chaque document
2. Document non indexé → bouton désactivé (curseur `not-allowed`, tooltip explicatif)
3. Document indexé → clic → Sheet s'ouvre avec le nom du document et le nombre de chunks
4. Cliquer sur un chunk → contenu complet s'affiche en dessous
5. Recliquer → contenu se referme
6. Si `metadata_json` non null → section Métadonnées visible après expansion
7. Fermer la Sheet → retour à la liste sans rechargement de page

Closes #108