### PR TITLE
fix(invitations): fiabiliser la validation des liens

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -520,6 +520,9 @@
       "loading": "Accepting invitation…",
       "success": "Invitation accepted! You have joined the organization.",
       "goToOrganizations": "View my organizations",
+      "unauthenticated": "Sign in or create an account to accept this invitation.",
+      "signIn": "Sign in",
+      "createAccount": "Create account",
       "invalidToken": "This invitation link is invalid or has expired.",
       "missingToken": "Invalid link: missing token.",
       "error": "An error occurred while accepting the invitation."

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -520,6 +520,9 @@
       "loading": "Acceptation de l'invitation en cours…",
       "success": "Invitation acceptée ! Vous avez rejoint l'organisation.",
       "goToOrganizations": "Voir mes organisations",
+      "unauthenticated": "Connectez-vous ou créez un compte pour accepter cette invitation.",
+      "signIn": "Se connecter",
+      "createAccount": "Créer un compte",
       "invalidToken": "Ce lien d'invitation est invalide ou a expiré.",
       "missingToken": "Lien invalide : token manquant.",
       "error": "Une erreur est survenue lors de l'acceptation de l'invitation."

--- a/client/src/components/molecules/auth/login-form.tsx
+++ b/client/src/components/molecules/auth/login-form.tsx
@@ -16,6 +16,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { buildAuthRedirectPath, getSafeAuthCallbackUrl } from "@/lib/auth/callback-url";
 
 function MicrosoftIcon() {
   return (
@@ -44,6 +45,9 @@ export function LoginForm({ entraEnabled = false, backendUrl = "http://localhost
   const t = useTranslations("auth.login");
   const router = useRouter();
   const searchParams = useSearchParams();
+  const rawCallbackUrl = searchParams.get("callbackUrl");
+  const callbackUrl = getSafeAuthCallbackUrl(rawCallbackUrl);
+  const registerHref = buildAuthRedirectPath("/register", rawCallbackUrl);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState(
@@ -72,7 +76,7 @@ export function LoginForm({ entraEnabled = false, backendUrl = "http://localhost
             document.cookie = `raggae_locale=${user.locale};path=/;max-age=${maxAge};SameSite=Lax`;
           }
         }
-        router.push("/projects");
+        router.push(callbackUrl);
       }
     } catch {
       setError(t("unexpectedError"));
@@ -116,7 +120,7 @@ export function LoginForm({ entraEnabled = false, backendUrl = "http://localhost
           </Button>
           <p className="text-center text-sm text-muted-foreground">
             {t("noAccount")}{" "}
-            <a href="/register" className="text-primary hover:underline">{t("register")}</a>
+            <a href={registerHref} className="text-primary hover:underline">{t("register")}</a>
           </p>
           {entraEnabled && (
             <>
@@ -130,7 +134,7 @@ export function LoginForm({ entraEnabled = false, backendUrl = "http://localhost
                 variant="outline"
                 className="w-full"
                 onClick={() => {
-                  window.location.href = `${backendUrl}/api/v1/auth/entra/login?redirect_url=/projects`;
+                  window.location.href = `${backendUrl}/api/v1/auth/entra/login?redirect_url=${encodeURIComponent(callbackUrl)}`;
                 }}
               >
                 <MicrosoftIcon />

--- a/client/src/components/molecules/auth/register-form.tsx
+++ b/client/src/components/molecules/auth/register-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -13,12 +13,16 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { buildAuthRedirectPath } from "@/lib/auth/callback-url";
 import { register } from "@/lib/api/auth";
 import { ApiError } from "@/lib/api/client";
 
 export function RegisterForm() {
   const t = useTranslations("auth.register");
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const rawCallbackUrl = searchParams.get("callbackUrl");
+  const loginHref = buildAuthRedirectPath("/login", rawCallbackUrl);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [fullName, setFullName] = useState("");
@@ -40,7 +44,7 @@ export function RegisterForm() {
 
     try {
       await register({ email, password, full_name: fullName });
-      router.push("/login");
+      router.push(loginHref);
     } catch (err) {
       if (err instanceof ApiError && err.status === 409) {
         setError(t("emailAlreadyExists"));
@@ -100,7 +104,7 @@ export function RegisterForm() {
           </Button>
           <p className="text-center text-sm text-muted-foreground">
             {t("alreadyHaveAccount")}{" "}
-            <a href="/login" className="text-primary hover:underline">{t("signIn")}</a>
+            <a href={loginHref} className="text-primary hover:underline">{t("signIn")}</a>
           </p>
         </form>
       </CardContent>

--- a/client/src/components/organisms/organization/accept-invitation-content.tsx
+++ b/client/src/components/organisms/organization/accept-invitation-content.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useTranslations } from "next-intl";
 import { ApiError } from "@/lib/api/client";
 import { acceptOrganizationInvitation } from "@/lib/api/organizations";
+import { buildAuthRedirectPath } from "@/lib/auth/callback-url";
 import { useAuth } from "@/lib/hooks/use-auth";
 
 type Status = "loading" | "success" | "invalid_token" | "missing_token" | "error";
@@ -17,6 +18,7 @@ export function AcceptInvitationContent() {
   const { token, isLoading: authLoading } = useAuth();
   const queryClient = useQueryClient();
   const invitationToken = searchParams.get("token");
+  const callbackUrl = invitationToken ? `/invitations/accept?${searchParams.toString()}` : null;
   const [status, setStatus] = useState<Status>(invitationToken ? "loading" : "missing_token");
   const called = useRef(false);
 
@@ -38,6 +40,28 @@ export function AcceptInvitationContent() {
         }
       });
   }, [authLoading, token, searchParams, invitationToken, queryClient]);
+
+  if (!authLoading && invitationToken && !token) {
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">{t("unauthenticated")}</p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            href={buildAuthRedirectPath("/login", callbackUrl)}
+            className="text-sm font-medium underline underline-offset-4"
+          >
+            {t("signIn")}
+          </Link>
+          <Link
+            href={buildAuthRedirectPath("/register", callbackUrl)}
+            className="text-sm font-medium underline underline-offset-4"
+          >
+            {t("createAccount")}
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   if (status === "loading") {
     return <p className="text-sm text-muted-foreground">{t("loading")}</p>;

--- a/client/src/lib/auth/callback-url.ts
+++ b/client/src/lib/auth/callback-url.ts
@@ -1,0 +1,14 @@
+export function getSafeAuthCallbackUrl(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return "/projects";
+  }
+  return value;
+}
+
+export function buildAuthRedirectPath(path: "/login" | "/register", callbackUrl: string | null) {
+  const safeCallbackUrl = getSafeAuthCallbackUrl(callbackUrl);
+  if (!callbackUrl || safeCallbackUrl === "/projects") {
+    return path;
+  }
+  return `${path}?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`;
+}

--- a/client/src/lib/auth/callback-url.ts
+++ b/client/src/lib/auth/callback-url.ts
@@ -6,9 +6,9 @@ export function getSafeAuthCallbackUrl(value: string | null) {
 }
 
 export function buildAuthRedirectPath(path: "/login" | "/register", callbackUrl: string | null) {
-  const safeCallbackUrl = getSafeAuthCallbackUrl(callbackUrl);
-  if (!callbackUrl || safeCallbackUrl === "/projects") {
+  if (!callbackUrl) {
     return path;
   }
+  const safeCallbackUrl = getSafeAuthCallbackUrl(callbackUrl);
   return `${path}?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`;
 }

--- a/client/src/proxy.ts
+++ b/client/src/proxy.ts
@@ -5,12 +5,13 @@ import type { NextRequest } from "next/server";
 export async function proxy(request: NextRequest) {
   const token = await getToken({ req: request });
   const { pathname } = request.nextUrl;
+  const protectedPrefixes = ["/projects", "/invitations"];
 
   // Protected routes
-  if (pathname.startsWith("/projects")) {
+  if (protectedPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`))) {
     if (!token) {
       const loginUrl = new URL("/login", request.url);
-      loginUrl.searchParams.set("callbackUrl", pathname);
+      loginUrl.searchParams.set("callbackUrl", `${pathname}${request.nextUrl.search}`);
       return NextResponse.redirect(loginUrl);
     }
   }
@@ -24,5 +25,5 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/projects/:path*", "/login", "/register"],
+  matcher: ["/projects/:path*", "/invitations/:path*", "/login", "/register"],
 };

--- a/client/tests/components/molecules/auth/login-form.test.tsx
+++ b/client/tests/components/molecules/auth/login-form.test.tsx
@@ -11,13 +11,17 @@ vi.mock("next-auth/react", async () => {
 });
 
 const mockPush = vi.fn();
+const mockSearchParamsGet = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: () => null }),
+  useSearchParams: () => ({ get: (key: string) => mockSearchParamsGet(key) }),
 }));
 
 describe("LoginForm", () => {
-  afterEach(() => { vi.clearAllMocks(); });
+  afterEach(() => {
+    vi.clearAllMocks();
+    mockSearchParamsGet.mockReturnValue(null);
+  });
 
   it("should render email and password inputs", () => {
     renderWithProviders(<LoginForm />);
@@ -51,6 +55,32 @@ describe("LoginForm", () => {
       redirect: false,
     });
     expect(mockPush).toHaveBeenCalledWith("/projects");
+  });
+
+  it("should redirect to callbackUrl on success when provided", async () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "callbackUrl" ? "/invitations/accept?token=abc" : null,
+    );
+    mockSignIn.mockResolvedValue({ error: null });
+    const user = userEvent.setup();
+    renderWithProviders(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+    expect(mockPush).toHaveBeenCalledWith("/invitations/accept?token=abc");
+  });
+
+  it("should preserve callbackUrl on register link when provided", () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "callbackUrl" ? "/invitations/accept?token=abc" : null,
+    );
+
+    renderWithProviders(<LoginForm />);
+
+    expect(screen.getByRole("link", { name: /register/i })).toHaveAttribute(
+      "href",
+      "/register?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
   });
 
   it("should display an error alert on failed sign in", async () => {

--- a/client/tests/components/molecules/auth/register-form.test.tsx
+++ b/client/tests/components/molecules/auth/register-form.test.tsx
@@ -7,11 +7,16 @@ import { renderWithProviders } from "../../../helpers/render";
 import { server } from "../../../helpers/msw-server";
 
 const mockPush = vi.fn();
+const mockSearchParamsGet = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => ({ get: (key: string) => mockSearchParamsGet(key) }),
 }));
 
-afterEach(() => { vi.clearAllMocks(); });
+afterEach(() => {
+  vi.clearAllMocks();
+  mockSearchParamsGet.mockReturnValue(null);
+});
 
 describe("RegisterForm", () => {
   it("should render all input fields", () => {
@@ -51,6 +56,42 @@ describe("RegisterForm", () => {
     await user.type(screen.getByLabelText(/password/i), "password123");
     await user.click(screen.getByRole("button", { name: /create account/i }));
     expect(mockPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("should register and redirect to login with callbackUrl when provided", async () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "callbackUrl" ? "/invitations/accept?token=abc" : null,
+    );
+    server.use(
+      http.post("/api/v1/auth/register", () =>
+        HttpResponse.json(
+          { id: "user-1", email: "test@example.com", full_name: "Test User", is_active: true, created_at: "2026-01-01T00:00:00Z" },
+          { status: 201 },
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+    renderWithProviders(<RegisterForm />);
+    await user.type(screen.getByLabelText(/full name/i), "Test User");
+    await user.type(screen.getByLabelText(/email/i), "test@example.com");
+    await user.type(screen.getByLabelText(/password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+    expect(mockPush).toHaveBeenCalledWith(
+      "/login?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
+  });
+
+  it("should preserve callbackUrl on sign in link when provided", () => {
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "callbackUrl" ? "/invitations/accept?token=abc" : null,
+    );
+
+    renderWithProviders(<RegisterForm />);
+
+    expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
+      "href",
+      "/login?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
   });
 
   it("should display an alert on 409 conflict", async () => {

--- a/client/tests/components/organisms/organization/accept-invitation-content.test.tsx
+++ b/client/tests/components/organisms/organization/accept-invitation-content.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AcceptInvitationContent } from "@/components/organisms/organization/accept-invitation-content";
+import { renderWithProviders } from "../../../helpers/render";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams("token=abc"),
+}));
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: () => ({
+    token: null,
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/lib/api/organizations", () => ({
+  acceptOrganizationInvitation: vi.fn(),
+}));
+
+describe("AcceptInvitationContent", () => {
+  it("should show sign in and register links when user is not authenticated", () => {
+    renderWithProviders(<AcceptInvitationContent />);
+
+    expect(screen.getByText("Sign in or create an account to accept this invitation.")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Sign in" })).toHaveAttribute(
+      "href",
+      "/login?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
+    expect(screen.getByRole("link", { name: "Create account" })).toHaveAttribute(
+      "href",
+      "/register?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
+  });
+});

--- a/client/tests/unit/proxy.test.ts
+++ b/client/tests/unit/proxy.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { config, proxy } from "@/proxy";
+
+const mockGetToken = vi.fn();
+
+vi.mock("next-auth/jwt", () => ({
+  getToken: (...args: unknown[]) => mockGetToken(...args),
+}));
+
+describe("proxy", () => {
+  beforeEach(() => {
+    mockGetToken.mockReset();
+  });
+
+  it("should redirect invitation acceptance to login with the full callback URL", async () => {
+    mockGetToken.mockResolvedValue(null);
+    const request = new NextRequest("http://localhost:3000/invitations/accept?token=abc");
+
+    const response = await proxy(request);
+    const location = response.headers.get("location");
+
+    expect(response.status).toBe(307);
+    expect(location).not.toBeNull();
+    expect(new URL(location!).pathname).toBe("/login");
+    expect(new URL(location!).searchParams.get("callbackUrl")).toBe(
+      "/invitations/accept?token=abc",
+    );
+  });
+
+  it("should run on invitation routes", () => {
+    expect(config.matcher).toContain("/invitations/:path*");
+  });
+});

--- a/server/src/raggae/application/use_cases/organization/accept_organization_invitation.py
+++ b/server/src/raggae/application/use_cases/organization/accept_organization_invitation.py
@@ -11,6 +11,7 @@ from raggae.application.interfaces.repositories.organization_member_repository i
 from raggae.application.interfaces.repositories.organization_repository import (
     OrganizationRepository,
 )
+from raggae.application.interfaces.repositories.user_repository import UserRepository
 from raggae.domain.entities.organization_member import OrganizationMember
 from raggae.domain.exceptions.organization_exceptions import (
     OrganizationInvitationInvalidError,
@@ -26,10 +27,12 @@ class AcceptOrganizationInvitation:
 
     def __init__(
         self,
+        user_repository: UserRepository,
         organization_repository: OrganizationRepository,
         organization_member_repository: OrganizationMemberRepository,
         organization_invitation_repository: OrganizationInvitationRepository,
     ) -> None:
+        self._user_repository = user_repository
         self._organization_repository = organization_repository
         self._organization_member_repository = organization_member_repository
         self._organization_invitation_repository = organization_invitation_repository
@@ -44,9 +47,12 @@ class AcceptOrganizationInvitation:
             raise OrganizationNotFoundError(f"Organization {invitation.organization_id} not found")
 
         now = datetime.now(UTC)
+        user = await self._user_repository.find_by_id(user_id)
+        if user is None or invitation.email.strip().lower() != user.email.strip().lower():
+            raise OrganizationInvitationInvalidError("Invitation not found")
         if invitation.status != OrganizationInvitationStatus.PENDING:
             raise OrganizationInvitationInvalidError("Invitation is not pending")
-        if invitation.expires_at < now:
+        if invitation.is_expired(now):
             expired = invitation.with_status(
                 status=OrganizationInvitationStatus.EXPIRED,
                 updated_at=now,

--- a/server/src/raggae/application/use_cases/organization/accept_user_organization_invitation.py
+++ b/server/src/raggae/application/use_cases/organization/accept_user_organization_invitation.py
@@ -56,7 +56,7 @@ class AcceptUserOrganizationInvitation:
         now = datetime.now(UTC)
         if invitation.status != OrganizationInvitationStatus.PENDING:
             raise OrganizationInvitationInvalidError("Invitation is not pending")
-        if invitation.expires_at < now:
+        if invitation.is_expired(now):
             expired = invitation.with_status(
                 status=OrganizationInvitationStatus.EXPIRED,
                 updated_at=now,

--- a/server/src/raggae/application/use_cases/organization/list_user_pending_organization_invitations.py
+++ b/server/src/raggae/application/use_cases/organization/list_user_pending_organization_invitations.py
@@ -38,7 +38,7 @@ class ListUserPendingOrganizationInvitations:
         invitations = await self._organization_invitation_repository.find_pending_by_email(user.email)
         pending_invitations: list[UserPendingOrganizationInvitationDTO] = []
         for invitation in invitations:
-            if invitation.expires_at < now:
+            if invitation.is_expired(now):
                 expired = invitation.with_status(
                     status=OrganizationInvitationStatus.EXPIRED,
                     updated_at=now,

--- a/server/src/raggae/domain/entities/organization_invitation.py
+++ b/server/src/raggae/domain/entities/organization_invitation.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, replace
-from datetime import datetime
+from datetime import UTC, datetime
 from uuid import UUID
 
 from raggae.domain.value_objects.organization_invitation_status import (
@@ -37,3 +37,12 @@ class OrganizationInvitation:
             expires_at=expires_at,
             updated_at=updated_at,
         )
+
+    def is_expired(self, now: datetime) -> bool:
+        return self._as_utc(self.expires_at) < self._as_utc(now)
+
+    @staticmethod
+    def _as_utc(value: datetime) -> datetime:
+        if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -1053,6 +1053,7 @@ def get_revoke_organization_invitation_use_case() -> RevokeOrganizationInvitatio
 
 def get_accept_organization_invitation_use_case() -> AcceptOrganizationInvitation:
     return AcceptOrganizationInvitation(
+        user_repository=_user_repository,
         organization_repository=_organization_repository,
         organization_member_repository=_organization_member_repository,
         organization_invitation_repository=_organization_invitation_repository,

--- a/server/tests/unit/application/use_cases/organization/test_organization_invitation_use_cases.py
+++ b/server/tests/unit/application/use_cases/organization/test_organization_invitation_use_cases.py
@@ -257,6 +257,17 @@ class TestOrganizationInvitationUseCases:
     async def test_accept_invitation(self, setup_data) -> None:
         org_repo, member_repo, invitation_repo, user_repo, org, owner, _ = setup_data
         now = datetime.now(UTC)
+        user_id = uuid4()
+        await user_repo.save(
+            User(
+                id=user_id,
+                email="new@example.com",
+                hashed_password="hashed",
+                full_name="Invited User",
+                is_active=True,
+                created_at=now,
+            )
+        )
         invitation = OrganizationInvitation(
             id=uuid4(),
             organization_id=org.id,
@@ -271,21 +282,116 @@ class TestOrganizationInvitationUseCases:
         )
         await invitation_repo.save(invitation)
         use_case = AcceptOrganizationInvitation(
+            user_repository=user_repo,
             organization_repository=org_repo,
             organization_member_repository=member_repo,
             organization_invitation_repository=invitation_repo,
         )
 
-        accepted_member = await use_case.execute(token_hash="token-hash", user_id=uuid4())
+        accepted_member = await use_case.execute(token_hash="token-hash", user_id=user_id)
         saved_invitation = await invitation_repo.find_by_id(invitation.id)
 
         assert accepted_member.organization_id == org.id
         assert saved_invitation is not None
         assert saved_invitation.status == OrganizationInvitationStatus.ACCEPTED
 
+    async def test_accept_invitation_with_different_user_email_raises(self, setup_data) -> None:
+        org_repo, member_repo, invitation_repo, user_repo, org, owner, _ = setup_data
+        now = datetime.now(UTC)
+        user_id = uuid4()
+        await user_repo.save(
+            User(
+                id=user_id,
+                email="other@example.com",
+                hashed_password="hashed",
+                full_name="Other User",
+                is_active=True,
+                created_at=now,
+            )
+        )
+        invitation = OrganizationInvitation(
+            id=uuid4(),
+            organization_id=org.id,
+            email="new@example.com",
+            role=OrganizationMemberRole.USER,
+            status=OrganizationInvitationStatus.PENDING,
+            invited_by_user_id=owner.user_id,
+            token_hash="token-for-new",
+            expires_at=now + timedelta(days=1),
+            created_at=now,
+            updated_at=now,
+        )
+        await invitation_repo.save(invitation)
+        use_case = AcceptOrganizationInvitation(
+            user_repository=user_repo,
+            organization_repository=org_repo,
+            organization_member_repository=member_repo,
+            organization_invitation_repository=invitation_repo,
+        )
+
+        with pytest.raises(OrganizationInvitationInvalidError):
+            await use_case.execute(token_hash="token-for-new", user_id=user_id)
+
+        assert (
+            await member_repo.find_by_organization_and_user(
+                organization_id=org.id,
+                user_id=user_id,
+            )
+            is None
+        )
+
+    async def test_accept_invitation_with_naive_future_expiry_accepts(self, setup_data) -> None:
+        org_repo, member_repo, invitation_repo, user_repo, org, owner, _ = setup_data
+        now = datetime.now(UTC)
+        user_id = uuid4()
+        await user_repo.save(
+            User(
+                id=user_id,
+                email="new@example.com",
+                hashed_password="hashed",
+                full_name="Invited User",
+                is_active=True,
+                created_at=now,
+            )
+        )
+        invitation = OrganizationInvitation(
+            id=uuid4(),
+            organization_id=org.id,
+            email="new@example.com",
+            role=OrganizationMemberRole.USER,
+            status=OrganizationInvitationStatus.PENDING,
+            invited_by_user_id=owner.user_id,
+            token_hash="naive-future-token",
+            expires_at=(now + timedelta(days=1)).replace(tzinfo=None),
+            created_at=now,
+            updated_at=now,
+        )
+        await invitation_repo.save(invitation)
+        use_case = AcceptOrganizationInvitation(
+            user_repository=user_repo,
+            organization_repository=org_repo,
+            organization_member_repository=member_repo,
+            organization_invitation_repository=invitation_repo,
+        )
+
+        accepted_member = await use_case.execute(token_hash="naive-future-token", user_id=user_id)
+
+        assert accepted_member.organization_id == org.id
+
     async def test_accept_expired_invitation_raises(self, setup_data) -> None:
         org_repo, member_repo, invitation_repo, user_repo, org, owner, _ = setup_data
         now = datetime.now(UTC)
+        user_id = uuid4()
+        await user_repo.save(
+            User(
+                id=user_id,
+                email="new@example.com",
+                hashed_password="hashed",
+                full_name="Invited User",
+                is_active=True,
+                created_at=now,
+            )
+        )
         invitation = OrganizationInvitation(
             id=uuid4(),
             organization_id=org.id,
@@ -300,13 +406,14 @@ class TestOrganizationInvitationUseCases:
         )
         await invitation_repo.save(invitation)
         use_case = AcceptOrganizationInvitation(
+            user_repository=user_repo,
             organization_repository=org_repo,
             organization_member_repository=member_repo,
             organization_invitation_repository=invitation_repo,
         )
 
         with pytest.raises(OrganizationInvitationInvalidError):
-            await use_case.execute(token_hash="expired-token", user_id=uuid4())
+            await use_case.execute(token_hash="expired-token", user_id=user_id)
 
     async def test_list_user_pending_invitations_returns_only_pending_for_user_email(
         self,


### PR DESCRIPTION
## Problème
Les liens d'invitation pouvaient mal fonctionner après une redirection vers la page de connexion, car le chemin `/invitations/accept?token=...` n'était pas protégé et le login revenait systématiquement vers `/projects`. Pour un invité sans compte RAGGAE, le parcours restait bloqué sur l'état `Accepting invitation…` au lieu de proposer la création de compte en conservant le token. Côté backend, l'acceptation par token ne vérifiait pas que l'utilisateur connecté correspondait à l'email invité. Les comparaisons d'expiration pouvaient aussi être fragiles si une date naïve était renvoyée par la persistence.

## Solution
Protéger le parcours d'acceptation d'invitation côté frontend, conserver l'URL complète comme `callbackUrl`, puis rediriger vers cette URL après authentification. Pour un invité sans session, afficher explicitement les actions de connexion et de création de compte avec le même `callbackUrl`. Côté backend, valider l'email de l'utilisateur connecté avant d'accepter le token et centraliser la comparaison d'expiration en UTC dans l'entité d'invitation.

## Implémentation
- Ajout de la protection proxy pour `/invitations/*` avec conservation de la query string.
- Ajout d'un helper partagé pour sécuriser et propager les callback URLs internes.
- Redirection du formulaire de login vers un `callbackUrl` interne validé, y compris pour le SSO Entra.
- Conservation du `callbackUrl` entre login et inscription, puis retour vers login après création du compte.
- État explicite sur la page d'acceptation pour proposer connexion ou création de compte quand aucune session n'est active.
- Injection du `UserRepository` dans `AcceptOrganizationInvitation` pour vérifier l'email invité.
- Ajout de `OrganizationInvitation.is_expired()` pour normaliser les datetimes en UTC.
- Tests unitaires backend pour email non correspondant et expiration naïve future.
- Tests frontend pour le proxy invitation, la redirection login/register et l'état sans session.

## Recette
- Cliquer sur un lien `/invitations/accept?token=...` sans session active.
- Créer un compte RAGGAE avec l'email invité.
- Se connecter avec ce compte.
- Vérifier que l'utilisateur revient sur le lien d'acceptation et rejoint l'organisation.
- Vérifier qu'un autre compte ne peut pas accepter ce token.

Validations exécutées :
- `pytest tests/unit/application/use_cases/organization/test_organization_invitation_use_cases.py tests/e2e/test_organization_endpoints.py -q`
- `ruff format src/ tests/`
- `ruff check src/ tests/`
- `mypy src/`
- `pnpm vitest run tests/unit/proxy.test.ts tests/components/molecules/auth/login-form.test.tsx tests/components/molecules/auth/register-form.test.tsx tests/components/organisms/organization/accept-invitation-content.test.tsx`
- `pnpm exec eslint src/lib/auth/callback-url.ts src/proxy.ts src/components/molecules/auth/login-form.tsx src/components/molecules/auth/register-form.tsx src/components/organisms/organization/accept-invitation-content.tsx tests/unit/proxy.test.ts tests/components/molecules/auth/login-form.test.tsx tests/components/molecules/auth/register-form.test.tsx tests/components/organisms/organization/accept-invitation-content.test.tsx`

Note : le `pytest` complet a été lancé ; il échoue sur `tests/e2e/test_entra_sso_endpoints.py::TestEntraCallbackEndpoint::test_e2e_entra_callback_returns_403_when_domain_not_allowed` uniquement dans la suite complète, alors que ce test passe isolément. Cela semble relever d'un état global/flaky Entra existant, sans lien avec ce correctif.