### PR TITLE
fix: update Node.js version to v22 for pnpm compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
           cache-dependency-path: client/pnpm-lock.yaml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,253 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**Raggae** (RAG Generator Agent Expert) — a platform to create, manage, and publish conversational agents
+based on RAG (Retrieval Augmented Generation).
+
+## Tech Stack
+
+- **Backend**: Python 3.11+, FastAPI, SQLAlchemy 2.0 (async), Alembic, PostgreSQL 16 + pgvector
+- **Frontend**: Next.js 14 (TypeScript)
+- **Quality tools**: ruff (lint + format), mypy (type check), pytest (tests)
+
+## Essential Commands (Backend)
+
+All backend commands run from `server/`.
+
+```bash
+# Setup
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,test]"
+
+# Tests
+pytest                              # All tests
+pytest tests/unit                   # Unit tests only
+pytest tests/unit/domain/entities/test_user.py  # Single file
+pytest tests/unit/domain/entities/test_user.py::TestUser::test_create_user  # Single test
+pytest --cov=src --cov-report=html  # With coverage
+
+# Code quality
+ruff format src/ tests/             # Format
+ruff check src/ tests/              # Lint
+mypy src/                           # Type check
+
+# Database
+alembic upgrade head                # Apply migrations
+alembic revision --autogenerate -m "description"  # New migration
+alembic downgrade -1                # Rollback
+
+# Dev server
+uvicorn src.raggae.presentation.main:app --reload
+```
+
+## Frontend Commands
+
+```bash
+cd client && npm install && npm run dev
+cd client && npx vitest run          # Run all frontend tests (MUST be run from client/)
+cd client && npx vitest run <file>   # Run a single test file
+```
+
+## Frontend Architecture: Atomic Design (Strict)
+
+The frontend follows Atomic Design with five layers. Dependencies always point inward (atoms ← molecules ← organisms ← templates ← pages).
+
+```
+client/src/components/
+  atoms/       Pure UI elements — no data fetching, no business logic
+  molecules/   Atoms combinations — local state only (no hooks fetching remote data)
+  organisms/   Composite sections — fetch their own data via hooks, handle loading/error
+  templates/   Page skeletons — compose organisms into a layout, receive only route params
+client/src/app/
+  **/page.tsx  Next.js routes — extract URL params only, render one template
+```
+
+`components/ui/` (shadcn/Radix primitives) is NOT part of Atomic Design — treat it as a third-party library.
+
+### Layer rules (non-negotiable)
+
+| Layer | Fetches data? | Has `<h1>`? | Knows route params? |
+|-------|--------------|-------------|---------------------|
+| Atom | No | No | No |
+| Molecule | No | No | No |
+| Organism | Yes (own domain) | No | No |
+| Template | No | Yes | Yes (via props) |
+| Page (`page.tsx`) | No | No | Yes (useParams) |
+
+**Key rule**: organisms never contain page-level headers (`<h1>`, global description). Headers and page titles belong exclusively in templates.
+
+### Two template families
+
+#### 1. `PageTemplate` — document pages (list, settings, form…)
+Scrollable content with a title bar at the top.
+
+```
+┌─────────────────────────────────────────┐
+│ Page title                  [CTA button]│
+│ Short description                       │
+├─────────────────────────────────────────┤
+│  Scrollable content                     │
+│  (organisms, lists, forms…)             │
+└─────────────────────────────────────────┘
+```
+
+#### 2. `WorkspaceTemplate` — immersive/tool pages (chat, editor…)
+Full-height layout with a sticky top bar; internal content manages its own scroll.
+
+```
+┌─────────────────────────────────────────┐
+│ Breadcrumb (A › B)           [Actions]  │  ← sticky top bar, h-14
+├─────────────────────────────────────────┤
+│  Full-height content                    │
+│  (scroll managed internally)            │
+└─────────────────────────────────────────┘
+```
+
+Use `WorkspaceTemplate` when the page is an interactive tool that needs full viewport height (chat, document viewer, code editor, etc.).
+Use `PageTemplate` for everything else.
+
+### Naming conventions
+
+```
+atoms/<domain>/<ComponentName>.tsx           e.g. atoms/chat/copy-button.tsx
+molecules/<domain>/<ComponentName>.tsx       e.g. molecules/auth/login-form.tsx
+organisms/<domain>/<ComponentName>.tsx       e.g. organisms/project/project-list.tsx
+templates/<domain>/<name>-template.tsx       e.g. templates/project/projects-template.tsx
+```
+
+Templates are named with the `-template` suffix to make the layer explicit at import sites.
+
+## Architecture: DDD + Clean Architecture (Strict)
+
+Domain-Driven Design with four layers, dependencies always pointing inward:
+
+```
+Domain (entities, value objects, domain services, exceptions) — NO external dependencies
+  ↑
+Application (use cases, interfaces/ports, DTOs, application services) — depends only on Domain
+  ↑
+Infrastructure (SQLAlchemy repos, external services, config) — implements Application interfaces
+  ↑
+Presentation (FastAPI endpoints, Pydantic schemas, DI) — orchestrates use cases
+```
+
+Backend source layout: `server/src/raggae/{domain,application,infrastructure,presentation}/`
+Tests mirror source: `server/tests/{unit,integration,e2e}/`
+
+## Mandatory Development Rules
+
+### Code Quality
+
+1. **TDD (Red-Green-Refactor)**: Always write a failing test first, then minimal code to pass, then
+   refactor. Never write code without a test.
+2. **Baby Steps**: Small atomic commits (max 50–100 lines). Each commit must compile and pass all tests.
+3. **DDD + Clean Architecture**: Respect layer boundaries strictly. Domain has zero external dependencies.
+   No ORM models in domain. Use ubiquitous language in entity and use case naming.
+4. **Test coverage > 80%**: Pyramid — 70% unit, 20% integration, 10% E2E.
+   Do not write style-only tests (e.g. asserting CSS class names). Test behaviour, not presentation.
+5. **Clean Code**: Meaningful names, small focused functions, no magic values, no dead code.
+   Follow Software Craftsmanship principles (SOLID, DRY, YAGNI, KISS).
+
+### Language Conventions
+
+| What | Language |
+|------|----------|
+| Source code (variables, functions, classes, inline comments) | **English** |
+| Documentation (docs/, docstrings) | **French** |
+| Commit messages | **French** |
+| PR titles and descriptions | **French** |
+
+### Git Workflow
+
+> **RÈGLE ABSOLUE** : ne jamais commiter ni pusher directement sur `main`.
+> Toujours passer par une branche + Pull Request, sans exception.
+
+1. **Feature branching** — never commit directly to `main`. Always create a branch:
+
+   ```bash
+   git checkout -b feat/register-user     # new feature
+   git checkout -b fix/login-token        # bug fix
+   git checkout -b refactor/user-entity   # refactoring
+   git checkout -b test/project-use-cases # tests only
+   git checkout -b docs/architecture      # documentation
+   ```
+
+2. **Conventional Commits** (message in French):
+
+   ```
+   type(scope): description en français
+   ```
+
+   Allowed types: `feat`, `fix`, `test`, `refactor`, `docs`, `chore`, `build`.
+
+3. **No Claude attribution**: Never add co-author or Claude mentions in commits.
+
+4. **Quality gate before push**: run the full pre-push checklist (see below) before every `git push`.
+
+5. **Pull Request** : one PR per feature/fix/refactor. Use the PR format below.
+   **Never merge to `main` without a PR** — even for small or cosmetic changes.
+
+### Pull Request Format
+
+PR title and description must be in French. Description structure:
+
+```markdown
+## Problème
+Describe the problem or need this PR addresses.
+
+## Solution
+Explain the chosen approach and why.
+
+## Implémentation
+List the main technical changes (files, layers, patterns used).
+
+## Recette
+Steps or scenarios to manually validate the feature works correctly.
+```
+
+## Test Naming Conventions
+
+```python
+def test_<what>_<condition>_<expected>():              # Unit
+async def test_integration_<component>_<scenario>():   # Integration
+async def test_e2e_<feature>_<scenario>():             # E2E
+```
+
+Use Given/When/Then structure inside every test. Unit tests use in-memory fakes
+(e.g., `InMemoryUserRepository`, `FakePasswordHasher`).
+
+## Key Documentation
+
+Read these before coding:
+
+- **PLAN_IN_PROGRESS.md** — Current feature being developed: tasks, decisions, branch (read first if present)
+- **docs/AGENTS.md** — Development principles, workflow, and project scope (primary reference)
+- **docs/ARCHITECTURE.md** — Architectural decisions and patterns
+- **docs/DEVELOPMENT_WORKFLOW.md** — Daily Red-Green-Refactor workflow and git practices
+- **docs/SKILLS.md** — Technical examples (Python, FastAPI, SQLAlchemy patterns)
+- **docs/TESTING_STRATEGY.md** — Testing philosophy and fixtures
+
+## Commande "envoie en prod"
+
+Quand l'utilisateur dit **"envoie en prod"**, exécuter dans l'ordre :
+
+1. Tirer une branche depuis `main` en respectant les conventions de nommage
+2. Faire le ou les commits unitaires (Conventional Commits, messages en français)
+3. Lancer les tests et les checks qualité (voir Pre-Push Checklist ci-dessous)
+4. `git push` vers le remote
+5. Créer la PR en respectant le template (titre et description en français)
+6. Merger la PR
+
+## Pre-Push Checklist
+
+Run all of the following before every `git push`. All must pass with zero errors:
+
+```bash
+pytest                   # All tests pass
+ruff format src/ tests/  # Code formatted
+ruff check src/ tests/   # No lint errors
+mypy src/                # No type errors
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,10 @@ Read these before coding:
 - **docs/SKILLS.md** — Technical examples (Python, FastAPI, SQLAlchemy patterns)
 - **docs/TESTING_STRATEGY.md** — Testing philosophy and fixtures
 
+## Note sur l'utilisation des projets GitHub
+
+Pour les projets GitHub, veuillez utiliser l'expérience « Projects » nouvelle (new Projects experience) au lieu de l'expérience classique (GraphQL: Projects (classic)) qui est dépréciée. Voir : https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/
+
 ## Commande "envoie en prod"
 
 Quand l'utilisateur dit **"envoie en prod"**, exécuter dans l'ordre :

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,10 @@ Read these before coding:
 - **docs/SKILLS.md** — Technical examples (Python, FastAPI, SQLAlchemy patterns)
 - **docs/TESTING_STRATEGY.md** — Testing philosophy and fixtures
 
+## Note sur l'utilisation des projets GitHub
+
+Pour les projets GitHub, veuillez utiliser l'expérience « Projects » nouvelle (new Projects experience) au lieu de l'expérience classique (GraphQL: Projects (classic)) qui est dépréciée. Voir : https://github.blog/changelog/2024-05-23-sunset-notice-projects-classic/
+
 ## Commande "envoie en prod"
 
 Quand l'utilisateur dit **"envoie en prod"**, exécuter dans l'ordre :

--- a/client/package.json
+++ b/client/package.json
@@ -44,6 +44,7 @@
     "typescript": "^5",
     "vitest": "^4.0.18"
   },
+  "packageManager": "pnpm@10.29.2",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",

--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,11 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",
-      "msw"
+      "msw",
+      "@parcel/watcher",
+      "@swc/core",
+      "sharp",
+      "unrs-resolver"
     ]
   }
 }


### PR DESCRIPTION
## Problème

Le CI échouait avec l'erreur  en raison d'une incompatibilité entre la version de Node.js utilisée (v20.20.2) et la version de pnpm (11.0.8) requérant au minimum Node.js v22.13.

## Solution

Mise à jour de la version de Node.js dans le workflow CI de "20" à "22" pour assurer la compatibilité avec pnpm 11.0.8 et permettre le chargement du module  requis.

## Implémentation

- Modification du fichier
- Changement de  à  dans le job

- ## Recette

1. Le workflow CI devrait se terminer avec succès
2. Les tests frontend devraient passer correctement
3. La build du client devrait fonctionner sans erreur liée au module SQLite