### PR TITLE
feat(stats): séries temporelles 90 jours sur /stats

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -708,6 +708,16 @@
       "relevantAnswersRate": "Relevance rate",
       "multiTurnRate": "Multi-turn conversations",
       "averageSources": "Sources / answer"
+    },
+    "timeseries": {
+      "title": "Last 90 days",
+      "description": "Daily volume over the last 90 days.",
+      "userMessages": "Messages sent",
+      "conversations": "Conversations created",
+      "dailyActiveUsers": "Daily active users",
+      "reliableAnswers": "Reliable answers",
+      "documentsIndexed": "Documents indexed",
+      "projectsCreated": "Projects created"
     }
   },
   "errors": {

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -708,6 +708,16 @@
       "relevantAnswersRate": "Taux de pertinence",
       "multiTurnRate": "Conversations multi-tours",
       "averageSources": "Sources / réponse"
+    },
+    "timeseries": {
+      "title": "Évolution sur 90 jours",
+      "description": "Volume quotidien sur les 90 derniers jours, jour par jour.",
+      "userMessages": "Messages envoyés",
+      "conversations": "Conversations créées",
+      "dailyActiveUsers": "Utilisateurs actifs / jour",
+      "reliableAnswers": "Réponses fiables",
+      "documentsIndexed": "Documents indexés",
+      "projectsCreated": "Projets créés"
     }
   },
   "errors": {

--- a/client/src/components/atoms/stats/sparkline.tsx
+++ b/client/src/components/atoms/stats/sparkline.tsx
@@ -1,0 +1,78 @@
+import { Card } from "@/components/ui/card";
+
+interface SparklinePoint {
+  date: string;
+  value: number;
+}
+
+interface SparklineCardProps {
+  label: string;
+  points: SparklinePoint[];
+  total?: number;
+}
+
+const VIEWBOX_WIDTH = 300;
+const VIEWBOX_HEIGHT = 60;
+
+export function SparklineCard({ label, points, total }: SparklineCardProps) {
+  const sum = total ?? points.reduce((acc, p) => acc + p.value, 0);
+  const max = points.reduce((acc, p) => (p.value > acc ? p.value : acc), 0);
+
+  const path = buildPath(points, max);
+  const lastValue = points.length > 0 ? points[points.length - 1].value : 0;
+
+  return (
+    <Card className="flex flex-col gap-2 p-5">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm text-muted-foreground">{label}</span>
+        <span className="text-2xl font-bold tabular-nums">
+          {sum.toLocaleString("fr-FR")}
+        </span>
+      </div>
+      <svg
+        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+        className="h-16 w-full"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`Évolution de ${label}`}
+      >
+        {max > 0 ? (
+          <path
+            d={path}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            className="text-primary"
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : (
+          <line
+            x1={0}
+            x2={VIEWBOX_WIDTH}
+            y1={VIEWBOX_HEIGHT / 2}
+            y2={VIEWBOX_HEIGHT / 2}
+            stroke="currentColor"
+            strokeWidth={1}
+            strokeDasharray="3 3"
+            className="text-muted-foreground/40"
+          />
+        )}
+      </svg>
+      <span className="text-xs text-muted-foreground">
+        Dernier jour : {lastValue.toLocaleString("fr-FR")}
+      </span>
+    </Card>
+  );
+}
+
+function buildPath(points: SparklinePoint[], max: number): string {
+  if (points.length === 0 || max === 0) return "";
+  const stepX = VIEWBOX_WIDTH / Math.max(points.length - 1, 1);
+  return points
+    .map((p, i) => {
+      const x = i * stepX;
+      const y = VIEWBOX_HEIGHT - (p.value / max) * VIEWBOX_HEIGHT;
+      return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(" ");
+}

--- a/client/src/components/organisms/stats/stats-page.tsx
+++ b/client/src/components/organisms/stats/stats-page.tsx
@@ -7,6 +7,7 @@ import { StatCard } from "@/components/atoms/stats/stat-card";
 import { getStats } from "@/lib/api/stats";
 import type { StatsResponse } from "@/lib/api/stats";
 import { useAuth } from "@/lib/hooks/use-auth";
+import { StatsTimeseriesSection } from "@/components/organisms/stats/stats-timeseries-section";
 
 function StatsSkeleton() {
   return (
@@ -139,6 +140,9 @@ function StatsContent({ stats }: { stats: StatsResponse }) {
           />
         </div>
       </section>
+
+      {/* Timeseries (fetched independently) */}
+      <StatsTimeseriesSection />
 
       <p className="text-center text-xs text-muted-foreground">
         {t("generatedAt", {

--- a/client/src/components/organisms/stats/stats-timeseries-section.tsx
+++ b/client/src/components/organisms/stats/stats-timeseries-section.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
+import { Skeleton } from "@/components/ui/skeleton";
+import { SparklineCard } from "@/components/atoms/stats/sparkline";
+import { getStatsTimeseries } from "@/lib/api/stats";
+import { useAuth } from "@/lib/hooks/use-auth";
+
+const DEFAULT_DAYS = 90;
+
+function SectionSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <Skeleton key={i} className="h-36" />
+      ))}
+    </div>
+  );
+}
+
+export function StatsTimeseriesSection() {
+  const t = useTranslations("stats");
+  const { token } = useAuth();
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["stats", "timeseries", DEFAULT_DAYS],
+    queryFn: () => getStatsTimeseries(token!, DEFAULT_DAYS),
+    enabled: !!token,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <section className="space-y-4">
+      <div className="space-y-1">
+        <h2 className="text-xl font-semibold">{t("timeseries.title")}</h2>
+        <p className="text-sm text-muted-foreground">{t("timeseries.description")}</p>
+      </div>
+
+      {isLoading && <SectionSkeleton />}
+
+      {error && <p className="text-destructive">{t("loadError")}</p>}
+
+      {data && (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <SparklineCard label={t("timeseries.userMessages")} points={data.user_messages} />
+          <SparklineCard label={t("timeseries.conversations")} points={data.conversations} />
+          <SparklineCard
+            label={t("timeseries.dailyActiveUsers")}
+            points={data.daily_active_users}
+          />
+          <SparklineCard label={t("timeseries.reliableAnswers")} points={data.reliable_answers} />
+          <SparklineCard
+            label={t("timeseries.documentsIndexed")}
+            points={data.documents_indexed}
+          />
+          <SparklineCard label={t("timeseries.projectsCreated")} points={data.projects_created} />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/lib/api/stats.ts
+++ b/client/src/lib/api/stats.ts
@@ -38,3 +38,27 @@ export interface StatsResponse {
 export function getStats(token: string): Promise<StatsResponse> {
   return apiFetch<StatsResponse>("/stats", { token });
 }
+
+export interface TimeSeriesPoint {
+  date: string;
+  value: number;
+}
+
+export interface StatsTimeSeriesResponse {
+  generated_at: string;
+  from_date: string;
+  to_date: string;
+  user_messages: TimeSeriesPoint[];
+  conversations: TimeSeriesPoint[];
+  daily_active_users: TimeSeriesPoint[];
+  reliable_answers: TimeSeriesPoint[];
+  documents_indexed: TimeSeriesPoint[];
+  projects_created: TimeSeriesPoint[];
+}
+
+export function getStatsTimeseries(
+  token: string,
+  days: number = 90,
+): Promise<StatsTimeSeriesResponse> {
+  return apiFetch<StatsTimeSeriesResponse>(`/stats/timeseries?days=${days}`, { token });
+}

--- a/server/src/raggae/application/dto/stats_dto.py
+++ b/server/src/raggae/application/dto/stats_dto.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 
 
 @dataclass
@@ -39,3 +39,22 @@ class StatsDTO:
     fonctionnement: StatsFonctionnementDTO
     usage: StatsUsageDTO
     impact: StatsImpactDTO
+
+
+@dataclass
+class TimeSeriesPoint:
+    date: date
+    value: int
+
+
+@dataclass
+class StatsTimeSeriesDTO:
+    generated_at: datetime
+    from_date: date
+    to_date: date
+    user_messages: list[TimeSeriesPoint]
+    conversations: list[TimeSeriesPoint]
+    daily_active_users: list[TimeSeriesPoint]
+    reliable_answers: list[TimeSeriesPoint]
+    documents_indexed: list[TimeSeriesPoint]
+    projects_created: list[TimeSeriesPoint]

--- a/server/src/raggae/application/interfaces/repositories/stats_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/stats_repository.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from raggae.application.dto.stats_dto import StatsDTO
+from raggae.application.dto.stats_dto import StatsDTO, StatsTimeSeriesDTO
 
 
 class StatsRepository(ABC):
@@ -9,3 +9,7 @@ class StatsRepository(ABC):
     @abstractmethod
     async def get_stats(self) -> StatsDTO:
         """Return aggregated platform statistics."""
+
+    @abstractmethod
+    async def get_timeseries(self, days: int) -> StatsTimeSeriesDTO:
+        """Return daily time series for the last `days` days (inclusive of today)."""

--- a/server/src/raggae/application/use_cases/stats/get_stats_timeseries.py
+++ b/server/src/raggae/application/use_cases/stats/get_stats_timeseries.py
@@ -1,0 +1,12 @@
+from raggae.application.dto.stats_dto import StatsTimeSeriesDTO
+from raggae.application.interfaces.repositories.stats_repository import StatsRepository
+
+
+class GetStatsTimeSeries:
+    """Use Case: Return daily time series for the last `days` days."""
+
+    def __init__(self, stats_repository: StatsRepository) -> None:
+        self._stats_repository = stats_repository
+
+    async def execute(self, days: int) -> StatsTimeSeriesDTO:
+        return await self._stats_repository.get_timeseries(days)

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_stats_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_stats_repository.py
@@ -1,10 +1,12 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from raggae.application.dto.stats_dto import (
     StatsDTO,
     StatsFonctionnementDTO,
     StatsImpactDTO,
+    StatsTimeSeriesDTO,
     StatsUsageDTO,
+    TimeSeriesPoint,
 )
 from raggae.application.interfaces.repositories.stats_repository import StatsRepository
 
@@ -40,4 +42,20 @@ class InMemoryStatsRepository(StatsRepository):
                 multi_turn_conversations_rate_percent=0.0,
                 average_sources_per_answer=0.0,
             ),
+        )
+
+    async def get_timeseries(self, days: int) -> StatsTimeSeriesDTO:
+        today = datetime.now(UTC).date()
+        from_date = today - timedelta(days=days - 1)
+        empty_series = [TimeSeriesPoint(date=from_date + timedelta(days=i), value=0) for i in range(days)]
+        return StatsTimeSeriesDTO(
+            generated_at=datetime.now(UTC),
+            from_date=from_date,
+            to_date=today,
+            user_messages=list(empty_series),
+            conversations=list(empty_series),
+            daily_active_users=list(empty_series),
+            reliable_answers=list(empty_series),
+            documents_indexed=list(empty_series),
+            projects_created=list(empty_series),
         )

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_stats_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_stats_repository.py
@@ -1,14 +1,16 @@
 from collections.abc import Callable
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 
-from sqlalchemy import func, select, text
+from sqlalchemy import Select, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from raggae.application.dto.stats_dto import (
     StatsDTO,
     StatsFonctionnementDTO,
     StatsImpactDTO,
+    StatsTimeSeriesDTO,
     StatsUsageDTO,
+    TimeSeriesPoint,
 )
 from raggae.application.interfaces.repositories.stats_repository import StatsRepository
 from raggae.infrastructure.database.models.conversation_model import ConversationModel
@@ -207,3 +209,106 @@ class SQLAlchemyStatsRepository(StatsRepository):
             multi_turn_conversations_rate_percent=round(multi_turn_rate, 1),
             average_sources_per_answer=round(float(avg_sources_row or 0), 1),
         )
+
+    async def get_timeseries(self, days: int) -> StatsTimeSeriesDTO:
+        today = datetime.now(UTC).date()
+        from_date = today - timedelta(days=days - 1)
+        from_dt = datetime.combine(from_date, datetime.min.time(), tzinfo=UTC)
+
+        async with self._session_factory() as session:
+            user_messages_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", MessageModel.created_at).label("bucket"),
+                    func.count().label("value"),
+                )
+                .where(MessageModel.role == "user")
+                .where(MessageModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+            conversations_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", ConversationModel.created_at).label("bucket"),
+                    func.count().label("value"),
+                )
+                .where(ConversationModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+            daily_active_users_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", MessageModel.created_at).label("bucket"),
+                    func.count(func.distinct(ConversationModel.user_id)).label("value"),
+                )
+                .select_from(MessageModel)
+                .join(ConversationModel, MessageModel.conversation_id == ConversationModel.id)
+                .where(MessageModel.role == "user")
+                .where(MessageModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+            reliable_answers_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", MessageModel.created_at).label("bucket"),
+                    func.count().label("value"),
+                )
+                .where(MessageModel.role == "assistant")
+                .where(MessageModel.reliability_percent >= _RELIABILITY_THRESHOLD)
+                .where(MessageModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+            documents_indexed_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", DocumentModel.created_at).label("bucket"),
+                    func.count().label("value"),
+                )
+                .where(DocumentModel.status == "indexed")
+                .where(DocumentModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+            projects_created_rows = await self._daily_counts(
+                session,
+                select(
+                    func.date_trunc("day", ProjectModel.created_at).label("bucket"),
+                    func.count().label("value"),
+                )
+                .where(ProjectModel.created_at >= from_dt)
+                .group_by("bucket"),
+            )
+
+        return StatsTimeSeriesDTO(
+            generated_at=datetime.now(UTC),
+            from_date=from_date,
+            to_date=today,
+            user_messages=_fill_series(from_date, days, user_messages_rows),
+            conversations=_fill_series(from_date, days, conversations_rows),
+            daily_active_users=_fill_series(from_date, days, daily_active_users_rows),
+            reliable_answers=_fill_series(from_date, days, reliable_answers_rows),
+            documents_indexed=_fill_series(from_date, days, documents_indexed_rows),
+            projects_created=_fill_series(from_date, days, projects_created_rows),
+        )
+
+    @staticmethod
+    async def _daily_counts(session: AsyncSession, stmt: Select[tuple[datetime, int]]) -> dict[date, int]:
+        result = await session.execute(stmt)
+        buckets: dict[date, int] = {}
+        for bucket, value in result.all():
+            buckets[bucket.date() if isinstance(bucket, datetime) else bucket] = int(value)
+        return buckets
+
+
+def _fill_series(from_date: date, days: int, buckets: dict[date, int]) -> list[TimeSeriesPoint]:
+    return [
+        TimeSeriesPoint(
+            date=(d := from_date + timedelta(days=i)),
+            value=buckets.get(d, 0),
+        )
+        for i in range(days)
+    ]

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -203,6 +203,7 @@ from raggae.application.use_cases.provider_credentials.save_provider_api_key imp
     SaveProviderApiKey,
 )
 from raggae.application.use_cases.stats.get_public_stats import GetPublicStats
+from raggae.application.use_cases.stats.get_stats_timeseries import GetStatsTimeSeries
 from raggae.application.use_cases.user.get_current_user import GetCurrentUser
 from raggae.application.use_cases.user.get_user_agent_configuration import GetUserAgentConfiguration
 from raggae.application.use_cases.user.handle_oauth_callback import HandleOAuthCallback
@@ -1192,6 +1193,10 @@ def get_agent_configuration_repository() -> AgentConfigurationRepository:
 
 def get_get_public_stats_use_case() -> GetPublicStats:
     return GetPublicStats(stats_repository=_stats_repository)
+
+
+def get_get_stats_timeseries_use_case() -> GetStatsTimeSeries:
+    return GetStatsTimeSeries(stats_repository=_stats_repository)
 
 
 def get_current_user_id(

--- a/server/src/raggae/presentation/api/v1/endpoints/stats.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/stats.py
@@ -1,14 +1,21 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from raggae.application.use_cases.stats.get_public_stats import GetPublicStats
-from raggae.presentation.api.dependencies import get_current_user_id, get_get_public_stats_use_case
+from raggae.application.use_cases.stats.get_stats_timeseries import GetStatsTimeSeries
+from raggae.presentation.api.dependencies import (
+    get_current_user_id,
+    get_get_public_stats_use_case,
+    get_get_stats_timeseries_use_case,
+)
 from raggae.presentation.api.v1.schemas.stats_schemas import (
     StatsFonctionnementResponse,
     StatsImpactResponse,
     StatsResponse,
+    StatsTimeSeriesResponse,
     StatsUsageResponse,
+    TimeSeriesPointResponse,
 )
 
 router = APIRouter(prefix="/stats", tags=["stats"], dependencies=[Depends(get_current_user_id)])
@@ -47,4 +54,28 @@ async def get_stats(
             multi_turn_conversations_rate_percent=dto.impact.multi_turn_conversations_rate_percent,
             average_sources_per_answer=dto.impact.average_sources_per_answer,
         ),
+    )
+
+
+@router.get("/timeseries", response_model=StatsTimeSeriesResponse)
+async def get_stats_timeseries(
+    use_case: Annotated[GetStatsTimeSeries, Depends(get_get_stats_timeseries_use_case)],
+    days: int = Query(90, ge=1, le=365),
+) -> StatsTimeSeriesResponse:
+    """Return daily time series for the last `days` days. Authentication required."""
+    dto = await use_case.execute(days=days)
+
+    def _points(series: list) -> list[TimeSeriesPointResponse]:  # type: ignore[type-arg]
+        return [TimeSeriesPointResponse(date=p.date, value=p.value) for p in series]
+
+    return StatsTimeSeriesResponse(
+        generated_at=dto.generated_at,
+        from_date=dto.from_date,
+        to_date=dto.to_date,
+        user_messages=_points(dto.user_messages),
+        conversations=_points(dto.conversations),
+        daily_active_users=_points(dto.daily_active_users),
+        reliable_answers=_points(dto.reliable_answers),
+        documents_indexed=_points(dto.documents_indexed),
+        projects_created=_points(dto.projects_created),
     )

--- a/server/src/raggae/presentation/api/v1/schemas/stats_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/stats_schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel
 
@@ -36,3 +36,20 @@ class StatsResponse(BaseModel):
     fonctionnement: StatsFonctionnementResponse
     usage: StatsUsageResponse
     impact: StatsImpactResponse
+
+
+class TimeSeriesPointResponse(BaseModel):
+    date: date
+    value: int
+
+
+class StatsTimeSeriesResponse(BaseModel):
+    generated_at: datetime
+    from_date: date
+    to_date: date
+    user_messages: list[TimeSeriesPointResponse]
+    conversations: list[TimeSeriesPointResponse]
+    daily_active_users: list[TimeSeriesPointResponse]
+    reliable_answers: list[TimeSeriesPointResponse]
+    documents_indexed: list[TimeSeriesPointResponse]
+    projects_created: list[TimeSeriesPointResponse]

--- a/server/tests/e2e/test_stats_endpoints.py
+++ b/server/tests/e2e/test_stats_endpoints.py
@@ -128,3 +128,91 @@ class TestStatsEndpoints:
         assert data["north_star_reliable_answers"] == 0
         assert data["usage"]["users_total"] == 0
         assert data["usage"]["conversations_total"] == 0
+
+    async def test_e2e_stats_timeseries_returns_401_without_authentication(self, client: AsyncClient) -> None:
+        # When
+        response = await client.get("/api/v1/stats/timeseries")
+
+        # Then
+        assert response.status_code == 401
+
+    async def test_e2e_stats_timeseries_returns_200_with_authentication(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When
+        response = await client.get("/api/v1/stats/timeseries", headers=headers)
+
+        # Then
+        assert response.status_code == 200
+
+    async def test_e2e_stats_timeseries_response_has_expected_structure(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When
+        response = await client.get("/api/v1/stats/timeseries", headers=headers)
+
+        # Then
+        data = response.json()
+        assert "generated_at" in data
+        assert "from_date" in data
+        assert "to_date" in data
+        for series_key in (
+            "user_messages",
+            "conversations",
+            "daily_active_users",
+            "reliable_answers",
+            "documents_indexed",
+            "projects_created",
+        ):
+            assert series_key in data
+            assert isinstance(data[series_key], list)
+
+    async def test_e2e_stats_timeseries_defaults_to_90_buckets(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When
+        response = await client.get("/api/v1/stats/timeseries", headers=headers)
+
+        # Then
+        data = response.json()
+        assert len(data["user_messages"]) == 90
+        assert len(data["conversations"]) == 90
+        assert len(data["projects_created"]) == 90
+
+    async def test_e2e_stats_timeseries_respects_days_query_param(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When
+        response = await client.get("/api/v1/stats/timeseries?days=7", headers=headers)
+
+        # Then
+        data = response.json()
+        assert len(data["user_messages"]) == 7
+
+    async def test_e2e_stats_timeseries_rejects_out_of_range_days(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When / Then
+        too_low = await client.get("/api/v1/stats/timeseries?days=0", headers=headers)
+        too_high = await client.get("/api/v1/stats/timeseries?days=366", headers=headers)
+        assert too_low.status_code == 422
+        assert too_high.status_code == 422
+
+    async def test_e2e_stats_timeseries_points_have_date_and_value(self, client: AsyncClient) -> None:
+        # Given
+        headers = await self._auth_headers(client)
+
+        # When
+        response = await client.get("/api/v1/stats/timeseries?days=3", headers=headers)
+
+        # Then
+        data = response.json()
+        for point in data["user_messages"]:
+            assert "date" in point
+            assert "value" in point
+            assert isinstance(point["value"], int)

--- a/server/tests/unit/application/use_cases/stats/test_get_stats_timeseries.py
+++ b/server/tests/unit/application/use_cases/stats/test_get_stats_timeseries.py
@@ -1,0 +1,67 @@
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from raggae.application.dto.stats_dto import StatsTimeSeriesDTO, TimeSeriesPoint
+from raggae.application.use_cases.stats.get_stats_timeseries import GetStatsTimeSeries
+
+
+class TestGetStatsTimeSeries:
+    @pytest.fixture
+    def mock_stats_repository(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def use_case(self, mock_stats_repository: AsyncMock) -> GetStatsTimeSeries:
+        return GetStatsTimeSeries(stats_repository=mock_stats_repository)
+
+    async def test_execute_delegates_to_repository_with_days(
+        self,
+        use_case: GetStatsTimeSeries,
+        mock_stats_repository: AsyncMock,
+    ) -> None:
+        # Given
+        expected = StatsTimeSeriesDTO(
+            generated_at=datetime.now(UTC),
+            from_date=date(2026, 3, 31),
+            to_date=date(2026, 6, 28),
+            user_messages=[TimeSeriesPoint(date=date(2026, 6, 28), value=3)],
+            conversations=[],
+            daily_active_users=[],
+            reliable_answers=[],
+            documents_indexed=[],
+            projects_created=[],
+        )
+        mock_stats_repository.get_timeseries.return_value = expected
+
+        # When
+        result = await use_case.execute(days=90)
+
+        # Then
+        assert result is expected
+        mock_stats_repository.get_timeseries.assert_awaited_once_with(90)
+
+    async def test_execute_propagates_days_parameter(
+        self,
+        use_case: GetStatsTimeSeries,
+        mock_stats_repository: AsyncMock,
+    ) -> None:
+        # Given
+        mock_stats_repository.get_timeseries.return_value = StatsTimeSeriesDTO(
+            generated_at=datetime.now(UTC),
+            from_date=date(2026, 6, 22),
+            to_date=date(2026, 6, 28),
+            user_messages=[],
+            conversations=[],
+            daily_active_users=[],
+            reliable_answers=[],
+            documents_indexed=[],
+            projects_created=[],
+        )
+
+        # When
+        await use_case.execute(days=7)
+
+        # Then
+        mock_stats_repository.get_timeseries.assert_awaited_once_with(7)


### PR DESCRIPTION
## Problème
La page `/stats` ne fournit qu'un snapshot instantané. Impossible de
voir comment l'usage ou l'impact évolue dans le temps, ni de
détecter une tendance (montée d'activité, panne d'indexation, etc.).

## Solution
Ajouter une route authentifiée `GET /api/v1/stats/timeseries` qui
renvoie six séries journalières sur les 90 derniers jours (paramètre
`days` borné 1..365), exposées à l'utilisateur via une nouvelle
section "Évolution sur 90 jours" sur la page Stats, sous forme de
sparklines.

Phase 1 : on se limite aux métriques calculables sans migration de
schéma — les familles **performance/coût** et **feedback** sont
hors scope (elles nécessiteront des colonnes ou tables dédiées et
feront l'objet de PR séparées).

## Implémentation

**Couche Application**
- `StatsTimeSeriesDTO` + `TimeSeriesPoint` dans `application/dto/stats_dto.py`
- Interface `StatsRepository.get_timeseries(days)` étendue
- Use case `GetStatsTimeSeries` (`application/use_cases/stats/get_stats_timeseries.py`)

**Couche Infrastructure**
- `SQLAlchemyStatsRepository.get_timeseries` : six requêtes agrégées
  `date_trunc('day', created_at) GROUP BY bucket`, comblage Python
  des jours vides à zéro pour garantir une série continue de N points
- `InMemoryStatsRepository.get_timeseries` : 90 buckets vides pour les tests

**Couche Présentation**
- Endpoint `GET /api/v1/stats/timeseries?days=90` (auth via
  `get_current_user_id`, `Query(ge=1, le=365)`)
- Schémas Pydantic `StatsTimeSeriesResponse` / `TimeSeriesPointResponse`
- DI `get_get_stats_timeseries_use_case`

**Tests**
- 2 tests unit sur le use case (délégation au repo, propagation du paramètre)
- 7 tests e2e sur l'endpoint (401 sans auth, 200 avec, structure, 90 buckets par défaut, `?days=7`, 422 hors range, format des points)

**Frontend (Atomic Design)**
- `lib/api/stats.ts` : type `StatsTimeSeriesResponse` + `getStatsTimeseries(token, days?)`
- Atom `SparklineCard` : courbe SVG inline (pas de dépendance ajoutée), total agrégé, valeur du dernier jour
- Organism `StatsTimeseriesSection` : fetch React Query indépendant (cache 5 min), skeleton, gestion erreur, grille de 6 cards
- Intégré dans `StatsPage` sous l'Impact
- i18n FR + EN (`stats.timeseries.*`)

**Séries fournies**
1. Messages utilisateur / jour
2. Conversations créées / jour
3. Utilisateurs actifs / jour (DAU)
4. Réponses fiables / jour (`reliability_percent ≥ 70`)
5. Documents indexés / jour
6. Projets créés / jour (pas de `published_at` en base, on prend la date de création)

## Recette

1. Lancer le backend (`uvicorn`) et le frontend (`npm run dev`)
2. Se connecter
3. Aller sur `/stats`
4. Vérifier que la section **Évolution sur 90 jours** apparaît sous "Impact" avec 6 sparklines
5. Sans données récentes : les courbes sont remplacées par une ligne pointillée et les totaux affichent 0
6. Avec une base peuplée : vérifier que les courbes correspondent à l'activité observable (envoi de quelques messages dans un projet doit faire monter la dernière barre des séries `Messages envoyés`, `Conversations créées`, `Utilisateurs actifs`, et idéalement `Réponses fiables` si la fiabilité ≥ 70 %)
7. Curl direct :
   - `GET /api/v1/stats/timeseries` sans token → 401
   - `GET /api/v1/stats/timeseries` avec token → 200, payload contenant `from_date`, `to_date`, et six listes de 90 points
   - `GET /api/v1/stats/timeseries?days=7` → 7 points par série
   - `GET /api/v1/stats/timeseries?days=400` → 422

## Hors scope (phases ultérieures)
- Phase 2 : performance & coût (migration `messages` avec `latency_ms`, `prompt_tokens`, `completion_tokens`, `cost_usd`, `model_id`, instrumentation du use case chat)
- Phase 3 : qualité perçue / feedback (table `message_feedback`, UI thumbs up/down sous chaque réponse)