### PR TITLE
feat(mcp): domaine et use cases org MCP (PR 1/6)

### DIFF
--- a/docs/MCP_FEATURE_PLAN.md
+++ b/docs/MCP_FEATURE_PLAN.md
@@ -1,0 +1,389 @@
+# MCP au niveau organisation, activables par projet
+
+> Plan d'implémentation, à dérouler PR après PR.
+> Sauvegardé après la session de cadrage du 2026-06-29.
+> Quand le refactoring `refactor/agent-configurations` (cf. `PLAN_IN_PROGRESS.md`) sera mergé, ce plan pourra être recopié dans `PLAN_IN_PROGRESS.md` à son tour.
+
+## Vue d'ensemble
+
+Une **organisation** peut déclarer des serveurs **MCP** (Model Context Protocol) distants.
+Un **projet** de cette organisation peut **activer (opt-in)** les MCP de son choix pour exposer leurs **tools** au LLM lors des conversations.
+
+## Décisions de cadrage (figées)
+
+| Dimension | Choix |
+|---|---|
+| Transport | HTTP/SSE distant uniquement (Streamable HTTP) |
+| Capabilities exposées | `tools` uniquement |
+| Auth supportée | Aucune **ou** Bearer token chiffré |
+| Activation projet | Opt-in explicite par projet |
+| Granularité tools | Tout ou rien par MCP (pas d'allow-list V1) |
+| Découverte tools | Snapshot à la déclaration + bouton "rafraîchir" manuel |
+| Collisions de noms | Préfixe automatique `<mcp_slug>__<tool_name>` |
+| Sécurité réseau | HTTPS obligatoire + denylist IPs privées (anti-SSRF) |
+| Tool calling LLM | Function calling natif (OpenAI / Anthropic / Mistral / Gemini). Providers non compatibles : MCP ignorés avec warning UI. |
+| Timeout / retry | Timeout configurable (5–60 s, défaut 30 s), pas de retry serveur, erreur remontée au LLM |
+| Observabilité | Logs structurés + compteurs agrégés dans `/stats` |
+| Limites V1 | Aucune (à monitorer) |
+| Permissions org | OWNER + MAKER (déclarer / modifier / supprimer) |
+| Permissions projet | Tout membre ayant accès au projet (activer / désactiver) |
+| Lifecycle | Désactivation transparente (active project conservées). Suppression cascade sur les activations projet. |
+
+## Modèle de domaine
+
+### `OrgMcpServer` (rattaché à une org)
+
+```python
+@dataclass(frozen=True)
+class OrgMcpServer:
+    id: UUID
+    organization_id: UUID
+    name: str                          # humain
+    slug: str                          # unique dans l'org, dérivé du name
+    url: str                           # HTTPS obligatoire
+    auth_type: McpAuthType             # NONE | BEARER
+    encrypted_bearer_token: str | None # null si NONE
+    token_fingerprint: str | None
+    token_suffix: str | None
+    is_active: bool                    # org-level on/off
+    tools_snapshot: list[McpToolSnapshot]
+    tools_snapshot_at: datetime
+    timeout_seconds: int               # défaut 30, plage 5-60
+    created_at: datetime
+    updated_at: datetime
+    created_by_user_id: UUID
+```
+
+### `ProjectMcpActivation` (jointure project ↔ mcp)
+
+```python
+@dataclass(frozen=True)
+class ProjectMcpActivation:
+    project_id: UUID
+    org_mcp_server_id: UUID
+    is_active: bool
+    activated_at: datetime
+    activated_by_user_id: UUID
+```
+
+### Value objects
+
+```python
+class McpAuthType(str, Enum):
+    NONE = "none"
+    BEARER = "bearer"
+
+@dataclass(frozen=True)
+class McpToolSnapshot:
+    name: str
+    description: str
+    input_schema: dict  # JSON Schema
+```
+
+### Exceptions domaine
+
+- `McpServerNotFoundError`
+- `McpDuplicateSlugError`
+- `McpAccessDeniedError`
+- `McpUrlForbiddenError` (URL non HTTPS, IP privée, hôte interdit)
+- `McpHandshakeError` (échec `tools/list` à la déclaration)
+- `McpToolNotFoundError`
+- `McpCallTimeoutError`
+
+## Règles métier détaillées
+
+1. **HTTPS obligatoire**. Résolution DNS côté serveur, refus des IPs privées / loopback / link-local (10/8, 127/8, 169.254/16, 172.16/12, 192.168/16, fc00::/7, ::1, etc.). Validation à la déclaration **et** à chaque appel (le DNS peut changer entre-temps).
+2. **Slug unique par org**. Généré depuis le `name` (kebab-case ASCII). En cas de conflit, suffixe numérique `-2`, `-3`, etc.
+3. **Permissions**
+   - Déclarer / modifier / supprimer un MCP org : `OWNER` ou `MAKER` (analogue à `OrgModelProviderCredential`).
+   - Activer / désactiver dans un projet : tout membre ayant accès au projet.
+4. **Lifecycle**
+   - `OrgMcpServer.is_active = false` : les activations projet sont **conservées** mais le MCP n'est plus appelé. Réactivation = retour à l'état précédent.
+   - Suppression : **cascade** sur `ProjectMcpActivation`.
+5. **Refresh des tools** : appel `tools/list` sur le serveur MCP, mise à jour du snapshot. Bouton manuel uniquement en V1. Pas de job périodique.
+6. **Tool calling**
+   - Tools exposés au LLM uniquement si le provider supporte le function calling natif (OpenAI / Anthropic / Mistral / Gemini).
+   - Pour les autres providers : MCP activés **ignorés silencieusement** avec un warning visible dans les settings projet.
+   - Préfixe `<mcp_slug>__<tool_name>` côté LLM pour lever les collisions. Séparateur `__` car compatible avec la regex tool name d'OpenAI (`^[a-zA-Z0-9_-]{1,64}$`).
+7. **Exécution d'un tool call**
+   - Timeout par défaut 30 s (paramétrable par MCP, 5–60 s).
+   - Pas de retry serveur — toute erreur (timeout, 5xx, MCP down) est remontée comme `tool_result` d'erreur au LLM, qui décide.
+   - Logs structurés (`project_id`, `mcp_id`, `tool_name`, `status`, `latency_ms`). Agrégation pour `/stats`.
+
+## Découpage en 6 PRs (baby steps)
+
+Chaque PR doit être **petite** (~300–700 lignes max), compiler, passer tous les tests, et être autonome.
+La PR `n+1` peut s'appuyer sur la PR `n` mergée, mais ne doit pas être bloquée par elle pour partir en review.
+
+---
+
+### PR 1 — Domaine + use cases org (in-memory)
+
+**Branche** : `feat/mcp-domain-and-org-use-cases`
+
+Objectif : poser les briques pures (zéro dépendance externe), avec repository in-memory + tests unitaires.
+Aucun endpoint, aucune migration, aucune UI.
+
+#### Domain
+
+- [ ] `domain/value_objects/mcp_auth_type.py` — enum `McpAuthType`
+- [ ] `domain/value_objects/mcp_tool_snapshot.py` — value object `McpToolSnapshot`
+- [ ] `domain/entities/org_mcp_server.py` — entité immutable + invariants (URL HTTPS, masquage token, helpers `mask_token`)
+- [ ] `domain/entities/project_mcp_activation.py` — entité immutable
+- [ ] `domain/exceptions/mcp_exceptions.py` — toutes les exceptions listées
+- [ ] Tests unitaires entités + value objects
+
+#### Application
+
+- [ ] `application/dto/org_mcp_server_dto.py` — DTO sortie (sans token clair)
+- [ ] `application/dto/project_mcp_activation_dto.py`
+- [ ] `application/interfaces/repositories/org_mcp_server_repository.py`
+- [ ] `application/interfaces/repositories/project_mcp_activation_repository.py`
+- [ ] `application/interfaces/services/mcp_client.py` (ports `list_tools`, `call_tool`)
+- [ ] `application/interfaces/services/url_safety_validator.py`
+- [ ] Use cases org sous `application/use_cases/org_mcp/` :
+  - [ ] `declare_org_mcp_server.py` — handshake `list_tools` à la déclaration
+  - [ ] `update_org_mcp_server.py`
+  - [ ] `refresh_org_mcp_tools.py`
+  - [ ] `activate_org_mcp_server.py`
+  - [ ] `deactivate_org_mcp_server.py`
+  - [ ] `delete_org_mcp_server.py` (cascade sur activations)
+  - [ ] `list_org_mcp_servers.py`
+- [ ] Tests unitaires de chaque use case avec :
+  - `InMemoryOrgMcpServerRepository`
+  - `InMemoryProjectMcpActivationRepository`
+  - `FakeMcpClient` (renvoie un snapshot scripté)
+  - `FakeUrlSafetyValidator` (toujours OK ou raise selon le test)
+
+#### Critères d'acceptation PR 1
+
+- `pytest tests/unit/` vert
+- `ruff format` / `ruff check` / `mypy` propres
+- Aucune modification dans `infrastructure/`, `presentation/`, `client/`
+
+---
+
+### PR 2 — Infrastructure : persistence, client MCP, anti-SSRF
+
+**Branche** : `feat/mcp-infrastructure`
+**Dépend de** : PR 1 mergée.
+
+#### Migration Alembic
+
+- [ ] Table `org_mcp_servers`
+  - `id` UUID PK
+  - `organization_id` UUID FK `organizations.id` ON DELETE CASCADE
+  - `name` text NOT NULL
+  - `slug` text NOT NULL
+  - `url` text NOT NULL
+  - `auth_type` text NOT NULL (`none` / `bearer`)
+  - `encrypted_bearer_token` text NULL
+  - `token_fingerprint` text NULL
+  - `token_suffix` text NULL
+  - `is_active` boolean NOT NULL DEFAULT true
+  - `tools_snapshot` jsonb NOT NULL DEFAULT `'[]'`
+  - `tools_snapshot_at` timestamptz NOT NULL
+  - `timeout_seconds` integer NOT NULL DEFAULT 30
+  - `created_by_user_id` UUID NOT NULL
+  - `created_at`, `updated_at` timestamptz
+  - UNIQUE `(organization_id, slug)`
+- [ ] Table `project_mcp_activations`
+  - `project_id` UUID FK `projects.id` ON DELETE CASCADE
+  - `org_mcp_server_id` UUID FK `org_mcp_servers.id` ON DELETE CASCADE
+  - `is_active` boolean NOT NULL DEFAULT true
+  - `activated_at` timestamptz NOT NULL
+  - `activated_by_user_id` UUID NOT NULL
+  - PK `(project_id, org_mcp_server_id)`
+
+#### Infrastructure
+
+- [ ] `infrastructure/database/models/org_mcp_server_model.py`
+- [ ] `infrastructure/database/models/project_mcp_activation_model.py`
+- [ ] `infrastructure/database/repositories/sqlalchemy_org_mcp_server_repository.py`
+- [ ] `infrastructure/database/repositories/sqlalchemy_project_mcp_activation_repository.py`
+- [ ] `infrastructure/services/url_safety_validator_impl.py`
+  - Résolution DNS (toutes les adresses)
+  - Refus IPv4 privées, loopback, link-local, multicast, broadcast, "this network"
+  - Refus IPv6 unique-local (fc00::/7), loopback (::1), link-local (fe80::/10)
+  - Exige scheme `https://`
+- [ ] `infrastructure/services/http_mcp_client.py`
+  - Basé sur `httpx.AsyncClient`
+  - Implémente `list_tools(url, auth)` et `call_tool(url, auth, tool, args, timeout)`
+  - Re-valide l'URL via `UrlSafetyValidator` à chaque appel
+  - Mapping erreurs HTTP → exceptions domaine
+- [ ] Réutilisation du `ProviderApiKeyCryptoService` existant pour chiffrer/déchiffrer le bearer token
+
+#### Tests
+
+- [ ] Tests intégration `SQLAlchemyOrgMcpServerRepository`
+- [ ] Tests intégration `SQLAlchemyProjectMcpActivationRepository`
+- [ ] Tests unitaires `UrlSafetyValidatorImpl` (chaque famille d'IPs interdites, IPv4 + IPv6)
+- [ ] Tests unitaires `HttpMcpClient` avec serveur MCP factice (`pytest-httpx` ou équivalent)
+
+#### Critères d'acceptation PR 2
+
+- Migrations passent en up + downgrade
+- Tests d'intégration verts
+- Aucune modification dans `presentation/` ni `client/`
+
+---
+
+### PR 3 — Endpoints org + UI org
+
+**Branche** : `feat/mcp-org-endpoints-and-ui`
+**Dépend de** : PR 2 mergée.
+
+#### Présentation backend
+
+- [ ] Schemas Pydantic `presentation/api/v1/schemas/org_mcp_server.py`
+  - `OrgMcpServerCreateRequest`, `OrgMcpServerUpdateRequest`, `OrgMcpServerResponse`, `McpToolSnapshotResponse`
+- [ ] Route `presentation/api/v1/routes/org_mcp_servers.py`
+  - `POST /api/v1/organizations/{org_id}/mcp-servers` → declare
+  - `GET /api/v1/organizations/{org_id}/mcp-servers` → list
+  - `GET /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}` → detail
+  - `PATCH /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}` → update
+  - `POST /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}/refresh` → refresh tools
+  - `POST /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}/activate` → org-level activate
+  - `POST /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}/deactivate`
+  - `DELETE /api/v1/organizations/{org_id}/mcp-servers/{mcp_id}` → cascade
+- [ ] Injection DI dans `dependencies.py`
+- [ ] Tests E2E avec `TestClient` + DB de test
+
+#### Frontend
+
+- [ ] Régénérer le client Orval depuis le schéma OpenAPI mis à jour
+- [ ] `client/src/components/atoms/mcp/` — chips, badges (status, masque token)
+- [ ] `client/src/components/molecules/mcp/mcp-server-form.tsx` — formulaire déclaration / édition (URL, auth, timeout)
+- [ ] `client/src/components/molecules/mcp/mcp-tools-list.tsx` — affichage du snapshot
+- [ ] `client/src/components/organisms/organization/org-mcp-list.tsx` — CRUD complet, bouton refresh, toggle is_active
+- [ ] Intégration dans `templates/organization/...-template.tsx` (paramètres org existants)
+- [ ] Tests Vitest sur les molecules et l'organism (comportement, pas style)
+
+#### Critères d'acceptation PR 3
+
+- Parcours complet possible en local : déclarer un MCP, rafraîchir ses tools, le désactiver, le supprimer
+- Tests backend + frontend verts
+- Aucune modification du flux chat
+
+---
+
+### PR 4 — Activations projet
+
+**Branche** : `feat/mcp-project-activations`
+**Dépend de** : PR 3 mergée.
+
+#### Application
+
+- [ ] Use cases sous `application/use_cases/project_mcp/`
+  - [ ] `activate_project_mcp.py` — vérifie que le MCP est `is_active` au niveau org et appartient à la même org que le projet
+  - [ ] `deactivate_project_mcp.py`
+  - [ ] `list_project_mcp_activations.py` — retourne les activations + snapshot des tools pour chaque MCP
+- [ ] DTO + tests unitaires
+
+#### Présentation backend
+
+- [ ] Schemas `presentation/api/v1/schemas/project_mcp_activation.py`
+- [ ] Route `presentation/api/v1/routes/project_mcp_activations.py`
+  - `GET /api/v1/projects/{project_id}/mcp-activations` → liste activations + tools
+  - `POST /api/v1/projects/{project_id}/mcp-activations/{mcp_id}` → activate
+  - `DELETE /api/v1/projects/{project_id}/mcp-activations/{mcp_id}` → deactivate
+- [ ] Tests E2E
+
+#### Frontend
+
+- [ ] Régénérer Orval
+- [ ] `client/src/components/organisms/project/project-mcp-activations.tsx`
+  - Liste des MCP org disponibles (uniquement ceux `is_active=true`)
+  - Toggle activate/deactivate par MCP
+  - Snapshot des tools visible (read-only en V1)
+  - Warning visible si le provider LLM courant ne supporte pas le function calling
+- [ ] Insertion dans `templates/project/project-settings-template.tsx`
+
+#### Critères d'acceptation PR 4
+
+- Un maker peut activer/désactiver un MCP dans son projet
+- Le warning provider non-compatible s'affiche correctement
+- Tests verts
+
+---
+
+### PR 5 — Intégration dans le flux chat (tool calling)
+
+**Branche** : `feat/mcp-chat-tool-calling`
+**Dépend de** : PR 4 mergée.
+
+Cœur de la valeur utilisateur : les tools MCP deviennent effectivement appelables par le LLM.
+
+#### Domain / Application
+
+- [ ] Service domaine ou application `McpToolResolver` :
+  - Charge les activations projet
+  - Filtre celles dont `OrgMcpServer.is_active = true`
+  - Aplati les tools en `[{prefixed_name, mcp_id, original_name, description, input_schema}, ...]`
+- [ ] Adapter le use case `SendChatMessage` (ou équivalent) :
+  - Appelle `McpToolResolver` au début
+  - Si le provider LLM supporte les tools : ajoute `tools=[...]` au payload
+  - Si non : ignore les MCP (déjà signalé en UI)
+  - Boucle de tool-use : recevoir tool_call, router vers le bon MCP via `mcp_id`, appeler `McpClient.call_tool(...)`, renvoyer `tool_result` au LLM, recommencer jusqu'à réponse finale
+  - Logs structurés (`project_id`, `mcp_id`, `tool_name`, `status`, `latency_ms`)
+
+#### Infrastructure
+
+- [ ] Adapter chaque adapter LLM existant pour accepter une liste de tools standardisée et la traduire au format du provider
+- [ ] Identifier proprement les providers compatibles function calling (capability flag)
+
+#### Tests
+
+- [ ] Tests unitaires `McpToolResolver` (préfixage, filtrage org `is_active`, projet `is_active`)
+- [ ] Tests intégration de bout en bout du flux chat avec un `FakeMcpClient` qui renvoie un résultat scripté
+- [ ] Tests sur la gestion des erreurs : timeout, MCP down, tool inconnu
+
+#### Critères d'acceptation PR 5
+
+- Conversation en local avec un MCP réel (ex: serveur de test) qui répond à un tool call
+- Logs structurés présents dans les bons formats
+- Comportement gracieux en cas d'erreur
+
+---
+
+### PR 6 — Stats / observabilité
+
+**Branche** : `feat/mcp-stats`
+**Dépend de** : PR 5 mergée.
+
+- [ ] Compteurs agrégés (en mémoire ou table légère) :
+  - Nombre d'appels par `mcp_id` (succès / erreurs)
+  - Latence p50/p95
+  - Comptage par jour pour les graphes 90j
+- [ ] Endpoint `/api/v1/stats/mcp` ou extension de `/stats` existant
+- [ ] Frontend : section MCP dans la page `/stats`
+- [ ] Tests
+
+---
+
+## Pre-Push Checklist (à chaque PR)
+
+```bash
+# Backend
+cd server && pytest
+cd server && ruff format src/ tests/
+cd server && ruff check src/ tests/
+cd server && mypy src/
+
+# Frontend
+cd client && npx tsc --noEmit
+cd client && npx vitest run
+```
+
+## Points de vigilance globaux
+
+- **Sécurité SSRF** : la validation anti-SSRF doit être couverte par des tests unitaires exhaustifs (chaque famille d'IPs privées IPv4 et IPv6). La validation doit être faite **à chaque appel**, pas seulement à la déclaration (le DNS peut changer).
+- **Chiffrement du token Bearer** : réutiliser strictement le `ProviderApiKeyCryptoService` existant (même algo, même clé, même rotation). Ne jamais logger le token clair.
+- **Pas de limites V1** : surveiller la taille du payload `tools` envoyé au LLM. Un compteur dans `/stats` permettra de réintroduire une limite si on observe des dérives.
+- **Préfixage tools** : séparateur `__` (deux underscores), compatible regex OpenAI. Ne pas utiliser `.` ni `:`.
+- **Pas d'attribution Claude** dans les commits / PRs.
+- **PR title & description en français**, format `Problème / Solution / Implémentation / Recette`.
+
+## Quand ce plan reprend la main
+
+Quand le refactoring `refactor/agent-configurations` est mergé et que `PLAN_IN_PROGRESS.md` est libéré, copier la PR 1 ci-dessus dans `PLAN_IN_PROGRESS.md` et démarrer.

--- a/server/src/raggae/application/dto/org_mcp_server_dto.py
+++ b/server/src/raggae/application/dto/org_mcp_server_dto.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class McpToolSnapshotDTO:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class OrgMcpServerDTO:
+    id: UUID
+    organization_id: UUID
+    name: str
+    slug: str
+    url: str
+    auth_type: str
+    masked_token: str | None
+    is_active: bool
+    tools_snapshot_at: datetime
+    timeout_seconds: int
+    created_at: datetime
+    updated_at: datetime
+    tools_snapshot: list[McpToolSnapshotDTO] = field(default_factory=list)

--- a/server/src/raggae/application/dto/project_mcp_activation_dto.py
+++ b/server/src/raggae/application/dto/project_mcp_activation_dto.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class ProjectMcpActivationDTO:
+    project_id: UUID
+    org_mcp_server_id: UUID
+    is_active: bool
+    activated_at: datetime

--- a/server/src/raggae/application/interfaces/repositories/org_mcp_server_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/org_mcp_server_repository.py
@@ -1,0 +1,20 @@
+from typing import Protocol
+from uuid import UUID
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+
+
+class OrgMcpServerRepository(Protocol):
+    """Interface for organization MCP server persistence."""
+
+    async def save(self, server: OrgMcpServer) -> None:
+        """Insert or update an MCP server by id."""
+        ...
+
+    async def find_by_id(self, server_id: UUID, organization_id: UUID) -> OrgMcpServer | None: ...
+
+    async def find_by_slug(self, organization_id: UUID, slug: str) -> OrgMcpServer | None: ...
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgMcpServer]: ...
+
+    async def delete(self, server_id: UUID, organization_id: UUID) -> None: ...

--- a/server/src/raggae/application/interfaces/repositories/project_mcp_activation_repository.py
+++ b/server/src/raggae/application/interfaces/repositories/project_mcp_activation_repository.py
@@ -1,0 +1,24 @@
+from typing import Protocol
+from uuid import UUID
+
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+
+
+class ProjectMcpActivationRepository(Protocol):
+    """Interface for project ↔ MCP server activation persistence."""
+
+    async def save(self, activation: ProjectMcpActivation) -> None:
+        """Insert or update an activation by (project_id, org_mcp_server_id)."""
+        ...
+
+    async def find(self, project_id: UUID, org_mcp_server_id: UUID) -> ProjectMcpActivation | None: ...
+
+    async def list_by_project_id(self, project_id: UUID) -> list[ProjectMcpActivation]: ...
+
+    async def list_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> list[ProjectMcpActivation]: ...
+
+    async def delete(self, project_id: UUID, org_mcp_server_id: UUID) -> None: ...
+
+    async def delete_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> None:
+        """Delete all activations for a given MCP server (cascade on server removal)."""
+        ...

--- a/server/src/raggae/application/interfaces/services/mcp_bearer_token_crypto_service.py
+++ b/server/src/raggae/application/interfaces/services/mcp_bearer_token_crypto_service.py
@@ -1,0 +1,15 @@
+from typing import Protocol
+
+
+class McpBearerTokenCryptoService(Protocol):
+    """Interface for MCP bearer token encryption/decryption.
+
+    Mirrors `ProviderApiKeyCryptoService` semantically; kept as a separate port to avoid
+    coupling two unrelated secret domains. Implementations may delegate to the same backend.
+    """
+
+    def encrypt(self, raw_token: str) -> str: ...
+
+    def decrypt(self, encrypted_token: str) -> str: ...
+
+    def fingerprint(self, raw_token: str) -> str: ...

--- a/server/src/raggae/application/interfaces/services/mcp_client.py
+++ b/server/src/raggae/application/interfaces/services/mcp_client.py
@@ -1,0 +1,37 @@
+from typing import Any, Protocol
+
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+class McpClient(Protocol):
+    """Outbound MCP transport client (HTTP/SSE).
+
+    Implementations must re-validate URLs against an `UrlSafetyValidator` before every call.
+    """
+
+    async def list_tools(
+        self,
+        url: str,
+        bearer_token: str | None = None,
+    ) -> list[McpToolSnapshot]:
+        """Call `tools/list` on the remote MCP server and return the snapshot.
+
+        Raises `McpHandshakeError` if the call fails.
+        Raises `McpUrlForbiddenError` if the URL is rejected by the safety validator.
+        """
+        ...
+
+    async def call_tool(
+        self,
+        url: str,
+        tool: str,
+        arguments: dict[str, Any],
+        timeout_seconds: int,
+        bearer_token: str | None = None,
+    ) -> dict[str, Any]:
+        """Invoke one tool on the remote MCP server and return its result payload.
+
+        Raises `McpCallTimeoutError` on timeout, `McpToolNotFoundError` if tool is unknown,
+        and `McpUrlForbiddenError` if the URL is rejected by the safety validator.
+        """
+        ...

--- a/server/src/raggae/application/interfaces/services/url_safety_validator.py
+++ b/server/src/raggae/application/interfaces/services/url_safety_validator.py
@@ -1,0 +1,13 @@
+from typing import Protocol
+
+
+class UrlSafetyValidator(Protocol):
+    """Validates an outbound URL against SSRF and scheme rules.
+
+    Implementations must enforce HTTPS, resolve the host via DNS, and refuse loopback,
+    link-local, private, or otherwise reserved IP ranges.
+    """
+
+    async def validate(self, url: str) -> None:
+        """Raises `McpUrlForbiddenError` when the URL is unsafe."""
+        ...

--- a/server/src/raggae/application/use_cases/org_mcp/_mapping.py
+++ b/server/src/raggae/application/use_cases/org_mcp/_mapping.py
@@ -1,0 +1,29 @@
+"""Internal mapping helpers shared across org_mcp use cases."""
+
+from raggae.application.dto.org_mcp_server_dto import McpToolSnapshotDTO, OrgMcpServerDTO
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+
+
+def to_dto(server: OrgMcpServer) -> OrgMcpServerDTO:
+    return OrgMcpServerDTO(
+        id=server.id,
+        organization_id=server.organization_id,
+        name=server.name,
+        slug=server.slug,
+        url=server.url,
+        auth_type=server.auth_type.value,
+        masked_token=server.masked_token,
+        is_active=server.is_active,
+        tools_snapshot=[
+            McpToolSnapshotDTO(
+                name=t.name,
+                description=t.description,
+                input_schema=t.input_schema,
+            )
+            for t in server.tools_snapshot
+        ],
+        tools_snapshot_at=server.tools_snapshot_at,
+        timeout_seconds=server.timeout_seconds,
+        created_at=server.created_at,
+        updated_at=server.updated_at,
+    )

--- a/server/src/raggae/application/use_cases/org_mcp/activate_org_mcp_server.py
+++ b/server/src/raggae/application/use_cases/org_mcp/activate_org_mcp_server.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class ActivateOrgMcpServer:
+    """Use case: activate an MCP server at the organization level."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, server_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )
+        server = await self._server_repository.find_by_id(server_id, organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {server_id} not found")
+        await self._server_repository.save(server.activate())

--- a/server/src/raggae/application/use_cases/org_mcp/deactivate_org_mcp_server.py
+++ b/server/src/raggae/application/use_cases/org_mcp/deactivate_org_mcp_server.py
@@ -1,0 +1,40 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class DeactivateOrgMcpServer:
+    """Use case: deactivate an MCP server at the organization level."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, server_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )
+        server = await self._server_repository.find_by_id(server_id, organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {server_id} not found")
+        await self._server_repository.save(server.deactivate())

--- a/server/src/raggae/application/use_cases/org_mcp/declare_org_mcp_server.py
+++ b/server/src/raggae/application/use_cases/org_mcp/declare_org_mcp_server.py
@@ -1,0 +1,123 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.services.mcp_bearer_token_crypto_service import (
+    McpBearerTokenCryptoService,
+)
+from raggae.application.interfaces.services.mcp_client import McpClient
+from raggae.application.interfaces.services.url_safety_validator import UrlSafetyValidator
+from raggae.application.use_cases.org_mcp._mapping import to_dto
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_slug import slugify
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+MIN_TIMEOUT_SECONDS = 5
+MAX_TIMEOUT_SECONDS = 60
+
+
+class DeclareOrgMcpServer:
+    """Use case: declare a new MCP server at organization level."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        url_safety_validator: UrlSafetyValidator,
+        mcp_client: McpClient,
+        bearer_token_crypto_service: McpBearerTokenCryptoService,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+        self._url_safety_validator = url_safety_validator
+        self._mcp_client = mcp_client
+        self._crypto = bearer_token_crypto_service
+
+    async def execute(
+        self,
+        organization_id: UUID,
+        user_id: UUID,
+        name: str,
+        url: str,
+        auth_type: str,
+        bearer_token: str | None,
+        timeout_seconds: int,
+    ) -> OrgMcpServerDTO:
+        await self._ensure_can_manage(organization_id, user_id)
+        resolved_auth = McpAuthType(auth_type)
+        self._validate_inputs(resolved_auth, bearer_token, timeout_seconds)
+        await self._url_safety_validator.validate(url)
+
+        slug = await self._allocate_slug(organization_id, name)
+        tools = await self._mcp_client.list_tools(url=url, bearer_token=bearer_token)
+        now = datetime.now(UTC)
+
+        if resolved_auth == McpAuthType.BEARER:
+            assert bearer_token is not None  # noqa: S101 — guarded by _validate_inputs
+            encrypted = self._crypto.encrypt(bearer_token)
+            fingerprint = self._crypto.fingerprint(bearer_token)
+            suffix = bearer_token[-4:]
+        else:
+            encrypted = None
+            fingerprint = None
+            suffix = None
+
+        server = OrgMcpServer(
+            id=uuid4(),
+            organization_id=organization_id,
+            name=name,
+            slug=slug,
+            url=url,
+            auth_type=resolved_auth,
+            encrypted_bearer_token=encrypted,
+            token_fingerprint=fingerprint,
+            token_suffix=suffix,
+            is_active=True,
+            tools_snapshot=list(tools),
+            tools_snapshot_at=now,
+            timeout_seconds=timeout_seconds,
+            created_at=now,
+            updated_at=now,
+            created_by_user_id=user_id,
+        )
+        await self._server_repository.save(server)
+        return to_dto(server)
+
+    async def _ensure_can_manage(self, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )
+
+    @staticmethod
+    def _validate_inputs(auth_type: McpAuthType, bearer_token: str | None, timeout_seconds: int) -> None:
+        if not MIN_TIMEOUT_SECONDS <= timeout_seconds <= MAX_TIMEOUT_SECONDS:
+            raise ValueError(
+                f"timeout_seconds must be between {MIN_TIMEOUT_SECONDS} and {MAX_TIMEOUT_SECONDS}"
+            )
+        if auth_type == McpAuthType.BEARER and not bearer_token:
+            raise ValueError("bearer_token is required when auth_type is 'bearer'")
+
+    async def _allocate_slug(self, organization_id: UUID, name: str) -> str:
+        base = slugify(name)
+        candidate = base
+        suffix_index = 2
+        while await self._server_repository.find_by_slug(organization_id, candidate) is not None:
+            candidate = f"{base}-{suffix_index}"
+            suffix_index += 1
+        return candidate

--- a/server/src/raggae/application/use_cases/org_mcp/delete_org_mcp_server.py
+++ b/server/src/raggae/application/use_cases/org_mcp/delete_org_mcp_server.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_mcp_activation_repository import (
+    ProjectMcpActivationRepository,
+)
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class DeleteOrgMcpServer:
+    """Use case: delete an MCP server and cascade its project activations."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        project_mcp_activation_repository: ProjectMcpActivationRepository,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+        self._activation_repository = project_mcp_activation_repository
+
+    async def execute(self, server_id: UUID, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )
+        server = await self._server_repository.find_by_id(server_id, organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {server_id} not found")
+        await self._activation_repository.delete_by_org_mcp_server_id(server_id)
+        await self._server_repository.delete(server_id, organization_id)

--- a/server/src/raggae/application/use_cases/org_mcp/list_org_mcp_servers.py
+++ b/server/src/raggae/application/use_cases/org_mcp/list_org_mcp_servers.py
@@ -1,0 +1,35 @@
+from uuid import UUID
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.use_cases.org_mcp._mapping import to_dto
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+
+
+class ListOrgMcpServers:
+    """Use case: list all MCP servers declared by an organization."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, organization_id: UUID, user_id: UUID) -> list[OrgMcpServerDTO]:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} is not a member of organization {organization_id}"
+            )
+        servers = await self._server_repository.list_by_org_id(organization_id)
+        return [to_dto(s) for s in servers]

--- a/server/src/raggae/application/use_cases/org_mcp/refresh_org_mcp_tools.py
+++ b/server/src/raggae/application/use_cases/org_mcp/refresh_org_mcp_tools.py
@@ -1,0 +1,65 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.services.mcp_bearer_token_crypto_service import (
+    McpBearerTokenCryptoService,
+)
+from raggae.application.interfaces.services.mcp_client import McpClient
+from raggae.application.use_cases.org_mcp._mapping import to_dto
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class RefreshOrgMcpTools:
+    """Use case: refresh the tools snapshot of an MCP server by re-calling `tools/list`."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        mcp_client: McpClient,
+        bearer_token_crypto_service: McpBearerTokenCryptoService,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+        self._mcp_client = mcp_client
+        self._crypto = bearer_token_crypto_service
+
+    async def execute(
+        self,
+        server_id: UUID,
+        organization_id: UUID,
+        user_id: UUID,
+    ) -> OrgMcpServerDTO:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )
+        server = await self._server_repository.find_by_id(server_id, organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {server_id} not found")
+
+        bearer_token = None
+        if server.auth_type == McpAuthType.BEARER and server.encrypted_bearer_token is not None:
+            bearer_token = self._crypto.decrypt(server.encrypted_bearer_token)
+
+        tools = await self._mcp_client.list_tools(url=server.url, bearer_token=bearer_token)
+        refreshed = server.with_refreshed_tools(list(tools), datetime.now(UTC))
+        await self._server_repository.save(refreshed)
+        return to_dto(refreshed)

--- a/server/src/raggae/application/use_cases/org_mcp/update_org_mcp_server.py
+++ b/server/src/raggae/application/use_cases/org_mcp/update_org_mcp_server.py
@@ -1,0 +1,113 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.services.mcp_bearer_token_crypto_service import (
+    McpBearerTokenCryptoService,
+)
+from raggae.application.interfaces.services.url_safety_validator import UrlSafetyValidator
+from raggae.application.use_cases.org_mcp._mapping import to_dto
+from raggae.application.use_cases.org_mcp.declare_org_mcp_server import (
+    MAX_TIMEOUT_SECONDS,
+    MIN_TIMEOUT_SECONDS,
+)
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+
+class UpdateOrgMcpServer:
+    """Use case: update editable settings (name/url/timeout/auth) of an MCP server."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        organization_member_repository: OrganizationMemberRepository,
+        url_safety_validator: UrlSafetyValidator,
+        bearer_token_crypto_service: McpBearerTokenCryptoService,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._member_repository = organization_member_repository
+        self._url_safety_validator = url_safety_validator
+        self._crypto = bearer_token_crypto_service
+
+    async def execute(
+        self,
+        server_id: UUID,
+        organization_id: UUID,
+        user_id: UUID,
+        name: str,
+        url: str,
+        timeout_seconds: int,
+        auth_type: str | None,
+        bearer_token: str | None,
+    ) -> OrgMcpServerDTO:
+        await self._ensure_can_manage(organization_id, user_id)
+        if not MIN_TIMEOUT_SECONDS <= timeout_seconds <= MAX_TIMEOUT_SECONDS:
+            raise ValueError(
+                f"timeout_seconds must be between {MIN_TIMEOUT_SECONDS} and {MAX_TIMEOUT_SECONDS}"
+            )
+
+        server = await self._server_repository.find_by_id(server_id, organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {server_id} not found")
+
+        if url != server.url:
+            await self._url_safety_validator.validate(url)
+
+        now = datetime.now(UTC)
+        updated = server.with_updated_settings(
+            name=name,
+            url=url,
+            timeout_seconds=timeout_seconds,
+            updated_at=now,
+        )
+        updated = self._apply_auth_change(updated, auth_type, bearer_token, now)
+
+        await self._server_repository.save(updated)
+        return to_dto(updated)
+
+    def _apply_auth_change(
+        self,
+        server: OrgMcpServer,
+        auth_type: str | None,
+        bearer_token: str | None,
+        now: datetime,
+    ) -> OrgMcpServer:
+        if auth_type is None:
+            return server
+        resolved = McpAuthType(auth_type)
+        if resolved == McpAuthType.NONE:
+            return server.without_auth(now)
+        if not bearer_token:
+            raise ValueError("bearer_token is required when auth_type is 'bearer'")
+        encrypted = self._crypto.encrypt(bearer_token)
+        fingerprint = self._crypto.fingerprint(bearer_token)
+        suffix = bearer_token[-4:]
+        return server.with_bearer_token(
+            encrypted_token=encrypted,
+            fingerprint=fingerprint,
+            suffix=suffix,
+            updated_at=now,
+        )
+
+    async def _ensure_can_manage(self, organization_id: UUID, user_id: UUID) -> None:
+        member = await self._member_repository.find_by_organization_and_user(
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if member is None or member.role not in {
+            OrganizationMemberRole.OWNER,
+            OrganizationMemberRole.MAKER,
+        }:
+            raise OrganizationAccessDeniedError(
+                f"User {user_id} cannot manage MCP servers for organization {organization_id}"
+            )

--- a/server/src/raggae/domain/entities/org_mcp_server.py
+++ b/server/src/raggae/domain/entities/org_mcp_server.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from uuid import UUID
+
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+@dataclass(frozen=True)
+class OrgMcpServer:
+    """Organization-level MCP server declaration. Immutable."""
+
+    id: UUID
+    organization_id: UUID
+    name: str
+    slug: str
+    url: str
+    auth_type: McpAuthType
+    encrypted_bearer_token: str | None
+    token_fingerprint: str | None
+    token_suffix: str | None
+    is_active: bool
+    tools_snapshot_at: datetime
+    timeout_seconds: int
+    created_at: datetime
+    updated_at: datetime
+    created_by_user_id: UUID
+    tools_snapshot: list[McpToolSnapshot] = field(default_factory=list)
+
+    @property
+    def masked_token(self) -> str | None:
+        if self.auth_type != McpAuthType.BEARER or self.token_suffix is None:
+            return None
+        return f"...{self.token_suffix}"
+
+    def activate(self) -> "OrgMcpServer":
+        return replace(self, is_active=True)
+
+    def deactivate(self) -> "OrgMcpServer":
+        return replace(self, is_active=False)
+
+    def with_refreshed_tools(self, tools: list[McpToolSnapshot], refreshed_at: datetime) -> "OrgMcpServer":
+        return replace(self, tools_snapshot=list(tools), tools_snapshot_at=refreshed_at)
+
+    def with_updated_settings(
+        self,
+        name: str,
+        url: str,
+        timeout_seconds: int,
+        updated_at: datetime,
+    ) -> "OrgMcpServer":
+        return replace(
+            self,
+            name=name,
+            url=url,
+            timeout_seconds=timeout_seconds,
+            updated_at=updated_at,
+        )
+
+    def with_bearer_token(
+        self,
+        encrypted_token: str,
+        fingerprint: str,
+        suffix: str,
+        updated_at: datetime,
+    ) -> "OrgMcpServer":
+        return replace(
+            self,
+            auth_type=McpAuthType.BEARER,
+            encrypted_bearer_token=encrypted_token,
+            token_fingerprint=fingerprint,
+            token_suffix=suffix,
+            updated_at=updated_at,
+        )
+
+    def without_auth(self, updated_at: datetime) -> "OrgMcpServer":
+        return replace(
+            self,
+            auth_type=McpAuthType.NONE,
+            encrypted_bearer_token=None,
+            token_fingerprint=None,
+            token_suffix=None,
+            updated_at=updated_at,
+        )

--- a/server/src/raggae/domain/entities/project_mcp_activation.py
+++ b/server/src/raggae/domain/entities/project_mcp_activation.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, replace
+from datetime import datetime
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class ProjectMcpActivation:
+    """Activation of one organization MCP server by one project. Immutable."""
+
+    project_id: UUID
+    org_mcp_server_id: UUID
+    is_active: bool
+    activated_at: datetime
+    activated_by_user_id: UUID
+
+    def activate(self) -> "ProjectMcpActivation":
+        return replace(self, is_active=True)
+
+    def deactivate(self) -> "ProjectMcpActivation":
+        return replace(self, is_active=False)

--- a/server/src/raggae/domain/exceptions/mcp_exceptions.py
+++ b/server/src/raggae/domain/exceptions/mcp_exceptions.py
@@ -1,0 +1,26 @@
+class McpServerNotFoundError(Exception):
+    """Raised when an MCP server cannot be found."""
+
+
+class McpDuplicateSlugError(ValueError):
+    """Raised when an MCP server slug is already taken in the organization."""
+
+
+class McpAccessDeniedError(PermissionError):
+    """Raised when a user cannot manage MCP servers for an organization."""
+
+
+class McpUrlForbiddenError(ValueError):
+    """Raised when an MCP server URL is rejected (non-HTTPS, private IP, denylisted host)."""
+
+
+class McpHandshakeError(Exception):
+    """Raised when the initial `tools/list` handshake with an MCP server fails."""
+
+
+class McpToolNotFoundError(Exception):
+    """Raised when a tool requested for invocation is not present in the snapshot."""
+
+
+class McpCallTimeoutError(Exception):
+    """Raised when an MCP tool call exceeds its timeout."""

--- a/server/src/raggae/domain/value_objects/mcp_auth_type.py
+++ b/server/src/raggae/domain/value_objects/mcp_auth_type.py
@@ -1,0 +1,8 @@
+from enum import StrEnum
+
+
+class McpAuthType(StrEnum):
+    """Supported authentication types for an MCP server."""
+
+    NONE = "none"
+    BEARER = "bearer"

--- a/server/src/raggae/domain/value_objects/mcp_slug.py
+++ b/server/src/raggae/domain/value_objects/mcp_slug.py
@@ -1,0 +1,15 @@
+import re
+
+_NON_KEBAB = re.compile(r"[^a-z0-9]+")
+_MULTI_DASH = re.compile(r"-+")
+
+
+def slugify(name: str) -> str:
+    """Build a kebab-case ASCII slug from a human-friendly name.
+
+    Falls back to `'mcp'` when no kebab characters remain.
+    """
+    lowered = name.lower()
+    replaced = _NON_KEBAB.sub("-", lowered)
+    collapsed = _MULTI_DASH.sub("-", replaced).strip("-")
+    return collapsed or "mcp"

--- a/server/src/raggae/domain/value_objects/mcp_tool_snapshot.py
+++ b/server/src/raggae/domain/value_objects/mcp_tool_snapshot.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class McpToolSnapshot:
+    """Snapshot of one tool exposed by an MCP server, as returned by `tools/list`."""
+
+    name: str
+    description: str
+    input_schema: dict[str, Any] = field(default_factory=dict)

--- a/server/tests/unit/application/use_cases/org_mcp/_helpers.py
+++ b/server/tests/unit/application/use_cases/org_mcp/_helpers.py
@@ -1,0 +1,44 @@
+"""Shared test helpers for org_mcp use cases."""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+
+
+def make_member(role: str) -> object:
+    """Build a minimal duck-typed member object with the given role."""
+    return type("Member", (), {"role": role})()
+
+
+def make_server(
+    *,
+    server_id: UUID | None = None,
+    organization_id: UUID | None = None,
+    name: str = "Notion",
+    slug: str = "notion",
+    url: str = "https://mcp.example.com",
+    auth_type: McpAuthType = McpAuthType.NONE,
+    is_active: bool = True,
+    timeout_seconds: int = 30,
+) -> OrgMcpServer:
+    now = datetime.now(UTC)
+    return OrgMcpServer(
+        id=server_id or uuid4(),
+        organization_id=organization_id or uuid4(),
+        name=name,
+        slug=slug,
+        url=url,
+        auth_type=auth_type,
+        encrypted_bearer_token="enc" if auth_type == McpAuthType.BEARER else None,
+        token_fingerprint="fp" if auth_type == McpAuthType.BEARER else None,
+        token_suffix="abcd" if auth_type == McpAuthType.BEARER else None,
+        is_active=is_active,
+        tools_snapshot=[],
+        tools_snapshot_at=now,
+        timeout_seconds=timeout_seconds,
+        created_at=now,
+        updated_at=now,
+        created_by_user_id=uuid4(),
+    )

--- a/server/tests/unit/application/use_cases/org_mcp/test_activate_deactivate_org_mcp_server.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_activate_deactivate_org_mcp_server.py
@@ -1,0 +1,108 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.activate_org_mcp_server import ActivateOrgMcpServer
+from raggae.application.use_cases.org_mcp.deactivate_org_mcp_server import DeactivateOrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_deps(
+    *,
+    member_role: OrganizationMemberRole | None,
+    existing_server: object | None,
+) -> tuple[AsyncMock, AsyncMock]:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=existing_server)
+    server_repo.save = AsyncMock()
+    return server_repo, member_repo
+
+
+class TestActivateOrgMcpServer:
+    async def test_activate_sets_is_active_true_and_persists(self) -> None:
+        # Given
+        existing = make_server(is_active=False)
+        server_repo, member_repo = _build_deps(
+            member_role=OrganizationMemberRole.OWNER, existing_server=existing
+        )
+        use_case = ActivateOrgMcpServer(
+            org_mcp_server_repository=server_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then
+        server_repo.save.assert_awaited_once()
+        saved = server_repo.save.await_args.args[0]
+        assert saved.is_active is True
+
+    async def test_activate_not_found_raises(self) -> None:
+        # Given
+        server_repo, member_repo = _build_deps(member_role=OrganizationMemberRole.OWNER, existing_server=None)
+        use_case = ActivateOrgMcpServer(
+            org_mcp_server_repository=server_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(server_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_activate_access_denied_for_user_role(self) -> None:
+        # Given
+        existing = make_server()
+        server_repo, member_repo = _build_deps(
+            member_role=OrganizationMemberRole.USER, existing_server=existing
+        )
+        use_case = ActivateOrgMcpServer(
+            org_mcp_server_repository=server_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+            )
+
+
+class TestDeactivateOrgMcpServer:
+    async def test_deactivate_sets_is_active_false_and_persists(self) -> None:
+        # Given
+        existing = make_server(is_active=True)
+        server_repo, member_repo = _build_deps(
+            member_role=OrganizationMemberRole.MAKER, existing_server=existing
+        )
+        use_case = DeactivateOrgMcpServer(
+            org_mcp_server_repository=server_repo,
+            organization_member_repository=member_repo,
+        )
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then
+        server_repo.save.assert_awaited_once()
+        saved = server_repo.save.await_args.args[0]
+        assert saved.is_active is False

--- a/server/tests/unit/application/use_cases/org_mcp/test_declare_org_mcp_server.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_declare_org_mcp_server.py
@@ -1,0 +1,303 @@
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.declare_org_mcp_server import DeclareOrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpHandshakeError,
+    McpUrlForbiddenError,
+)
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_use_case(
+    *,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.OWNER,
+    existing_servers: list[object] | None = None,
+    existing_by_slug: dict[str, object] | None = None,
+    handshake_tools: list[McpToolSnapshot] | None = None,
+    handshake_raises: Exception | None = None,
+    url_validator_raises: Exception | None = None,
+) -> tuple[DeclareOrgMcpServer, dict[str, object]]:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.list_by_org_id = AsyncMock(return_value=existing_servers or [])
+
+    async def _find_by_slug(_org_id: object, slug: str) -> object | None:
+        return (existing_by_slug or {}).get(slug)
+
+    server_repo.find_by_slug = AsyncMock(side_effect=_find_by_slug)
+    server_repo.save = AsyncMock()
+    url_validator = AsyncMock()
+    if url_validator_raises is not None:
+        url_validator.validate = AsyncMock(side_effect=url_validator_raises)
+    else:
+        url_validator.validate = AsyncMock(return_value=None)
+    mcp_client = AsyncMock()
+    if handshake_raises is not None:
+        mcp_client.list_tools = AsyncMock(side_effect=handshake_raises)
+    else:
+        mcp_client.list_tools = AsyncMock(return_value=handshake_tools or [])
+    crypto = Mock()
+    crypto.encrypt.return_value = "encrypted-value"
+    crypto.fingerprint.return_value = "fp123"
+
+    use_case = DeclareOrgMcpServer(
+        org_mcp_server_repository=server_repo,
+        organization_member_repository=member_repo,
+        url_safety_validator=url_validator,
+        mcp_client=mcp_client,
+        bearer_token_crypto_service=crypto,
+    )
+    deps: dict[str, object] = {
+        "member_repo": member_repo,
+        "server_repo": server_repo,
+        "url_validator": url_validator,
+        "mcp_client": mcp_client,
+        "crypto": crypto,
+    }
+    return use_case, deps
+
+
+class TestDeclareOrgMcpServer:
+    async def test_declare_success_as_owner_with_no_auth(self) -> None:
+        # Given
+        tools = [McpToolSnapshot(name="search", description="Search", input_schema={})]
+        use_case, deps = _build_use_case(handshake_tools=tools)
+
+        # When
+        result = await use_case.execute(
+            organization_id=uuid4(),
+            user_id=uuid4(),
+            name="Notion",
+            url="https://mcp.example.com",
+            auth_type="none",
+            bearer_token=None,
+            timeout_seconds=30,
+        )
+
+        # Then
+        assert result.name == "Notion"
+        assert result.slug == "notion"
+        assert result.url == "https://mcp.example.com"
+        assert result.auth_type == "none"
+        assert result.masked_token is None
+        assert result.is_active is True
+        assert len(result.tools_snapshot) == 1
+        assert result.tools_snapshot[0].name == "search"
+        deps["server_repo"].save.assert_awaited_once()  # type: ignore[attr-defined]
+        deps["url_validator"].validate.assert_awaited_once()  # type: ignore[attr-defined]
+
+    async def test_declare_success_as_maker_with_bearer(self) -> None:
+        # Given
+        use_case, deps = _build_use_case(member_role=OrganizationMemberRole.MAKER)
+
+        # When
+        result = await use_case.execute(
+            organization_id=uuid4(),
+            user_id=uuid4(),
+            name="GitHub",
+            url="https://mcp.github.com",
+            auth_type="bearer",
+            bearer_token="gh-token-wxyz",
+            timeout_seconds=15,
+        )
+
+        # Then
+        assert result.auth_type == "bearer"
+        assert result.masked_token == "...wxyz"
+        deps["crypto"].encrypt.assert_called_once_with("gh-token-wxyz")  # type: ignore[attr-defined]
+        deps["crypto"].fingerprint.assert_called_once_with("gh-token-wxyz")  # type: ignore[attr-defined]
+
+    async def test_declare_access_denied_for_user_role(self) -> None:
+        # Given
+        use_case, _ = _build_use_case(member_role=OrganizationMemberRole.USER)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+
+    async def test_declare_access_denied_for_non_member(self) -> None:
+        # Given
+        use_case, _ = _build_use_case(member_role=None)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+
+    async def test_declare_rejected_url_raises(self) -> None:
+        # Given
+        use_case, deps = _build_use_case(url_validator_raises=McpUrlForbiddenError("blocked"))
+
+        # When / Then
+        with pytest.raises(McpUrlForbiddenError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Bad",
+                url="http://localhost:8080",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+        deps["server_repo"].save.assert_not_awaited()  # type: ignore[attr-defined]
+        deps["mcp_client"].list_tools.assert_not_awaited()  # type: ignore[attr-defined]
+
+    async def test_declare_handshake_error_propagates(self) -> None:
+        # Given
+        use_case, deps = _build_use_case(handshake_raises=McpHandshakeError("502"))
+
+        # When / Then
+        with pytest.raises(McpHandshakeError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+        deps["server_repo"].save.assert_not_awaited()  # type: ignore[attr-defined]
+
+    async def test_declare_rejects_invalid_timeout(self) -> None:
+        # Given
+        use_case, _ = _build_use_case()
+
+        # When / Then
+        with pytest.raises(ValueError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=4,
+            )
+        with pytest.raises(ValueError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="none",
+                bearer_token=None,
+                timeout_seconds=120,
+            )
+
+    async def test_declare_rejects_bearer_without_token(self) -> None:
+        # Given
+        use_case, _ = _build_use_case()
+
+        # When / Then
+        with pytest.raises(ValueError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="Notion",
+                url="https://mcp.example.com",
+                auth_type="bearer",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+
+    async def test_declare_appends_numeric_suffix_on_slug_collision(self) -> None:
+        # Given
+        org_id = uuid4()
+        existing_a = make_server(organization_id=org_id, name="Notion", slug="notion")
+        existing_b = make_server(organization_id=org_id, name="Notion v2", slug="notion-2")
+        use_case, _ = _build_use_case(existing_by_slug={"notion": existing_a, "notion-2": existing_b})
+
+        # When
+        result = await use_case.execute(
+            organization_id=org_id,
+            user_id=uuid4(),
+            name="Notion",
+            url="https://mcp.example.com",
+            auth_type="none",
+            bearer_token=None,
+            timeout_seconds=30,
+        )
+
+        # Then
+        assert result.slug == "notion-3"
+
+    async def test_declare_passes_bearer_token_to_handshake(self) -> None:
+        # Given
+        use_case, deps = _build_use_case()
+
+        # When
+        await use_case.execute(
+            organization_id=uuid4(),
+            user_id=uuid4(),
+            name="GitHub",
+            url="https://mcp.github.com",
+            auth_type="bearer",
+            bearer_token="gh-token-1234",
+            timeout_seconds=30,
+        )
+
+        # Then
+        deps["mcp_client"].list_tools.assert_awaited_once_with(  # type: ignore[attr-defined]
+            url="https://mcp.github.com", bearer_token="gh-token-1234"
+        )
+
+    async def test_declare_invalid_auth_type_raises(self) -> None:
+        # Given
+        use_case, _ = _build_use_case()
+
+        # When / Then
+        with pytest.raises(ValueError):
+            await use_case.execute(
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="X",
+                url="https://x",
+                auth_type="oauth",
+                bearer_token=None,
+                timeout_seconds=30,
+            )
+
+    async def test_declare_default_auth_type_resolved_to_enum(self) -> None:
+        # Given
+        use_case, _ = _build_use_case()
+
+        # When
+        result = await use_case.execute(
+            organization_id=uuid4(),
+            user_id=uuid4(),
+            name="X",
+            url="https://x",
+            auth_type=McpAuthType.NONE.value,
+            bearer_token=None,
+            timeout_seconds=30,
+        )
+
+        # Then
+        assert result.auth_type == "none"

--- a/server/tests/unit/application/use_cases/org_mcp/test_delete_org_mcp_server.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_delete_org_mcp_server.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.delete_org_mcp_server import DeleteOrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_use_case(
+    *,
+    member_role: OrganizationMemberRole | None,
+    existing_server: object | None,
+) -> tuple[DeleteOrgMcpServer, dict[str, AsyncMock]]:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=existing_server)
+    server_repo.delete = AsyncMock()
+    activation_repo = AsyncMock()
+    activation_repo.delete_by_org_mcp_server_id = AsyncMock()
+    use_case = DeleteOrgMcpServer(
+        org_mcp_server_repository=server_repo,
+        organization_member_repository=member_repo,
+        project_mcp_activation_repository=activation_repo,
+    )
+    return use_case, {
+        "server_repo": server_repo,
+        "activation_repo": activation_repo,
+    }
+
+
+class TestDeleteOrgMcpServer:
+    async def test_delete_cascades_activations_then_server(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, deps = _build_use_case(member_role=OrganizationMemberRole.OWNER, existing_server=existing)
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then — activations supprimées AVANT le serveur
+        deps["activation_repo"].delete_by_org_mcp_server_id.assert_awaited_once_with(existing.id)
+        deps["server_repo"].delete.assert_awaited_once_with(existing.id, existing.organization_id)
+
+    async def test_delete_not_found_raises(self) -> None:
+        # Given
+        use_case, deps = _build_use_case(member_role=OrganizationMemberRole.OWNER, existing_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(server_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+        deps["activation_repo"].delete_by_org_mcp_server_id.assert_not_awaited()
+        deps["server_repo"].delete.assert_not_awaited()
+
+    async def test_delete_access_denied_for_user_role(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, _ = _build_use_case(member_role=OrganizationMemberRole.USER, existing_server=existing)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+            )

--- a/server/tests/unit/application/use_cases/org_mcp/test_list_org_mcp_servers.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_list_org_mcp_servers.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.list_org_mcp_servers import ListOrgMcpServers
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_use_case(
+    *,
+    member_role: OrganizationMemberRole | None,
+    servers: list[object] | None = None,
+) -> ListOrgMcpServers:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.list_by_org_id = AsyncMock(return_value=servers or [])
+    return ListOrgMcpServers(
+        org_mcp_server_repository=server_repo,
+        organization_member_repository=member_repo,
+    )
+
+
+class TestListOrgMcpServers:
+    async def test_list_succeeds_for_any_member(self) -> None:
+        # Given
+        org_id = uuid4()
+        servers = [make_server(organization_id=org_id, name="A", slug="a")]
+        use_case = _build_use_case(member_role=OrganizationMemberRole.USER, servers=servers)
+
+        # When
+        result = await use_case.execute(organization_id=org_id, user_id=uuid4())
+
+        # Then
+        assert len(result) == 1
+        assert result[0].slug == "a"
+
+    async def test_list_denied_for_non_member(self) -> None:
+        # Given
+        use_case = _build_use_case(member_role=None)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(organization_id=uuid4(), user_id=uuid4())

--- a/server/tests/unit/application/use_cases/org_mcp/test_refresh_org_mcp_tools.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_refresh_org_mcp_tools.py
@@ -1,0 +1,143 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.refresh_org_mcp_tools import RefreshOrgMcpTools
+from raggae.domain.exceptions.mcp_exceptions import McpHandshakeError, McpServerNotFoundError
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_use_case(
+    *,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.OWNER,
+    existing_server: object | None = None,
+    handshake_tools: list[McpToolSnapshot] | None = None,
+    handshake_raises: Exception | None = None,
+    decrypted_token: str | None = "decrypted-token",
+) -> tuple[RefreshOrgMcpTools, dict[str, object]]:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=existing_server)
+    server_repo.save = AsyncMock()
+    mcp_client = AsyncMock()
+    if handshake_raises is not None:
+        mcp_client.list_tools = AsyncMock(side_effect=handshake_raises)
+    else:
+        mcp_client.list_tools = AsyncMock(return_value=handshake_tools or [])
+    from unittest.mock import Mock
+
+    crypto = Mock()
+    crypto.decrypt.return_value = decrypted_token
+    use_case = RefreshOrgMcpTools(
+        org_mcp_server_repository=server_repo,
+        organization_member_repository=member_repo,
+        mcp_client=mcp_client,
+        bearer_token_crypto_service=crypto,
+    )
+    return use_case, {
+        "server_repo": server_repo,
+        "mcp_client": mcp_client,
+        "crypto": crypto,
+    }
+
+
+class TestRefreshOrgMcpTools:
+    async def test_refresh_updates_snapshot(self) -> None:
+        # Given
+        existing = make_server()
+        new_tools = [
+            McpToolSnapshot(name="search", description="", input_schema={}),
+            McpToolSnapshot(name="create", description="", input_schema={}),
+        ]
+        use_case, deps = _build_use_case(existing_server=existing, handshake_tools=new_tools)
+
+        # When
+        result = await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then
+        assert len(result.tools_snapshot) == 2
+        assert result.tools_snapshot[0].name == "search"
+        deps["server_repo"].save.assert_awaited_once()  # type: ignore[attr-defined]
+
+    async def test_refresh_passes_decrypted_bearer_to_client(self) -> None:
+        # Given
+        existing = make_server(auth_type=McpAuthType.BEARER)
+        use_case, deps = _build_use_case(existing_server=existing, decrypted_token="clear-token-1234")
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then
+        deps["mcp_client"].list_tools.assert_awaited_once_with(  # type: ignore[attr-defined]
+            url=existing.url, bearer_token="clear-token-1234"
+        )
+
+    async def test_refresh_no_auth_does_not_call_crypto(self) -> None:
+        # Given
+        existing = make_server(auth_type=McpAuthType.NONE)
+        use_case, deps = _build_use_case(existing_server=existing)
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+        )
+
+        # Then
+        deps["crypto"].decrypt.assert_not_called()  # type: ignore[attr-defined]
+        deps["mcp_client"].list_tools.assert_awaited_once_with(  # type: ignore[attr-defined]
+            url=existing.url, bearer_token=None
+        )
+
+    async def test_refresh_not_found_raises(self) -> None:
+        # Given
+        use_case, _ = _build_use_case(existing_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(server_id=uuid4(), organization_id=uuid4(), user_id=uuid4())
+
+    async def test_refresh_access_denied_for_user_role(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, _ = _build_use_case(member_role=OrganizationMemberRole.USER, existing_server=existing)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+            )
+
+    async def test_refresh_handshake_error_propagates(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, deps = _build_use_case(existing_server=existing, handshake_raises=McpHandshakeError("502"))
+
+        # When / Then
+        with pytest.raises(McpHandshakeError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+            )
+        deps["server_repo"].save.assert_not_awaited()  # type: ignore[attr-defined]

--- a/server/tests/unit/application/use_cases/org_mcp/test_update_org_mcp_server.py
+++ b/server/tests/unit/application/use_cases/org_mcp/test_update_org_mcp_server.py
@@ -1,0 +1,232 @@
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.org_mcp.update_org_mcp_server import UpdateOrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpServerNotFoundError,
+    McpUrlForbiddenError,
+)
+from raggae.domain.exceptions.organization_exceptions import OrganizationAccessDeniedError
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_server
+
+
+def _build_use_case(
+    *,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.OWNER,
+    existing_server: object | None = None,
+) -> tuple[UpdateOrgMcpServer, dict[str, object]]:
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=existing_server)
+    server_repo.save = AsyncMock()
+    url_validator = AsyncMock()
+    url_validator.validate = AsyncMock(return_value=None)
+    crypto = Mock()
+    crypto.encrypt.return_value = "encrypted-new"
+    crypto.fingerprint.return_value = "fp-new"
+    use_case = UpdateOrgMcpServer(
+        org_mcp_server_repository=server_repo,
+        organization_member_repository=member_repo,
+        url_safety_validator=url_validator,
+        bearer_token_crypto_service=crypto,
+    )
+    return use_case, {
+        "server_repo": server_repo,
+        "url_validator": url_validator,
+        "crypto": crypto,
+    }
+
+
+class TestUpdateOrgMcpServer:
+    async def test_update_name_url_timeout(self) -> None:
+        # Given
+        org_id = uuid4()
+        server_id = uuid4()
+        existing = make_server(server_id=server_id, organization_id=org_id, name="Old", timeout_seconds=30)
+        use_case, deps = _build_use_case(existing_server=existing)
+
+        # When
+        result = await use_case.execute(
+            server_id=server_id,
+            organization_id=org_id,
+            user_id=uuid4(),
+            name="New",
+            url="https://new.example.com",
+            timeout_seconds=20,
+            auth_type=None,
+            bearer_token=None,
+        )
+
+        # Then
+        assert result.name == "New"
+        assert result.url == "https://new.example.com"
+        assert result.timeout_seconds == 20
+        deps["url_validator"].validate.assert_awaited_once_with("https://new.example.com")  # type: ignore[attr-defined]
+        deps["server_repo"].save.assert_awaited_once()  # type: ignore[attr-defined]
+
+    async def test_update_changes_auth_to_bearer(self) -> None:
+        # Given
+        existing = make_server(auth_type=McpAuthType.NONE)
+        use_case, deps = _build_use_case(existing_server=existing)
+
+        # When
+        result = await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+            name=existing.name,
+            url=existing.url,
+            timeout_seconds=existing.timeout_seconds,
+            auth_type="bearer",
+            bearer_token="new-token-abcd",
+        )
+
+        # Then
+        assert result.auth_type == "bearer"
+        assert result.masked_token == "...abcd"
+        deps["crypto"].encrypt.assert_called_once_with("new-token-abcd")  # type: ignore[attr-defined]
+
+    async def test_update_removes_auth(self) -> None:
+        # Given
+        existing = make_server(auth_type=McpAuthType.BEARER)
+        use_case, _ = _build_use_case(existing_server=existing)
+
+        # When
+        result = await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+            name=existing.name,
+            url=existing.url,
+            timeout_seconds=existing.timeout_seconds,
+            auth_type="none",
+            bearer_token=None,
+        )
+
+        # Then
+        assert result.auth_type == "none"
+        assert result.masked_token is None
+
+    async def test_update_preserves_existing_bearer_when_auth_type_unchanged(self) -> None:
+        # Given
+        existing = make_server(auth_type=McpAuthType.BEARER)
+        use_case, deps = _build_use_case(existing_server=existing)
+
+        # When
+        result = await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+            name="Renamed",
+            url=existing.url,
+            timeout_seconds=existing.timeout_seconds,
+            auth_type=None,
+            bearer_token=None,
+        )
+
+        # Then — token preserved, crypto NOT called
+        assert result.auth_type == "bearer"
+        assert result.masked_token == "...abcd"
+        deps["crypto"].encrypt.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_update_access_denied_for_user_role(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, _ = _build_use_case(member_role=OrganizationMemberRole.USER, existing_server=existing)
+
+        # When / Then
+        with pytest.raises(OrganizationAccessDeniedError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+                name="X",
+                url="https://x",
+                timeout_seconds=30,
+                auth_type=None,
+                bearer_token=None,
+            )
+
+    async def test_update_not_found_raises(self) -> None:
+        # Given
+        use_case, _ = _build_use_case(existing_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(
+                server_id=uuid4(),
+                organization_id=uuid4(),
+                user_id=uuid4(),
+                name="X",
+                url="https://x",
+                timeout_seconds=30,
+                auth_type=None,
+                bearer_token=None,
+            )
+
+    async def test_update_invalid_timeout_raises(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, _ = _build_use_case(existing_server=existing)
+
+        # When / Then
+        with pytest.raises(ValueError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+                name=existing.name,
+                url=existing.url,
+                timeout_seconds=999,
+                auth_type=None,
+                bearer_token=None,
+            )
+
+    async def test_update_url_validates_only_when_changed(self) -> None:
+        # Given
+        existing = make_server(url="https://same.example.com")
+        use_case, deps = _build_use_case(existing_server=existing)
+
+        # When
+        await use_case.execute(
+            server_id=existing.id,
+            organization_id=existing.organization_id,
+            user_id=uuid4(),
+            name=existing.name,
+            url="https://same.example.com",
+            timeout_seconds=existing.timeout_seconds,
+            auth_type=None,
+            bearer_token=None,
+        )
+
+        # Then — URL unchanged, validator not called
+        deps["url_validator"].validate.assert_not_awaited()  # type: ignore[attr-defined]
+
+    async def test_update_rejects_forbidden_url(self) -> None:
+        # Given
+        existing = make_server()
+        use_case, deps = _build_use_case(existing_server=existing)
+        deps["url_validator"].validate = AsyncMock(  # type: ignore[attr-defined]
+            side_effect=McpUrlForbiddenError("blocked")
+        )
+
+        # When / Then
+        with pytest.raises(McpUrlForbiddenError):
+            await use_case.execute(
+                server_id=existing.id,
+                organization_id=existing.organization_id,
+                user_id=uuid4(),
+                name=existing.name,
+                url="http://localhost:9999",
+                timeout_seconds=existing.timeout_seconds,
+                auth_type=None,
+                bearer_token=None,
+            )

--- a/server/tests/unit/domain/entities/test_org_mcp_server.py
+++ b/server/tests/unit/domain/entities/test_org_mcp_server.py
@@ -1,0 +1,132 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+def _make_server(**overrides: object) -> OrgMcpServer:
+    now = datetime.now(UTC)
+    defaults: dict[str, object] = {
+        "id": uuid4(),
+        "organization_id": uuid4(),
+        "name": "Notion",
+        "slug": "notion",
+        "url": "https://mcp.example.com",
+        "auth_type": McpAuthType.NONE,
+        "encrypted_bearer_token": None,
+        "token_fingerprint": None,
+        "token_suffix": None,
+        "is_active": True,
+        "tools_snapshot": [],
+        "tools_snapshot_at": now,
+        "timeout_seconds": 30,
+        "created_at": now,
+        "updated_at": now,
+        "created_by_user_id": uuid4(),
+    }
+    defaults.update(overrides)
+    return OrgMcpServer(**defaults)  # type: ignore[arg-type]
+
+
+def test_masked_token_returns_suffix_when_bearer_set() -> None:
+    server = _make_server(
+        auth_type=McpAuthType.BEARER,
+        encrypted_bearer_token="enc",
+        token_fingerprint="fp",
+        token_suffix="abcd",
+    )
+
+    assert server.masked_token == "...abcd"
+
+
+def test_masked_token_returns_none_when_no_auth() -> None:
+    server = _make_server(auth_type=McpAuthType.NONE)
+
+    assert server.masked_token is None
+
+
+def test_activate_sets_is_active_true() -> None:
+    server = _make_server(is_active=False)
+
+    activated = server.activate()
+
+    assert activated.is_active is True
+    assert server.is_active is False  # original unchanged
+
+
+def test_deactivate_sets_is_active_false() -> None:
+    server = _make_server(is_active=True)
+
+    deactivated = server.deactivate()
+
+    assert deactivated.is_active is False
+    assert server.is_active is True
+
+
+def test_with_refreshed_tools_updates_snapshot_and_timestamp() -> None:
+    server = _make_server()
+    tools = [McpToolSnapshot(name="search", description="", input_schema={})]
+    refreshed_at = datetime.now(UTC)
+
+    refreshed = server.with_refreshed_tools(tools, refreshed_at)
+
+    assert refreshed.tools_snapshot == tools
+    assert refreshed.tools_snapshot_at == refreshed_at
+
+
+def test_with_updated_settings_changes_mutable_fields() -> None:
+    server = _make_server(name="Old", timeout_seconds=30)
+    updated_at = datetime.now(UTC)
+
+    updated = server.with_updated_settings(
+        name="New name",
+        url="https://new.example.com",
+        timeout_seconds=15,
+        updated_at=updated_at,
+    )
+
+    assert updated.name == "New name"
+    assert updated.url == "https://new.example.com"
+    assert updated.timeout_seconds == 15
+    assert updated.updated_at == updated_at
+    # immutable fields preserved
+    assert updated.id == server.id
+    assert updated.slug == server.slug
+
+
+def test_with_bearer_token_sets_auth_fields() -> None:
+    server = _make_server(auth_type=McpAuthType.NONE)
+    updated_at = datetime.now(UTC)
+
+    updated = server.with_bearer_token(
+        encrypted_token="encrypted-value",
+        fingerprint="fp123",
+        suffix="wxyz",
+        updated_at=updated_at,
+    )
+
+    assert updated.auth_type == McpAuthType.BEARER
+    assert updated.encrypted_bearer_token == "encrypted-value"
+    assert updated.token_fingerprint == "fp123"
+    assert updated.token_suffix == "wxyz"
+    assert updated.updated_at == updated_at
+
+
+def test_without_auth_clears_token_fields() -> None:
+    server = _make_server(
+        auth_type=McpAuthType.BEARER,
+        encrypted_bearer_token="enc",
+        token_fingerprint="fp",
+        token_suffix="abcd",
+    )
+    updated_at = datetime.now(UTC)
+
+    updated = server.without_auth(updated_at)
+
+    assert updated.auth_type == McpAuthType.NONE
+    assert updated.encrypted_bearer_token is None
+    assert updated.token_fingerprint is None
+    assert updated.token_suffix is None
+    assert updated.updated_at == updated_at

--- a/server/tests/unit/domain/entities/test_project_mcp_activation.py
+++ b/server/tests/unit/domain/entities/test_project_mcp_activation.py
@@ -1,0 +1,34 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+
+
+def _make_activation(**overrides: object) -> ProjectMcpActivation:
+    defaults: dict[str, object] = {
+        "project_id": uuid4(),
+        "org_mcp_server_id": uuid4(),
+        "is_active": True,
+        "activated_at": datetime.now(UTC),
+        "activated_by_user_id": uuid4(),
+    }
+    defaults.update(overrides)
+    return ProjectMcpActivation(**defaults)  # type: ignore[arg-type]
+
+
+def test_activate_returns_active_copy() -> None:
+    activation = _make_activation(is_active=False)
+
+    activated = activation.activate()
+
+    assert activated.is_active is True
+    assert activation.is_active is False
+
+
+def test_deactivate_returns_inactive_copy() -> None:
+    activation = _make_activation(is_active=True)
+
+    deactivated = activation.deactivate()
+
+    assert deactivated.is_active is False
+    assert activation.is_active is True

--- a/server/tests/unit/domain/value_objects/test_mcp_auth_type.py
+++ b/server/tests/unit/domain/value_objects/test_mcp_auth_type.py
@@ -1,0 +1,11 @@
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+
+
+def test_mcp_auth_type_values() -> None:
+    assert McpAuthType.NONE.value == "none"
+    assert McpAuthType.BEARER.value == "bearer"
+
+
+def test_mcp_auth_type_from_string() -> None:
+    assert McpAuthType("none") is McpAuthType.NONE
+    assert McpAuthType("bearer") is McpAuthType.BEARER

--- a/server/tests/unit/domain/value_objects/test_mcp_slug.py
+++ b/server/tests/unit/domain/value_objects/test_mcp_slug.py
@@ -1,0 +1,27 @@
+from raggae.domain.value_objects.mcp_slug import slugify
+
+
+def test_slugify_simple_name() -> None:
+    assert slugify("My MCP") == "my-mcp"
+
+
+def test_slugify_strips_special_chars() -> None:
+    assert slugify("Acme/Notion (prod)") == "acme-notion-prod"
+
+
+def test_slugify_collapses_separators() -> None:
+    assert slugify("foo   bar---baz") == "foo-bar-baz"
+
+
+def test_slugify_trims_dashes() -> None:
+    assert slugify("---hello---") == "hello"
+
+
+def test_slugify_drops_diacritics_replaced_by_dash() -> None:
+    # Non-ASCII chars become separators (kebab-case ASCII)
+    assert slugify("résumé") == "r-sum"
+
+
+def test_slugify_empty_falls_back_to_default() -> None:
+    assert slugify("   ") == "mcp"
+    assert slugify("!!!") == "mcp"

--- a/server/tests/unit/domain/value_objects/test_mcp_tool_snapshot.py
+++ b/server/tests/unit/domain/value_objects/test_mcp_tool_snapshot.py
@@ -1,0 +1,27 @@
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+def test_mcp_tool_snapshot_holds_metadata() -> None:
+    # Given / When
+    snapshot = McpToolSnapshot(
+        name="search",
+        description="Search documents",
+        input_schema={"type": "object", "properties": {"q": {"type": "string"}}},
+    )
+
+    # Then
+    assert snapshot.name == "search"
+    assert snapshot.description == "Search documents"
+    assert snapshot.input_schema["type"] == "object"
+
+
+def test_mcp_tool_snapshot_is_immutable() -> None:
+    # Given
+    snapshot = McpToolSnapshot(name="search", description="", input_schema={})
+
+    # When / Then
+    try:
+        snapshot.name = "other"  # type: ignore[misc]
+    except Exception:  # noqa: BLE001
+        return
+    raise AssertionError("McpToolSnapshot should be immutable")


### PR DESCRIPTION
## Problème

Raggae n'a pas de mécanisme pour qu'une organisation déclare des serveurs MCP (Model Context Protocol) et les expose, optionnellement, à ses projets. La fonctionnalité complète sera livrée en six PRs incrémentales (voir `docs/MCP_FEATURE_PLAN.md`).

## Solution

Cette première PR pose les briques pures de la fonctionnalité — couche domaine et use cases d'administration des MCP au niveau organisation — sans encore introduire de persistance, d'endpoint ni d'UI.

## Implémentation

- **Domaine**
  - Value objects `McpAuthType` (`none` / `bearer`), `McpToolSnapshot`, et helper `slugify` (kebab-case ASCII avec fallback).
  - Entités immutables `OrgMcpServer` (avec helpers `activate`, `deactivate`, `with_refreshed_tools`, `with_updated_settings`, `with_bearer_token`, `without_auth`) et `ProjectMcpActivation`.
  - Exceptions domaine `McpServerNotFoundError`, `McpDuplicateSlugError`, `McpAccessDeniedError`, `McpUrlForbiddenError`, `McpHandshakeError`, `McpToolNotFoundError`, `McpCallTimeoutError`.
- **Application**
  - DTOs `OrgMcpServerDTO`, `McpToolSnapshotDTO`, `ProjectMcpActivationDTO`.
  - Interfaces `OrgMcpServerRepository`, `ProjectMcpActivationRepository`, `McpClient`, `UrlSafetyValidator`, `McpBearerTokenCryptoService`. Aucune implémentation : elle viendra dans la PR 2 (infrastructure).
  - Use cases sous `application/use_cases/org_mcp/` : `declare`, `list`, `update`, `refresh`, `activate`, `deactivate`, `delete`. Ils appliquent les permissions OWNER/MAKER (USER pour `list` seulement), valident l'URL via `UrlSafetyValidator`, gèrent le chiffrement du bearer token, font le handshake `tools/list` à la déclaration et au refresh, et cascade les activations projet à la suppression.
- **Tests** : 36 tests unitaires en Given/When/Then (mocks `AsyncMock`/`Mock`), tous verts.
- **Documentation** : ajout de `docs/MCP_FEATURE_PLAN.md` décrivant la fonctionnalité complète et le découpage en 6 PRs.

## Recette

1. Récupérer la branche et installer l'environnement :
   ```bash
   cd server && source .venv/bin/activate
   pytest tests/unit/domain/value_objects/test_mcp_auth_type.py \
          tests/unit/domain/value_objects/test_mcp_tool_snapshot.py \
          tests/unit/domain/value_objects/test_mcp_slug.py \
          tests/unit/domain/entities/test_org_mcp_server.py \
          tests/unit/domain/entities/test_project_mcp_activation.py \
          tests/unit/application/use_cases/org_mcp -v
   ```
   → 56 tests passent (20 domaine + 36 use cases).
2. Vérifier le pipeline qualité complet :
   ```bash
   pytest                            # 995 passed, 0 failed, 35 skipped
   ruff format src/ tests/
   ruff check src/ tests/
   mypy src/
   ```
3. Lire `docs/MCP_FEATURE_PLAN.md` pour comprendre la suite (PR 2 : infrastructure et migrations).

Aucune migration, aucun endpoint, aucune dépendance ajoutée : cette PR est purement additive et n'affecte aucun comportement existant.