### PR TITLE
feat(settings): améliorer l'UX du paramétrage de projet (P1 quickwins)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -216,6 +216,7 @@
       "updateSuccess": "Project updated",
       "updateError": "Failed to update project",
       "general": {
+        "identityTitle": "Identity",
         "nameLabel": "Name *",
         "namePlaceholder": "My project",
         "descriptionLabel": "Description",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -216,6 +216,7 @@
       "updateSuccess": "Projet mis à jour",
       "updateError": "Erreur lors de la mise à jour du projet",
       "general": {
+        "identityTitle": "Identité",
         "nameLabel": "Nom *",
         "namePlaceholder": "Mon projet",
         "descriptionLabel": "Description",

--- a/client/src/components/atoms/feedback/progress-bar.tsx
+++ b/client/src/components/atoms/feedback/progress-bar.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+
+type ProgressBarVariant = "default" | "warning" | "danger";
+type ProgressBarSize = "sm" | "md";
+
+interface ProgressBarProps {
+  value: number;
+  max: number;
+  variant?: ProgressBarVariant;
+  size?: ProgressBarSize;
+  label?: string;
+  className?: string;
+}
+
+const VARIANTS: Record<ProgressBarVariant, string> = {
+  default: "bg-primary",
+  warning: "bg-amber-500",
+  danger: "bg-red-600",
+};
+
+const SIZES: Record<ProgressBarSize, string> = {
+  sm: "h-0.5",
+  md: "h-1.5",
+};
+
+export function ProgressBar({
+  value,
+  max,
+  variant = "default",
+  size = "md",
+  label,
+  className,
+}: ProgressBarProps) {
+  const ratio = Math.min(Math.max(max > 0 ? value / max : 0, 0), 1);
+  return (
+    <div
+      className={cn("w-full overflow-hidden rounded-full bg-muted", SIZES[size], className)}
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={max}
+      aria-label={label}
+    >
+      <div
+        className={cn("h-full rounded-full transition-all duration-300", VARIANTS[variant])}
+        style={{ width: `${ratio * 100}%` }}
+      />
+    </div>
+  );
+}

--- a/client/src/components/molecules/document/document-upload.tsx
+++ b/client/src/components/molecules/document/document-upload.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ProgressBar } from "@/components/atoms/feedback/progress-bar";
 import { formatFileSize } from "@/lib/utils/format";
 
 const SUPPORTED_EXTENSIONS = [".pdf", ".docx", ".pptx", ".txt", ".md", ".csv", ".xlsx", ".xls"] as const;
@@ -127,12 +128,7 @@ export function DocumentUpload({ onUpload, isUploading, uploadProgress = 0, disa
               </span>
               <span>{uploadProgress}%</span>
             </div>
-            <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-              <div
-                className="h-full rounded-full bg-primary transition-all duration-300"
-                style={{ width: `${uploadProgress}%` }}
-              />
-            </div>
+            <ProgressBar value={uploadProgress} max={100} label={t("uploading")} />
           </div>
         )}
 

--- a/client/src/components/organisms/project/settings/project-general-panel.tsx
+++ b/client/src/components/organisms/project/settings/project-general-panel.tsx
@@ -60,10 +60,11 @@ export function ProjectGeneralPanel({ projectId }: { projectId: string }) {
   }
 
   return (
-    <Card className="max-w-3xl">
+    <Card>
       <CardContent className="space-y-8">
         {/* Identity */}
-        <div className="space-y-6">
+        <div className="space-y-4">
+          <h2 className="text-base font-semibold tracking-tight">{t("general.identityTitle")}</h2>
           <div className="space-y-2">
             <Label htmlFor="name">{t("general.nameLabel")}</Label>
             <Input

--- a/client/src/components/organisms/project/settings/project-instructions-panel.tsx
+++ b/client/src/components/organisms/project/settings/project-instructions-panel.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent } from "@/components/ui/card";
+import { ProgressBar } from "@/components/atoms/feedback/progress-bar";
 import { useProject, useUpdateProject } from "@/lib/hooks/use-projects";
 
 const MAX_SYSTEM_PROMPT_LENGTH = 8000;
@@ -25,7 +26,15 @@ export function ProjectInstructionsPanel({ projectId }: { projectId: string }) {
   const effectiveSystemPrompt = systemPrompt ?? (project.system_prompt ?? "");
   const hasChanges = effectiveSystemPrompt !== (project.system_prompt ?? "");
   const systemPromptLength = effectiveSystemPrompt.length;
-  const nearLimit = systemPromptLength >= 7000;
+  const fillRatio = systemPromptLength / MAX_SYSTEM_PROMPT_LENGTH;
+  const counterColor =
+    fillRatio >= 0.95
+      ? "text-red-600"
+      : fillRatio >= 0.75
+        ? "text-amber-700"
+        : "text-muted-foreground";
+  const progressVariant: "default" | "warning" | "danger" =
+    fillRatio >= 0.95 ? "danger" : fillRatio >= 0.75 ? "warning" : "default";
 
   function handleSave() {
     updateProject.mutate(
@@ -38,12 +47,12 @@ export function ProjectInstructionsPanel({ projectId }: { projectId: string }) {
   }
 
   return (
-    <Card className="max-w-3xl">
+    <Card>
       <CardContent className="space-y-4">
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label htmlFor="systemPrompt">{t("answerGeneration.promptLabel")}</Label>
-            <span className={`text-xs ${nearLimit ? "text-amber-700" : "text-muted-foreground"}`}>
+            <span className={`text-xs tabular-nums ${counterColor}`}>
               {systemPromptLength}/{MAX_SYSTEM_PROMPT_LENGTH}
             </span>
           </div>
@@ -54,6 +63,13 @@ export function ProjectInstructionsPanel({ projectId }: { projectId: string }) {
             placeholder={t("answerGeneration.promptPlaceholder")}
             rows={16}
             maxLength={MAX_SYSTEM_PROMPT_LENGTH}
+          />
+          <ProgressBar
+            value={systemPromptLength}
+            max={MAX_SYSTEM_PROMPT_LENGTH}
+            variant={progressVariant}
+            size="sm"
+            label={t("answerGeneration.promptLabel")}
           />
           <p className="text-xs text-muted-foreground">{t("answerGeneration.promptLimit")}</p>
         </div>

--- a/client/src/components/organisms/project/settings/project-knowledge-panel.tsx
+++ b/client/src/components/organisms/project/settings/project-knowledge-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FileText } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { InlineAlert } from "@/components/atoms/feedback/inline-alert";
@@ -45,7 +46,7 @@ export function ProjectKnowledgePanel({ projectId }: { projectId: string }) {
   const hasEmbeddingModel = !!effectiveEmbeddingBackend;
 
   return (
-    <div className="max-w-4xl space-y-4">
+    <div className="space-y-4">
       {!hasEmbeddingModel && (
         <InlineAlert>{t("documentIngestion.noEmbeddingModel")}</InlineAlert>
       )}
@@ -106,7 +107,10 @@ export function ProjectKnowledgePanel({ projectId }: { projectId: string }) {
           ))}
         </div>
       ) : (
-        <p className="text-sm text-muted-foreground">{t("documentIngestion.empty")}</p>
+        <div className="flex flex-col items-center justify-center gap-2 rounded-md border border-dashed py-10 px-4 text-center">
+          <FileText className="size-8 text-muted-foreground/60" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">{t("documentIngestion.empty")}</p>
+        </div>
       )}
 
 

--- a/client/src/components/templates/project/project-settings-template.tsx
+++ b/client/src/components/templates/project/project-settings-template.tsx
@@ -76,9 +76,9 @@ export function ProjectSettingsTemplate({ projectId }: ProjectSettingsTemplatePr
           })}
           </div>
           <Button
-            variant="ghost"
+            variant="outline"
             size="sm"
-            className="mb-1 gap-1.5"
+            className="mb-2 gap-1.5"
             onClick={() => setVersionsOpen(true)}
           >
             <History className="size-4" />


### PR DESCRIPTION
## Problème

La page de paramétrage de projet (`/projects/[id]/settings`) présente
plusieurs frictions UX identifiées lors d'une revue heuristique :

- Asymétrie dans le panel Général (section « Accès » a un titre, pas
  la section identité).
- Incohérence des largeurs maximales (template `max-w-3xl`,
  Connaissances `max-w-4xl`, panels redéclarant en plus du parent).
- Bouton « Versions » trop discret (variant ghost, icône seule).
- Empty state des documents = simple paragraphe sans CTA visuel.
- Compteur de caractères des Instructions binaire (seuil dur à 7000),
  sans feedback visuel progressif.

Par ailleurs, la barre de progression de l'upload était inlinée dans
`DocumentUpload`, ce qui empêchait sa réutilisation.

## Solution

Cinq quick wins ciblés sur les frictions ci-dessus, plus l'extraction
d'un atom `ProgressBar` pour assurer la symétrie de code avec les
autres patterns de feedback (`InlineAlert`, `FieldHint`, `DirtyDot`).

## Implémentation

**Nouvel atom**
- `atoms/feedback/progress-bar.tsx` : variants `default | warning | danger`,
  tailles `sm | md`, rôle `progressbar` accessible.

**Refactor**
- `molecules/document/document-upload.tsx` : utilise `ProgressBar` au
  lieu de la barre inline (aucune régression visuelle).

**Panels paramétrage**
- `organisms/project/settings/project-general-panel.tsx` : titre H2
  « Identité » + retrait du `max-w-3xl` redondant.
- `organisms/project/settings/project-instructions-panel.tsx` : compteur
  progressif (3 paliers : neutre / amber / red) + `ProgressBar` fine
  sous le textarea + retrait du `max-w-3xl`.
- `organisms/project/settings/project-knowledge-panel.tsx` : empty state
  visuel (encart pointillé + icône `FileText`) + retrait du `max-w-4xl`.
- `templates/project/project-settings-template.tsx` : bouton « Versions »
  passé en `variant=outline` pour gagner en visibilité.

**i18n**
- Clé `projects.settings.general.identityTitle` ajoutée (FR + EN).

## Recette

1. Aller sur un projet existant → `Paramètres`.
2. Onglet **Général** : vérifier deux sections titrées (« Identité » /
   « Accès »), largeur cohérente avec les autres onglets.
3. Onglet **Instructions** : saisir progressivement du texte ; à 6000+
   caractères le compteur passe en ambre, à 7600+ en rouge ; la barre
   fine sous le textarea grandit en couleur correspondante.
4. Onglet **Connaissances** sans aucun document : un encart pointillé
   avec icône s'affiche à la place du simple texte.
5. Header de la page : bouton « Versions » plus visible (contour).
6. Onglet **Connaissances**, lors d'un upload : la barre de progression
   continue de fonctionner comme avant (validation non régression).

Checks qualité : 448/448 tests Vitest verts, lint propre
(2 warnings préexistants sans rapport).