### PR TITLE
fix(auth): valider et URL-encoder redirect_url sur le SSO Entra

### DIFF
--- a/client/src/app/auth/callback/page.tsx
+++ b/client/src/app/auth/callback/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
 import { Suspense } from "react";
+import { getSafeAuthCallbackUrl } from "@/lib/auth/callback-url";
 
 function EntraCallback() {
   const router = useRouter();
@@ -15,7 +16,7 @@ function EntraCallback() {
     called.current = true;
 
     const code = searchParams.get("code");
-    const redirect = searchParams.get("redirect") || "/projects";
+    const redirect = getSafeAuthCallbackUrl(searchParams.get("redirect"));
 
     if (!code) {
       router.replace("/login");

--- a/client/tests/unit/lib/auth/callback-url.test.ts
+++ b/client/tests/unit/lib/auth/callback-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthRedirectPath, getSafeAuthCallbackUrl } from "@/lib/auth/callback-url";
+
+describe("getSafeAuthCallbackUrl", () => {
+  it("returns /projects when value is null", () => {
+    expect(getSafeAuthCallbackUrl(null)).toBe("/projects");
+  });
+
+  it("returns /projects when value is empty", () => {
+    expect(getSafeAuthCallbackUrl("")).toBe("/projects");
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(getSafeAuthCallbackUrl("//evil.com")).toBe("/projects");
+  });
+
+  it("rejects absolute URLs", () => {
+    expect(getSafeAuthCallbackUrl("https://evil.com")).toBe("/projects");
+  });
+
+  it("rejects values that do not start with a slash", () => {
+    expect(getSafeAuthCallbackUrl("projects")).toBe("/projects");
+  });
+
+  it("accepts internal relative paths", () => {
+    expect(getSafeAuthCallbackUrl("/invitations/accept?token=abc")).toBe(
+      "/invitations/accept?token=abc",
+    );
+  });
+});
+
+describe("buildAuthRedirectPath", () => {
+  it("returns the bare path when callbackUrl is null", () => {
+    expect(buildAuthRedirectPath("/login", null)).toBe("/login");
+  });
+
+  it("attaches a safe callbackUrl when provided", () => {
+    expect(buildAuthRedirectPath("/login", "/invitations/accept?token=abc")).toBe(
+      "/login?callbackUrl=%2Finvitations%2Faccept%3Ftoken%3Dabc",
+    );
+  });
+
+  it("normalizes a malicious callbackUrl to the safe fallback", () => {
+    expect(buildAuthRedirectPath("/login", "//evil.com")).toBe(
+      "/login?callbackUrl=%2Fprojects",
+    );
+  });
+});

--- a/server/src/raggae/presentation/api/v1/endpoints/entra.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/entra.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from urllib.parse import urlencode
 from uuid import uuid4
 
 from fastapi import APIRouter, Cookie, HTTPException, Request, Response, status
@@ -56,6 +57,13 @@ def _not_implemented() -> Response:
     )
 
 
+def _sanitize_redirect_url(value: str | None) -> str:
+    """Restrict redirect_url to internal relative paths (defense against open redirect)."""
+    if not value or not value.startswith("/") or value.startswith("//"):
+        return "/"
+    return value
+
+
 @router.get("/login")
 async def entra_login(
     request: Request,
@@ -65,8 +73,9 @@ async def entra_login(
     if not settings.entra_enabled:
         return _not_implemented()
 
+    safe_redirect_url = _sanitize_redirect_url(redirect_url)
     use_case = get_initiate_oauth_login_use_case()
-    result = await use_case.execute(redirect_url=redirect_url)
+    result = await use_case.execute(redirect_url=safe_redirect_url)
 
     signed_state = _serialize_state(result.state)
     response = RedirectResponse(url=result.authorization_url, status_code=302)
@@ -130,8 +139,9 @@ async def entra_callback(
     code_store = get_oauth_code_store()
     await code_store.store(one_time_code, login_result, ttl_seconds=30)
 
-    redirect_url = parsed_state.redirect_url or "/"
-    frontend_callback = f"{settings.frontend_url}/auth/callback?code={one_time_code}&redirect={redirect_url}"
+    safe_redirect_url = _sanitize_redirect_url(parsed_state.redirect_url)
+    query = urlencode({"code": one_time_code, "redirect": safe_redirect_url})
+    frontend_callback = f"{settings.frontend_url}/auth/callback?{query}"
 
     response = RedirectResponse(url=frontend_callback, status_code=302)
     response.delete_cookie(key=_COOKIE_NAME)

--- a/server/tests/e2e/test_entra_sso_endpoints.py
+++ b/server/tests/e2e/test_entra_sso_endpoints.py
@@ -218,6 +218,77 @@ class TestEntraCallbackEndpoint:
         assert resp.headers["location"].startswith("http://localhost:3000/auth/callback")
         assert "code=" in resp.headers["location"]
 
+    async def test_e2e_entra_callback_sanitizes_malicious_redirect_url(
+        self, entra_client: AsyncClient
+    ) -> None:
+        # Given — login asks for a protocol-relative redirect_url
+        mock_app = make_msal_app()
+        with patch(
+            "raggae.infrastructure.services.entra_oauth_provider.msal.ConfidentialClientApplication",
+            return_value=mock_app,
+        ):
+            login_resp = await entra_client.get(
+                "/api/v1/auth/entra/login",
+                params={"redirect_url": "//evil.com"},
+                follow_redirects=False,
+            )
+        assert login_resp.status_code == 302
+        csrf_token = mock_app.initiate_auth_code_flow.call_args.kwargs["state"]
+        raw_cookie = login_resp.cookies["oauth_state"]
+
+        # When
+        with patch(
+            "raggae.infrastructure.services.entra_oauth_provider.msal.ConfidentialClientApplication",
+            return_value=mock_app,
+        ):
+            resp = await entra_client.get(
+                "/api/v1/auth/entra/callback",
+                params={"code": "auth-code", "state": csrf_token},
+                cookies={"oauth_state": raw_cookie},
+                follow_redirects=False,
+            )
+
+        # Then — frontend callback location does not embed the malicious target
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert location.startswith("http://localhost:3000/auth/callback?")
+        query = parse_qs(urlparse(location).query)
+        assert query["redirect"] == ["/"]
+        assert "evil.com" not in location
+
+    async def test_e2e_entra_callback_url_encodes_redirect_query(self, entra_client: AsyncClient) -> None:
+        # Given — legitimate redirect_url contains chars that must be URL-encoded
+        mock_app = make_msal_app()
+        with patch(
+            "raggae.infrastructure.services.entra_oauth_provider.msal.ConfidentialClientApplication",
+            return_value=mock_app,
+        ):
+            login_resp = await entra_client.get(
+                "/api/v1/auth/entra/login",
+                params={"redirect_url": "/invitations/accept?token=abc"},
+                follow_redirects=False,
+            )
+        csrf_token = mock_app.initiate_auth_code_flow.call_args.kwargs["state"]
+        raw_cookie = login_resp.cookies["oauth_state"]
+
+        # When
+        with patch(
+            "raggae.infrastructure.services.entra_oauth_provider.msal.ConfidentialClientApplication",
+            return_value=mock_app,
+        ):
+            resp = await entra_client.get(
+                "/api/v1/auth/entra/callback",
+                params={"code": "auth-code", "state": csrf_token},
+                cookies={"oauth_state": raw_cookie},
+                follow_redirects=False,
+            )
+
+        # Then — redirect param is preserved intact thanks to URL-encoding
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        query = parse_qs(urlparse(location).query)
+        assert query["redirect"] == ["/invitations/accept?token=abc"]
+
     async def test_e2e_entra_callback_clears_oauth_state_cookie(self, entra_client: AsyncClient) -> None:
         # Given
         mock_app = make_msal_app()


### PR DESCRIPTION
## Problème

Le parcours SSO Entra propageait le `redirect_url` sans aucune validation sur trois étapes :

1. `server/.../entra.py` — `entra_login(redirect_url: str = \"/\")` accepte n'importe quelle valeur (`//evil.com`, URL absolue, etc.) et l'embarque dans le state signé.
2. `server/.../entra.py` — au callback, le `redirect_url` est concaténé brut dans `frontend_callback`, sans URL-encoding (un `&` casse l'URL, un `//` survit).
3. `client/src/app/auth/callback/page.tsx` — `router.replace(redirect)` directement à partir du paramètre, sans rejet de `//`.

Conséquence : `GET /api/v1/auth/entra/login?redirect_url=//evil.com` → après authentification réussie, redirection vers `//evil.com` avec session active (open redirect).

La défense `getSafeAuthCallbackUrl` introduite par la PR #125 ne couvrait que le formulaire de login côté front et restait contournable.

Closes #128.

## Solution

- **Backend** : nouveau helper `_sanitize_redirect_url` (path relatif interne uniquement, fallback `/`). Appliqué en entrée de `/login` et en sortie de `/callback` (défense en profondeur, couvre aussi les states signés produits par d'anciennes versions). Construction de la query string via `urllib.parse.urlencode` pour garantir l'encoding.
- **Frontend** : `/auth/callback` réutilise `getSafeAuthCallbackUrl` sur le paramètre `redirect` avant `router.replace`.

## Implémentation

- `server/src/raggae/presentation/api/v1/endpoints/entra.py` : ajout de `_sanitize_redirect_url`, appel dans `entra_login` et `entra_callback`, `urlencode` pour la query.
- `client/src/app/auth/callback/page.tsx` : import et utilisation de `getSafeAuthCallbackUrl`.
- `server/tests/e2e/test_entra_sso_endpoints.py` : deux tests e2e — sanitation d'un `//evil.com` malveillant, URL-encoding d'un `redirect_url` légitime contenant `?` et `=`.
- `client/tests/unit/lib/auth/callback-url.test.ts` : tests unitaires sur `getSafeAuthCallbackUrl` et `buildAuthRedirectPath` documentant le contrat de sécurité.

## Recette

- `GET /api/v1/auth/entra/login?redirect_url=//evil.com` → après SSO réussi, la redirection finale revient sur `/` (pas `evil.com`).
- `GET /api/v1/auth/entra/login?redirect_url=/invitations/accept?token=abc` → après SSO, la page `/auth/callback` reçoit le `redirect` complet et redirige sur l'URL d'invitation.
- Lancer manuellement `/auth/callback?redirect=//evil.com&code=<bidon>` → la page retombe sur `/projects` (et non `//evil.com`).

## Validation

- `PYTHONPATH=server/src pytest -q` : 920 passed, 35 skipped.
- `ruff format src/ tests/`, `ruff check src/ tests/`, `mypy src/` : OK.
- `npx vitest run` : 464 passed.
- `npx eslint` sur les fichiers modifiés : OK.