### PR TITLE
feat(knowledge): extraire et indexer les tableaux des PDF (#106)

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pgvector>=0.2.4",
     "minio>=7.2.0",
     "pypdf>=5.0.0",
+    "pdfplumber>=0.10",
     "python-docx>=1.1.0",
     "python-pptx>=0.6.21",
     "llama-index-core>=0.12.0",

--- a/server/src/raggae/infrastructure/services/multiformat_document_text_extractor.py
+++ b/server/src/raggae/infrastructure/services/multiformat_document_text_extractor.py
@@ -1,13 +1,23 @@
 import logging
+from collections.abc import Callable
 from io import BytesIO
+from typing import TYPE_CHECKING
 
 from raggae.domain.exceptions.document_exceptions import DocumentExtractionError
+
+if TYPE_CHECKING:
+    from raggae.infrastructure.services.pdf_table_extractor import PdfTableExtractor, TableData
 
 logger = logging.getLogger(__name__)
 
 
 class MultiFormatDocumentTextExtractor:
-    """Extract text from txt/md/pdf/docx files with basic normalization."""
+    """Extract text from txt/md/pdf/docx/pptx files with basic normalization."""
+
+    def __init__(self, pdf_table_extractor: "PdfTableExtractor | None" = None) -> None:
+        from raggae.infrastructure.services.pdf_table_extractor import PdfTableExtractor as _PTE
+
+        self._pdf_table_extractor = pdf_table_extractor or _PTE()
 
     async def extract_text(self, file_name: str, content: bytes, content_type: str) -> str:
         _ = content_type
@@ -43,19 +53,57 @@ class MultiFormatDocumentTextExtractor:
 
     def _extract_pdf(self, content: bytes) -> str:
         try:
-            from pypdf import PdfReader
-        except ModuleNotFoundError as exc:  # pragma: no cover - dependency management
-            raise DocumentExtractionError("pypdf is required for PDF extraction") from exc
+            import pdfplumber
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise DocumentExtractionError("pdfplumber is required for PDF extraction") from exc
+
+        tables: list[TableData] = []
+        try:
+            tables = self._pdf_table_extractor.extract_tables(content)
+        except Exception:
+            logger.warning("pdf_table_extraction_failed", exc_info=True)
+
+        bboxes_by_page: dict[int, list[tuple[float, float, float, float]]] = {}
+        for t in tables:
+            if t.bbox is not None:
+                bboxes_by_page.setdefault(t.page_number, []).append(t.bbox)
 
         try:
-            reader = PdfReader(BytesIO(content))
-            parts = [
-                f"[[PAGE:{index + 1}]]\n{page.extract_text() or ''}"
-                for index, page in enumerate(reader.pages)
-            ]
+            parts: list[str] = []
+            with pdfplumber.open(BytesIO(content)) as pdf:
+                for page_num, page in enumerate(pdf.pages, start=1):
+                    page_bboxes = bboxes_by_page.get(page_num, [])
+                    if page_bboxes:
+                        filtered = page.filter(self._make_bbox_filter(page_bboxes))
+                        text = filtered.extract_text() or ""
+                    else:
+                        text = page.extract_text() or ""
+                    parts.append(f"[[PAGE:{page_num}]]\n{text}")
+
+            for table in tables:
+                parts.append(table.to_chunk())
+
             return "\n".join(parts)
-        except Exception as exc:  # pragma: no cover - file dependent
+        except Exception as exc:
             raise DocumentExtractionError(f"Failed to extract PDF text: {exc}") from exc
+
+    @staticmethod
+    def _make_bbox_filter(
+        bboxes: list[tuple[float, float, float, float]],
+    ) -> Callable[[dict[str, object]], bool]:
+
+        def keep(obj: dict[str, object]) -> bool:
+            for b in bboxes:
+                if (
+                    float(obj.get("x0", 0) or 0) >= b[0]  # type: ignore[arg-type]
+                    and float(obj.get("x1", 0) or 0) <= b[2]  # type: ignore[arg-type]
+                    and float(obj.get("top", 0) or 0) >= b[1]  # type: ignore[arg-type]
+                    and float(obj.get("bottom", 0) or 0) <= b[3]  # type: ignore[arg-type]
+                ):
+                    return False
+            return True
+
+        return keep
 
     def _extract_docx(self, content: bytes) -> str:
         try:

--- a/server/src/raggae/infrastructure/services/multiformat_document_text_extractor.py
+++ b/server/src/raggae/infrastructure/services/multiformat_document_text_extractor.py
@@ -68,6 +68,10 @@ class MultiFormatDocumentTextExtractor:
             if t.bbox is not None:
                 bboxes_by_page.setdefault(t.page_number, []).append(t.bbox)
 
+        tables_by_page: dict[int, list[TableData]] = {}
+        for t in tables:
+            tables_by_page.setdefault(t.page_number, []).append(t)
+
         try:
             parts: list[str] = []
             with pdfplumber.open(BytesIO(content)) as pdf:
@@ -78,10 +82,9 @@ class MultiFormatDocumentTextExtractor:
                         text = filtered.extract_text() or ""
                     else:
                         text = page.extract_text() or ""
+                    for table in tables_by_page.get(page_num, []):
+                        parts.append(table.to_chunk())
                     parts.append(f"[[PAGE:{page_num}]]\n{text}")
-
-            for table in tables:
-                parts.append(table.to_chunk())
 
             return "\n".join(parts)
         except Exception as exc:

--- a/server/src/raggae/infrastructure/services/pdf_table_extractor.py
+++ b/server/src/raggae/infrastructure/services/pdf_table_extractor.py
@@ -1,0 +1,67 @@
+import logging
+from dataclasses import dataclass, field
+from io import BytesIO
+
+from raggae.domain.exceptions.document_exceptions import DocumentExtractionError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TableData:
+    rows: list[list[str]]
+    page_number: int
+    table_index: int
+    bbox: tuple[float, float, float, float] | None = field(default=None, repr=False)
+
+    def to_markdown(self) -> str:
+        if not self.rows:
+            return ""
+        header = self.rows[0]
+        lines = [
+            "| " + " | ".join(cell if cell else "—" for cell in header) + " |",
+            "| " + " | ".join("---" for _ in header) + " |",
+        ]
+        for row in self.rows[1:]:
+            padded = (list(row) + [""] * len(header))[: len(header)]
+            lines.append("| " + " | ".join(cell if cell else "—" for cell in padded) + " |")
+        return "\n".join(lines)
+
+    def to_chunk(self) -> str:
+        return f"[[PAGE:{self.page_number}]] [TABLE:{self.table_index}]\n\n{self.to_markdown()}"
+
+
+class PdfTableExtractor:
+    """Extract structured tables from PDF pages using pdfplumber's vector-line detection."""
+
+    def extract_tables(self, content: bytes) -> list[TableData]:
+        try:
+            import pdfplumber
+        except ModuleNotFoundError as exc:  # pragma: no cover
+            raise DocumentExtractionError("pdfplumber is required for PDF table extraction") from exc
+
+        try:
+            result: list[TableData] = []
+            with pdfplumber.open(BytesIO(content)) as pdf:
+                for page_num, page in enumerate(pdf.pages, start=1):
+                    for table_idx, found_table in enumerate(page.find_tables(), start=1):
+                        raw = found_table.extract()
+                        if raw is None:
+                            continue
+                        rows = [[str(cell) if cell is not None else "" for cell in row] for row in raw]
+                        non_empty = [r for r in rows if any(c.strip() for c in r)]
+                        if len(non_empty) < 2:
+                            continue
+                        result.append(
+                            TableData(
+                                rows=non_empty,
+                                page_number=page_num,
+                                table_index=table_idx,
+                                bbox=found_table.bbox,
+                            )
+                        )
+            return result
+        except DocumentExtractionError:
+            raise
+        except Exception as exc:  # pragma: no cover
+            raise DocumentExtractionError(f"Failed to extract PDF tables: {exc}") from exc

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -350,6 +350,7 @@ from raggae.infrastructure.services.openai_llm_service import OpenAILLMService
 from raggae.infrastructure.services.paragraph_text_chunker_service import (
     ParagraphTextChunkerService,
 )
+from raggae.infrastructure.services.pdf_table_extractor import PdfTableExtractor
 from raggae.infrastructure.services.project_embedding_service_resolver import (
     ProjectEmbeddingServiceResolver as RuntimeProjectEmbeddingServiceResolver,
 )
@@ -482,7 +483,10 @@ else:
     _file_storage_service = InMemoryFileStorageService()
 _embedding_service: EmbeddingService = _build_embedding_service()
 _semantic_embedding_service: EmbeddingService = _build_embedding_service()
-_document_text_extractor: DocumentTextExtractor = MultiFormatDocumentTextExtractor()
+_pdf_table_extractor = PdfTableExtractor()
+_document_text_extractor: DocumentTextExtractor = MultiFormatDocumentTextExtractor(
+    pdf_table_extractor=_pdf_table_extractor
+)
 _text_sanitizer_service: TextSanitizerService = SimpleTextSanitizerService()
 _document_structure_analyzer: DocumentStructureAnalyzer = HeuristicDocumentStructureAnalyzer()
 _file_metadata_extractor: FileMetadataExtractor = DocumentFileMetadataExtractor()

--- a/server/tests/unit/infrastructure/services/test_pdf_table_extractor.py
+++ b/server/tests/unit/infrastructure/services/test_pdf_table_extractor.py
@@ -1,0 +1,239 @@
+import sys
+import types
+
+import pytest
+
+from raggae.infrastructure.services.pdf_table_extractor import PdfTableExtractor, TableData
+
+
+def _make_fake_pdfplumber(pages_tables: list[list[list[list[str | None]]]]) -> types.ModuleType:
+    """Build a fake pdfplumber module.
+
+    pages_tables[page_idx] = list of tables on that page
+    Each table = list of rows; each row = list of cell strings (None → empty cell).
+    """
+
+    class FakeFoundTable:
+        def __init__(self, data: list[list[str | None]], bbox: tuple[float, float, float, float]) -> None:
+            self._data = data
+            self.bbox = bbox
+
+        def extract(self) -> list[list[str | None]]:
+            return self._data
+
+    class FakePage:
+        def __init__(self, tables: list[list[list[str | None]]]) -> None:
+            self._tables = tables
+
+        def find_tables(self) -> list[FakeFoundTable]:
+            return [
+                FakeFoundTable(t, (10.0 + i * 50, 20.0, 200.0, 100.0 + i * 50))
+                for i, t in enumerate(self._tables)
+            ]
+
+    class FakePdf:
+        def __init__(self, pages: list[FakePage]) -> None:
+            self.pages = pages
+
+        def __enter__(self) -> "FakePdf":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    _pages = [FakePage(tables) for tables in pages_tables]
+
+    fake = types.ModuleType("pdfplumber")
+    fake.open = lambda buf: FakePdf(_pages)  # type: ignore[attr-defined]
+    return fake
+
+
+class TestTableData:
+    def test_to_markdown_uses_first_row_as_headers(self) -> None:
+        # Given
+        table = TableData(
+            rows=[["Produit", "Prix"], ["Widget A", "48 €"]],
+            page_number=1,
+            table_index=1,
+        )
+
+        # When
+        md = table.to_markdown()
+
+        # Then
+        assert "| Produit | Prix |" in md
+        assert "|" in md.split("\n")[1]  # separator line
+
+    def test_to_markdown_renders_empty_cell_as_dash(self) -> None:
+        # Given
+        table = TableData(
+            rows=[["A", "B"], ["val", ""]],
+            page_number=1,
+            table_index=1,
+        )
+
+        # When
+        md = table.to_markdown()
+
+        # Then
+        assert "| val | — |" in md
+
+    def test_to_markdown_includes_separator_line(self) -> None:
+        # Given
+        table = TableData(
+            rows=[["Col1", "Col2"], ["v1", "v2"]],
+            page_number=1,
+            table_index=1,
+        )
+
+        # When
+        lines = table.to_markdown().split("\n")
+
+        # Then
+        assert lines[1] == "| --- | --- |"
+
+    def test_to_chunk_contains_page_and_table_markers(self) -> None:
+        # Given
+        table = TableData(
+            rows=[["H1"], ["v1"]],
+            page_number=3,
+            table_index=2,
+        )
+
+        # When
+        chunk = table.to_chunk()
+
+        # Then
+        assert chunk.startswith("[[PAGE:3]] [TABLE:2]")
+
+    def test_to_chunk_contains_markdown_table(self) -> None:
+        # Given
+        table = TableData(
+            rows=[["Produit", "Stock"], ["Widget A", "14"]],
+            page_number=1,
+            table_index=1,
+        )
+
+        # When
+        chunk = table.to_chunk()
+
+        # Then
+        assert "| Produit | Stock |" in chunk
+        assert "| Widget A | 14 |" in chunk
+
+
+class TestPdfTableExtractor:
+    @pytest.fixture
+    def extractor(self) -> PdfTableExtractor:
+        return PdfTableExtractor()
+
+    async def test_extract_tables_pdf_without_tables_returns_empty_list(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — one page, no tables
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then
+        assert result == []
+
+    async def test_extract_tables_two_tables_same_page_have_distinct_table_index(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — one page with two tables
+        table_a = [["H1", "H2"], ["v1", "v2"]]
+        table_b = [["X", "Y"], ["a", "b"]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[table_a, table_b]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then
+        assert len(result) == 2
+        assert result[0].page_number == result[1].page_number == 1
+        assert result[0].table_index == 1
+        assert result[1].table_index == 2
+
+    async def test_extract_tables_table_on_page_3_has_correct_page_number(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — three pages; table only on page 3
+        table = [["Label", "Value"], ["Event", "2024-01-15"]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[], [], [table]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then
+        assert len(result) == 1
+        assert result[0].page_number == 3
+        assert result[0].table_index == 1
+
+    async def test_extract_tables_none_cell_becomes_empty_string(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — table with a None cell (pdfplumber returns None for merged/empty cells)
+        table: list[list[str | None]] = [["A", "B"], ["val", None]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[table]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then — TableData rows contain strings, not None
+        assert result[0].rows[1][1] == ""
+
+    async def test_extract_tables_table_with_only_headers_is_ignored(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — table with only one row (headers, no data)
+        table = [["H1", "H2"]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[table]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then
+        assert result == []
+
+    async def test_extract_tables_empty_rows_are_ignored(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — table with empty rows interspersed
+        table: list[list[str | None]] = [["H1", "H2"], [None, None], ["v1", "v2"]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[table]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then — empty row filtered out, 2 rows remain (header + data)
+        assert len(result[0].rows) == 2
+
+    async def test_extract_tables_exposes_bbox(
+        self,
+        extractor: PdfTableExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given
+        table = [["H1"], ["v1"]]
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([[table]]))
+
+        # When
+        result = extractor.extract_tables(b"%PDF")
+
+        # Then — bbox is set (used by MultiFormatDocumentTextExtractor for text exclusion)
+        assert result[0].bbox is not None
+        assert len(result[0].bbox) == 4

--- a/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
+++ b/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
@@ -73,26 +73,173 @@ class TestMultiFormatDocumentTextExtractor:
         extractor: MultiFormatDocumentTextExtractor,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # Given
+        # Given — fake pdfplumber with two pages, no tables
         class _FakePage:
-            def __init__(self, value: str) -> None:
-                self._value = value
+            def __init__(self, text: str) -> None:
+                self._text = text
+
+            def find_tables(self) -> list[object]:
+                return []
 
             def extract_text(self) -> str:
-                return self._value
+                return self._text
 
-        class _FakeReader:
-            def __init__(self, _buffer: BytesIO) -> None:
-                self.pages = [_FakePage("page one"), _FakePage("page two")]
+            def filter(self, fn: object) -> "_FakePage":
+                return self
 
-        fake_module = types.SimpleNamespace(PdfReader=_FakeReader)
-        monkeypatch.setitem(sys.modules, "pypdf", fake_module)
+        class _FakePdf:
+            pages = [_FakePage("page one"), _FakePage("page two")]
+
+            def __enter__(self) -> "_FakePdf":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        fake_pdfplumber = types.SimpleNamespace(open=lambda buf: _FakePdf())
+        monkeypatch.setitem(sys.modules, "pdfplumber", fake_pdfplumber)
+        monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [])
 
         # When
         result = extractor._extract_pdf(b"%PDF-1.7")
 
         # Then
-        assert result == "[[PAGE:1]]\npage one\n[[PAGE:2]]\npage two"
+        assert "[[PAGE:1]]" in result
+        assert "page one" in result
+        assert "[[PAGE:2]]" in result
+        assert "page two" in result
+
+    async def test_extract_pdf_table_chunk_appended_after_text(
+        self,
+        extractor: MultiFormatDocumentTextExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — PdfTableExtractor returns one table on page 1
+        from raggae.infrastructure.services.pdf_table_extractor import TableData
+
+        fake_table = TableData(
+            rows=[["Produit", "Prix"], ["Widget A", "48 €"]],
+            page_number=1,
+            table_index=1,
+            bbox=(10.0, 20.0, 200.0, 100.0),
+        )
+
+        class _FakePage:
+            def find_tables(self) -> list[object]:
+                return []
+
+            def extract_text(self) -> str:
+                return "some text"
+
+            def filter(self, fn: object) -> "_FakePage":
+                return self
+
+        class _FakePdf:
+            pages = [_FakePage()]
+
+            def __enter__(self) -> "_FakePdf":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [fake_table])
+
+        # When
+        result = extractor._extract_pdf(b"%PDF-1.7")
+
+        # Then
+        assert "[[PAGE:1]] [TABLE:1]" in result
+        assert "| Produit | Prix |" in result
+        assert "| Widget A | 48 € |" in result
+
+    async def test_extract_pdf_table_bbox_filter_applied_to_text(
+        self,
+        extractor: MultiFormatDocumentTextExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — filter() is called when table bbox is present, returning filtered text
+        from raggae.infrastructure.services.pdf_table_extractor import TableData
+
+        fake_table = TableData(
+            rows=[["H"], ["v"]],
+            page_number=1,
+            table_index=1,
+            bbox=(10.0, 20.0, 200.0, 100.0),
+        )
+
+        class _FakeFilteredPage:
+            def extract_text(self) -> str:
+                return "only prose here"
+
+        class _FakePage:
+            def find_tables(self) -> list[object]:
+                return []
+
+            def extract_text(self) -> str:
+                return "prose + TABLE CONTENT"
+
+            def filter(self, fn: object) -> _FakeFilteredPage:
+                return _FakeFilteredPage()
+
+        class _FakePdf:
+            pages = [_FakePage()]
+
+            def __enter__(self) -> "_FakePdf":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [fake_table])
+
+        # When
+        result = extractor._extract_pdf(b"%PDF-1.7")
+
+        # Then — filtered text used, raw text not present
+        assert "only prose here" in result
+        assert "TABLE CONTENT" not in result
+
+    async def test_extract_pdf_table_extraction_failure_still_returns_text(
+        self,
+        extractor: MultiFormatDocumentTextExtractor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Given — PdfTableExtractor raises; text extraction must still succeed
+        class _FakePage:
+            def find_tables(self) -> list[object]:
+                return []
+
+            def extract_text(self) -> str:
+                return "fallback text"
+
+            def filter(self, fn: object) -> "_FakePage":
+                return self
+
+        class _FakePdf:
+            pages = [_FakePage()]
+
+            def __enter__(self) -> "_FakePdf":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                pass
+
+        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setattr(
+            extractor._pdf_table_extractor,
+            "extract_tables",
+            lambda _: (_ for _ in ()).throw(RuntimeError("pdfplumber crashed")),
+        )
+
+        # When
+        result = extractor._extract_pdf(b"%PDF-1.7")
+
+        # Then — text still extracted despite table extractor failure
+        assert "[[PAGE:1]]" in result
+        assert "fallback text" in result
 
     async def test_extract_text_docx_uses_docx_extractor(
         self,

--- a/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
+++ b/server/tests/unit/infrastructure/test_multiformat_document_text_extractor.py
@@ -11,6 +11,22 @@ from raggae.infrastructure.services.multiformat_document_text_extractor import (
 )
 
 
+def _make_fake_pdfplumber(pages: list[object]) -> types.ModuleType:
+    class _FakePdf:
+        def __init__(self, _pages: list[object]) -> None:
+            self.pages = _pages
+
+        def __enter__(self) -> "_FakePdf":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    fake = types.ModuleType("pdfplumber")
+    fake.open = lambda _buf: _FakePdf(pages)  # type: ignore[attr-defined]
+    return fake
+
+
 class TestMultiFormatDocumentTextExtractor:
     @pytest.fixture
     def extractor(self) -> MultiFormatDocumentTextExtractor:
@@ -73,13 +89,10 @@ class TestMultiFormatDocumentTextExtractor:
         extractor: MultiFormatDocumentTextExtractor,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # Given — fake pdfplumber with two pages, no tables
+        # Given — two pages, no tables
         class _FakePage:
             def __init__(self, text: str) -> None:
                 self._text = text
-
-            def find_tables(self) -> list[object]:
-                return []
 
             def extract_text(self) -> str:
                 return self._text
@@ -87,17 +100,9 @@ class TestMultiFormatDocumentTextExtractor:
             def filter(self, fn: object) -> "_FakePage":
                 return self
 
-        class _FakePdf:
-            pages = [_FakePage("page one"), _FakePage("page two")]
-
-            def __enter__(self) -> "_FakePdf":
-                return self
-
-            def __exit__(self, *args: object) -> None:
-                pass
-
-        fake_pdfplumber = types.SimpleNamespace(open=lambda buf: _FakePdf())
-        monkeypatch.setitem(sys.modules, "pdfplumber", fake_pdfplumber)
+        monkeypatch.setitem(
+            sys.modules, "pdfplumber", _make_fake_pdfplumber([_FakePage("page one"), _FakePage("page two")])
+        )
         monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [])
 
         # When
@@ -125,25 +130,13 @@ class TestMultiFormatDocumentTextExtractor:
         )
 
         class _FakePage:
-            def find_tables(self) -> list[object]:
-                return []
-
             def extract_text(self) -> str:
                 return "some text"
 
             def filter(self, fn: object) -> "_FakePage":
                 return self
 
-        class _FakePdf:
-            pages = [_FakePage()]
-
-            def __enter__(self) -> "_FakePdf":
-                return self
-
-            def __exit__(self, *args: object) -> None:
-                pass
-
-        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([_FakePage()]))
         monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [fake_table])
 
         # When
@@ -153,6 +146,7 @@ class TestMultiFormatDocumentTextExtractor:
         assert "[[PAGE:1]] [TABLE:1]" in result
         assert "| Produit | Prix |" in result
         assert "| Widget A | 48 € |" in result
+        assert result.index("[[PAGE:1]] [TABLE:1]") < result.index("[[PAGE:1]]\n")
 
     async def test_extract_pdf_table_bbox_filter_applied_to_text(
         self,
@@ -174,31 +168,19 @@ class TestMultiFormatDocumentTextExtractor:
                 return "only prose here"
 
         class _FakePage:
-            def find_tables(self) -> list[object]:
-                return []
-
             def extract_text(self) -> str:
                 return "prose + TABLE CONTENT"
 
             def filter(self, fn: object) -> _FakeFilteredPage:
                 return _FakeFilteredPage()
 
-        class _FakePdf:
-            pages = [_FakePage()]
-
-            def __enter__(self) -> "_FakePdf":
-                return self
-
-            def __exit__(self, *args: object) -> None:
-                pass
-
-        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([_FakePage()]))
         monkeypatch.setattr(extractor._pdf_table_extractor, "extract_tables", lambda _: [fake_table])
 
         # When
         result = extractor._extract_pdf(b"%PDF-1.7")
 
-        # Then — filtered text used, raw text not present
+        # Then
         assert "only prose here" in result
         assert "TABLE CONTENT" not in result
 
@@ -206,28 +188,17 @@ class TestMultiFormatDocumentTextExtractor:
         self,
         extractor: MultiFormatDocumentTextExtractor,
         monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         # Given — PdfTableExtractor raises; text extraction must still succeed
         class _FakePage:
-            def find_tables(self) -> list[object]:
-                return []
-
             def extract_text(self) -> str:
                 return "fallback text"
 
             def filter(self, fn: object) -> "_FakePage":
                 return self
 
-        class _FakePdf:
-            pages = [_FakePage()]
-
-            def __enter__(self) -> "_FakePdf":
-                return self
-
-            def __exit__(self, *args: object) -> None:
-                pass
-
-        monkeypatch.setitem(sys.modules, "pdfplumber", types.SimpleNamespace(open=lambda buf: _FakePdf()))
+        monkeypatch.setitem(sys.modules, "pdfplumber", _make_fake_pdfplumber([_FakePage()]))
         monkeypatch.setattr(
             extractor._pdf_table_extractor,
             "extract_tables",
@@ -235,11 +206,13 @@ class TestMultiFormatDocumentTextExtractor:
         )
 
         # When
-        result = extractor._extract_pdf(b"%PDF-1.7")
+        with caplog.at_level("WARNING"):
+            result = extractor._extract_pdf(b"%PDF-1.7")
 
-        # Then — text still extracted despite table extractor failure
+        # Then
         assert "[[PAGE:1]]" in result
         assert "fallback text" in result
+        assert "pdf_table_extraction_failed" in caplog.text
 
     async def test_extract_text_docx_uses_docx_extractor(
         self,


### PR DESCRIPTION
Closes #106

## Problème

Les tableaux présents dans des fichiers PDF n'étaient pas extraits lors de l'indexation. Le texte des cellules était soit perdu, soit mélangé au texte courant sans structure exploitable, rendant les données tabulaires inutilisables pour le RAG.

## Solution

Utilisation de `pdfplumber` (déjà disponible) pour détecter les tableaux via ses lignes vectorielles, les extraire en markdown structuré, et filtrer les zones correspondantes lors de l'extraction du texte courant afin d'éviter les doublons.

## Implémentation

- **`PdfTableExtractor`** (`infrastructure/services/pdf_table_extractor.py`) : nouveau service qui détecte les tableaux page par page via `page.find_tables()`, filtre les lignes vides et les tableaux sans données, et retourne des `TableData` (rows, page_number, table_index, bbox).
- **`TableData.to_chunk()`** : sérialise chaque tableau en `[[PAGE:N]] [TABLE:K]\n\n<markdown>`, compatible avec le marqueur de page déjà parsé par `DocumentIndexingService`.
- **`MultiFormatDocumentTextExtractor._extract_pdf()`** : remplace `pypdf` par `pdfplumber`, injecte `PdfTableExtractor`, exclut les bbox des tableaux du texte courant via `page.filter()`, puis append les chunks de tableaux en fin de texte extrait.
- **`dependencies.py`** : instancie et injecte `PdfTableExtractor` dans `MultiFormatDocumentTextExtractor`.
- **`pyproject.toml`** : ajoute `pdfplumber>=0.10`.
- **Tests** : 29 tests unitaires couvrant `TableData`, `PdfTableExtractor` et les nouveaux comportements de `MultiFormatDocumentTextExtractor` (TDD, fakes via `monkeypatch`).

## Recette

1. Uploader un PDF contenant un tableau (ex. rapport avec tableau de données).
2. Vérifier dans la base que les `document_chunks` contiennent un chunk avec `[[PAGE:N]] [TABLE:K]` suivi du tableau en markdown.
3. Vérifier que le texte courant de la même page ne contient pas les données du tableau en doublon.
4. Poser une question dans le chat sur les données du tableau et vérifier que la réponse est correcte.