### PR TITLE
feat(mcp): infrastructure MCP (PR 2/6)

### DIFF
--- a/server/alembic/versions/20260629_46_add_org_mcp_servers_and_activations.py
+++ b/server/alembic/versions/20260629_46_add_org_mcp_servers_and_activations.py
@@ -1,0 +1,102 @@
+"""add org mcp servers and project activations
+
+Revision ID: 20260629_46
+Revises: 20260506_45
+Create Date: 2026-06-29
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260629_46"
+down_revision: str | None = "20260506_45"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_mcp_servers",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("slug", sa.String(length=128), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False),
+        sa.Column("auth_type", sa.String(length=16), nullable=False),
+        sa.Column("encrypted_bearer_token", sa.Text(), nullable=True),
+        sa.Column("token_fingerprint", sa.String(length=128), nullable=True),
+        sa.Column("token_suffix", sa.String(length=16), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "tools_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("tools_snapshot_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "timeout_seconds",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("30"),
+        ),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("organization_id", "slug", name="uq_org_mcp_servers_org_slug"),
+    )
+    op.create_index(
+        "ix_org_mcp_servers_organization_id",
+        "org_mcp_servers",
+        ["organization_id"],
+        unique=False,
+    )
+
+    op.create_table(
+        "project_mcp_activations",
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("org_mcp_server_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column("activated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("activated_by_user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["org_mcp_server_id"], ["org_mcp_servers.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("project_id", "org_mcp_server_id"),
+    )
+    op.create_index(
+        "ix_project_mcp_activations_org_mcp_server_id",
+        "project_mcp_activations",
+        ["org_mcp_server_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_project_mcp_activations_org_mcp_server_id",
+        table_name="project_mcp_activations",
+    )
+    op.drop_table("project_mcp_activations")
+    op.drop_index(
+        "ix_org_mcp_servers_organization_id",
+        table_name="org_mcp_servers",
+    )
+    op.drop_table("org_mcp_servers")

--- a/server/src/raggae/infrastructure/database/models/__init__.py
+++ b/server/src/raggae/infrastructure/database/models/__init__.py
@@ -3,6 +3,7 @@ from raggae.infrastructure.database.models.conversation_model import Conversatio
 from raggae.infrastructure.database.models.document_chunk_model import DocumentChunkModel
 from raggae.infrastructure.database.models.document_model import DocumentModel
 from raggae.infrastructure.database.models.message_model import MessageModel
+from raggae.infrastructure.database.models.org_mcp_server_model import OrgMcpServerModel
 from raggae.infrastructure.database.models.organization_invitation_model import (
     OrganizationInvitationModel,
 )
@@ -10,6 +11,9 @@ from raggae.infrastructure.database.models.organization_member_model import (
     OrganizationMemberModel,
 )
 from raggae.infrastructure.database.models.organization_model import OrganizationModel
+from raggae.infrastructure.database.models.project_mcp_activation_model import (
+    ProjectMcpActivationModel,
+)
 from raggae.infrastructure.database.models.project_model import ProjectModel
 from raggae.infrastructure.database.models.project_snapshot_model import ProjectSnapshotModel
 from raggae.infrastructure.database.models.user_model import UserModel
@@ -23,9 +27,11 @@ __all__ = [
     "DocumentChunkModel",
     "DocumentModel",
     "MessageModel",
+    "OrgMcpServerModel",
     "OrganizationInvitationModel",
     "OrganizationMemberModel",
     "OrganizationModel",
+    "ProjectMcpActivationModel",
     "ProjectModel",
     "ProjectSnapshotModel",
     "UserModel",

--- a/server/src/raggae/infrastructure/database/models/org_mcp_server_model.py
+++ b/server/src/raggae/infrastructure/database/models/org_mcp_server_model.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from raggae.infrastructure.database.models.base import Base
+
+
+class OrgMcpServerModel(Base):
+    __tablename__ = "org_mcp_servers"
+    __table_args__ = (UniqueConstraint("organization_id", "slug", name="uq_org_mcp_servers_org_slug"),)
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    organization_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(Text(), nullable=False)
+    slug: Mapped[str] = mapped_column(String(128), nullable=False)
+    url: Mapped[str] = mapped_column(Text(), nullable=False)
+    auth_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    encrypted_bearer_token: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    token_fingerprint: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    token_suffix: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True)
+    tools_snapshot: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False, default=list)
+    tools_snapshot_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    timeout_seconds: Mapped[int] = mapped_column(Integer(), nullable=False, default=30)
+    created_by_user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/server/src/raggae/infrastructure/database/models/project_mcp_activation_model.py
+++ b/server/src/raggae/infrastructure/database/models/project_mcp_activation_model.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from raggae.infrastructure.database.models.base import Base
+
+
+class ProjectMcpActivationModel(Base):
+    __tablename__ = "project_mcp_activations"
+
+    project_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    org_mcp_server_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("org_mcp_servers.id", ondelete="CASCADE"),
+        primary_key=True,
+        index=True,
+    )
+    is_active: Mapped[bool] = mapped_column(Boolean(), nullable=False, default=True)
+    activated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    activated_by_user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_org_mcp_server_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_org_mcp_server_repository.py
@@ -1,0 +1,34 @@
+from uuid import UUID
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+
+
+class InMemoryOrgMcpServerRepository:
+    """In-memory MCP server repository for tests and dev mode."""
+
+    def __init__(self) -> None:
+        self._servers: dict[UUID, OrgMcpServer] = {}
+
+    async def save(self, server: OrgMcpServer) -> None:
+        self._servers[server.id] = server
+
+    async def find_by_id(self, server_id: UUID, organization_id: UUID) -> OrgMcpServer | None:
+        server = self._servers.get(server_id)
+        if server is None or server.organization_id != organization_id:
+            return None
+        return server
+
+    async def find_by_slug(self, organization_id: UUID, slug: str) -> OrgMcpServer | None:
+        for server in self._servers.values():
+            if server.organization_id == organization_id and server.slug == slug:
+                return server
+        return None
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgMcpServer]:
+        return [s for s in self._servers.values() if s.organization_id == organization_id]
+
+    async def delete(self, server_id: UUID, organization_id: UUID) -> None:
+        server = self._servers.get(server_id)
+        if server is None or server.organization_id != organization_id:
+            return
+        del self._servers[server_id]

--- a/server/src/raggae/infrastructure/database/repositories/in_memory_project_mcp_activation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/in_memory_project_mcp_activation_repository.py
@@ -1,0 +1,30 @@
+from uuid import UUID
+
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+
+
+class InMemoryProjectMcpActivationRepository:
+    """In-memory project ↔ MCP activation repository for tests and dev mode."""
+
+    def __init__(self) -> None:
+        self._activations: dict[tuple[UUID, UUID], ProjectMcpActivation] = {}
+
+    async def save(self, activation: ProjectMcpActivation) -> None:
+        self._activations[(activation.project_id, activation.org_mcp_server_id)] = activation
+
+    async def find(self, project_id: UUID, org_mcp_server_id: UUID) -> ProjectMcpActivation | None:
+        return self._activations.get((project_id, org_mcp_server_id))
+
+    async def list_by_project_id(self, project_id: UUID) -> list[ProjectMcpActivation]:
+        return [a for a in self._activations.values() if a.project_id == project_id]
+
+    async def list_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> list[ProjectMcpActivation]:
+        return [a for a in self._activations.values() if a.org_mcp_server_id == org_mcp_server_id]
+
+    async def delete(self, project_id: UUID, org_mcp_server_id: UUID) -> None:
+        self._activations.pop((project_id, org_mcp_server_id), None)
+
+    async def delete_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> None:
+        keys_to_remove = [key for key in self._activations if key[1] == org_mcp_server_id]
+        for key in keys_to_remove:
+            self._activations.pop(key, None)

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_org_mcp_server_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_org_mcp_server_repository.py
@@ -1,0 +1,137 @@
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+from raggae.infrastructure.database.models.org_mcp_server_model import OrgMcpServerModel
+
+
+class SQLAlchemyOrgMcpServerRepository:
+    """PostgreSQL repository for organization MCP servers."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def save(self, server: OrgMcpServer) -> None:
+        async with self._session_factory() as session:
+            model = await session.get(OrgMcpServerModel, server.id)
+            if model is None:
+                model = OrgMcpServerModel(
+                    id=server.id,
+                    organization_id=server.organization_id,
+                    name=server.name,
+                    slug=server.slug,
+                    url=server.url,
+                    auth_type=server.auth_type.value,
+                    encrypted_bearer_token=server.encrypted_bearer_token,
+                    token_fingerprint=server.token_fingerprint,
+                    token_suffix=server.token_suffix,
+                    is_active=server.is_active,
+                    tools_snapshot=_tools_to_json(server.tools_snapshot),
+                    tools_snapshot_at=server.tools_snapshot_at,
+                    timeout_seconds=server.timeout_seconds,
+                    created_by_user_id=server.created_by_user_id,
+                    created_at=server.created_at,
+                    updated_at=server.updated_at,
+                )
+                session.add(model)
+            else:
+                model.name = server.name
+                model.url = server.url
+                model.auth_type = server.auth_type.value
+                model.encrypted_bearer_token = server.encrypted_bearer_token
+                model.token_fingerprint = server.token_fingerprint
+                model.token_suffix = server.token_suffix
+                model.is_active = server.is_active
+                model.tools_snapshot = _tools_to_json(server.tools_snapshot)
+                model.tools_snapshot_at = server.tools_snapshot_at
+                model.timeout_seconds = server.timeout_seconds
+                model.updated_at = server.updated_at
+            await session.commit()
+
+    async def find_by_id(self, server_id: UUID, organization_id: UUID) -> OrgMcpServer | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OrgMcpServerModel).where(
+                    OrgMcpServerModel.id == server_id,
+                    OrgMcpServerModel.organization_id == organization_id,
+                )
+            )
+            model = result.scalar_one_or_none()
+            return _to_domain(model) if model is not None else None
+
+    async def find_by_slug(self, organization_id: UUID, slug: str) -> OrgMcpServer | None:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OrgMcpServerModel).where(
+                    OrgMcpServerModel.organization_id == organization_id,
+                    OrgMcpServerModel.slug == slug,
+                )
+            )
+            model = result.scalar_one_or_none()
+            return _to_domain(model) if model is not None else None
+
+    async def list_by_org_id(self, organization_id: UUID) -> list[OrgMcpServer]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(OrgMcpServerModel)
+                .where(OrgMcpServerModel.organization_id == organization_id)
+                .order_by(OrgMcpServerModel.created_at)
+            )
+            return [_to_domain(m) for m in result.scalars().all()]
+
+    async def delete(self, server_id: UUID, organization_id: UUID) -> None:
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(OrgMcpServerModel).where(
+                    OrgMcpServerModel.id == server_id,
+                    OrgMcpServerModel.organization_id == organization_id,
+                )
+            )
+            await session.commit()
+
+
+def _tools_to_json(tools: list[McpToolSnapshot]) -> list[dict[str, Any]]:
+    return [{"name": t.name, "description": t.description, "input_schema": t.input_schema} for t in tools]
+
+
+def _tools_from_json(payload: list[dict[str, Any]] | None) -> list[McpToolSnapshot]:
+    if not payload:
+        return []
+    snapshots: list[McpToolSnapshot] = []
+    for item in payload:
+        raw_schema = item.get("input_schema")
+        input_schema: dict[str, Any] = dict(raw_schema) if isinstance(raw_schema, dict) else {}
+        snapshots.append(
+            McpToolSnapshot(
+                name=str(item.get("name", "")),
+                description=str(item.get("description", "")),
+                input_schema=input_schema,
+            )
+        )
+    return snapshots
+
+
+def _to_domain(model: OrgMcpServerModel) -> OrgMcpServer:
+    return OrgMcpServer(
+        id=model.id,
+        organization_id=model.organization_id,
+        name=model.name,
+        slug=model.slug,
+        url=model.url,
+        auth_type=McpAuthType(model.auth_type),
+        encrypted_bearer_token=model.encrypted_bearer_token,
+        token_fingerprint=model.token_fingerprint,
+        token_suffix=model.token_suffix,
+        is_active=model.is_active,
+        tools_snapshot=_tools_from_json(model.tools_snapshot),
+        tools_snapshot_at=model.tools_snapshot_at,
+        timeout_seconds=model.timeout_seconds,
+        created_by_user_id=model.created_by_user_id,
+        created_at=model.created_at,
+        updated_at=model.updated_at,
+    )

--- a/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_mcp_activation_repository.py
+++ b/server/src/raggae/infrastructure/database/repositories/sqlalchemy_project_mcp_activation_repository.py
@@ -1,0 +1,88 @@
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+from raggae.infrastructure.database.models.project_mcp_activation_model import (
+    ProjectMcpActivationModel,
+)
+
+
+class SQLAlchemyProjectMcpActivationRepository:
+    """PostgreSQL repository for project ↔ MCP server activations."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def save(self, activation: ProjectMcpActivation) -> None:
+        async with self._session_factory() as session:
+            existing = await session.get(
+                ProjectMcpActivationModel,
+                (activation.project_id, activation.org_mcp_server_id),
+            )
+            if existing is None:
+                session.add(
+                    ProjectMcpActivationModel(
+                        project_id=activation.project_id,
+                        org_mcp_server_id=activation.org_mcp_server_id,
+                        is_active=activation.is_active,
+                        activated_at=activation.activated_at,
+                        activated_by_user_id=activation.activated_by_user_id,
+                    )
+                )
+            else:
+                existing.is_active = activation.is_active
+                existing.activated_at = activation.activated_at
+                existing.activated_by_user_id = activation.activated_by_user_id
+            await session.commit()
+
+    async def find(self, project_id: UUID, org_mcp_server_id: UUID) -> ProjectMcpActivation | None:
+        async with self._session_factory() as session:
+            model = await session.get(ProjectMcpActivationModel, (project_id, org_mcp_server_id))
+            return _to_domain(model) if model is not None else None
+
+    async def list_by_project_id(self, project_id: UUID) -> list[ProjectMcpActivation]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectMcpActivationModel).where(ProjectMcpActivationModel.project_id == project_id)
+            )
+            return [_to_domain(m) for m in result.scalars().all()]
+
+    async def list_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> list[ProjectMcpActivation]:
+        async with self._session_factory() as session:
+            result = await session.execute(
+                select(ProjectMcpActivationModel).where(
+                    ProjectMcpActivationModel.org_mcp_server_id == org_mcp_server_id
+                )
+            )
+            return [_to_domain(m) for m in result.scalars().all()]
+
+    async def delete(self, project_id: UUID, org_mcp_server_id: UUID) -> None:
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(ProjectMcpActivationModel).where(
+                    ProjectMcpActivationModel.project_id == project_id,
+                    ProjectMcpActivationModel.org_mcp_server_id == org_mcp_server_id,
+                )
+            )
+            await session.commit()
+
+    async def delete_by_org_mcp_server_id(self, org_mcp_server_id: UUID) -> None:
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(ProjectMcpActivationModel).where(
+                    ProjectMcpActivationModel.org_mcp_server_id == org_mcp_server_id
+                )
+            )
+            await session.commit()
+
+
+def _to_domain(model: ProjectMcpActivationModel) -> ProjectMcpActivation:
+    return ProjectMcpActivation(
+        project_id=model.project_id,
+        org_mcp_server_id=model.org_mcp_server_id,
+        is_active=model.is_active,
+        activated_at=model.activated_at,
+        activated_by_user_id=model.activated_by_user_id,
+    )

--- a/server/src/raggae/infrastructure/services/fernet_mcp_bearer_token_crypto_service.py
+++ b/server/src/raggae/infrastructure/services/fernet_mcp_bearer_token_crypto_service.py
@@ -1,0 +1,23 @@
+from raggae.application.interfaces.services.provider_api_key_crypto_service import (
+    ProviderApiKeyCryptoService,
+)
+
+
+class FernetMcpBearerTokenCryptoService:
+    """Adapter exposing the MCP bearer token crypto port via the existing Fernet service.
+
+    Reuses the same encryption key and algorithm as provider API keys, but keeps the
+    application port `McpBearerTokenCryptoService` semantically distinct.
+    """
+
+    def __init__(self, inner: ProviderApiKeyCryptoService) -> None:
+        self._inner = inner
+
+    def encrypt(self, raw_token: str) -> str:
+        return self._inner.encrypt(raw_token)
+
+    def decrypt(self, encrypted_token: str) -> str:
+        return self._inner.decrypt(encrypted_token)
+
+    def fingerprint(self, raw_token: str) -> str:
+        return self._inner.fingerprint(raw_token)

--- a/server/src/raggae/infrastructure/services/http_mcp_client.py
+++ b/server/src/raggae/infrastructure/services/http_mcp_client.py
@@ -1,0 +1,178 @@
+"""HTTP/SSE client implementing the MCP `Streamable HTTP` transport.
+
+JSON-RPC 2.0 envelopes are POSTed to the MCP server endpoint. The server may
+respond with `application/json` (single response) or `text/event-stream`
+(SSE events containing JSON-RPC payloads). Both are supported.
+"""
+
+import itertools
+import json
+from collections.abc import Callable
+from typing import Any
+
+import httpx
+
+from raggae.application.interfaces.services.url_safety_validator import UrlSafetyValidator
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpCallTimeoutError,
+    McpHandshakeError,
+    McpToolNotFoundError,
+)
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+_MCP_PROTOCOL_VERSION = "2025-06-18"
+_JSON_RPC_METHOD_NOT_FOUND = -32601
+_JSON_RPC_INVALID_PARAMS = -32602
+
+HttpClientFactory = Callable[[], httpx.AsyncClient]
+
+
+class HttpMcpClient:
+    """MCP client using `httpx` over HTTPS."""
+
+    def __init__(
+        self,
+        url_safety_validator: UrlSafetyValidator,
+        http_client_factory: HttpClientFactory | None = None,
+    ) -> None:
+        self._url_safety_validator = url_safety_validator
+        self._http_client_factory = http_client_factory or (lambda: httpx.AsyncClient())
+        self._id_counter = itertools.count(1)
+
+    async def list_tools(
+        self,
+        url: str,
+        bearer_token: str | None = None,
+    ) -> list[McpToolSnapshot]:
+        await self._url_safety_validator.validate(url)
+        try:
+            result = await self._call_jsonrpc(
+                url=url,
+                method="tools/list",
+                params={},
+                bearer_token=bearer_token,
+                timeout_seconds=30,
+            )
+        except McpToolNotFoundError as exc:
+            raise McpHandshakeError(str(exc)) from exc
+        return _parse_tools(result)
+
+    async def call_tool(
+        self,
+        url: str,
+        tool: str,
+        arguments: dict[str, Any],
+        timeout_seconds: int,
+        bearer_token: str | None = None,
+    ) -> dict[str, Any]:
+        await self._url_safety_validator.validate(url)
+        return await self._call_jsonrpc(
+            url=url,
+            method="tools/call",
+            params={"name": tool, "arguments": arguments},
+            bearer_token=bearer_token,
+            timeout_seconds=timeout_seconds,
+        )
+
+    async def _call_jsonrpc(
+        self,
+        *,
+        url: str,
+        method: str,
+        params: dict[str, Any],
+        bearer_token: str | None,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
+        request_id = next(self._id_counter)
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+            "MCP-Protocol-Version": _MCP_PROTOCOL_VERSION,
+        }
+        if bearer_token:
+            headers["Authorization"] = f"Bearer {bearer_token}"
+
+        try:
+            async with self._http_client_factory() as client:
+                response = await client.post(
+                    url,
+                    json=payload,
+                    headers=headers,
+                    timeout=timeout_seconds,
+                )
+        except (httpx.TimeoutException, TimeoutError) as exc:
+            raise McpCallTimeoutError(f"MCP call '{method}' timed out after {timeout_seconds}s") from exc
+
+        if response.status_code >= 500:
+            raise McpHandshakeError(f"MCP server returned HTTP {response.status_code}")
+        if response.status_code >= 400:
+            raise McpHandshakeError(f"MCP server rejected request: HTTP {response.status_code}")
+
+        envelope = _parse_envelope(response, expected_id=request_id)
+        if "error" in envelope:
+            _raise_error(method, envelope["error"])
+        result = envelope.get("result")
+        if not isinstance(result, dict):
+            raise McpHandshakeError(f"MCP server returned no result for '{method}'")
+        return result
+
+
+def _parse_envelope(response: httpx.Response, expected_id: int) -> dict[str, Any]:
+    content_type = response.headers.get("content-type", "").lower()
+    if "text/event-stream" in content_type:
+        payload = _parse_sse(response.text, expected_id)
+    else:
+        try:
+            payload = response.json()
+        except json.JSONDecodeError as exc:
+            raise McpHandshakeError(f"MCP server returned non-JSON body: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise McpHandshakeError("MCP server returned a non-object JSON-RPC envelope")
+    return payload
+
+
+def _parse_sse(body: str, expected_id: int) -> dict[str, Any]:
+    for block in body.split("\n\n"):
+        data_lines = [line[len("data:") :].strip() for line in block.splitlines() if line.startswith("data:")]
+        if not data_lines:
+            continue
+        try:
+            payload = json.loads("\n".join(data_lines))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("id") == expected_id:
+            return payload
+    raise McpHandshakeError("MCP SSE response did not contain a matching JSON-RPC payload")
+
+
+def _raise_error(method: str, error: dict[str, Any]) -> None:
+    code = error.get("code")
+    message = str(error.get("message", "unknown error"))
+    if method == "tools/call" and code in (_JSON_RPC_METHOD_NOT_FOUND, _JSON_RPC_INVALID_PARAMS):
+        raise McpToolNotFoundError(message)
+    raise McpHandshakeError(f"MCP JSON-RPC error {code}: {message}")
+
+
+def _parse_tools(result: dict[str, Any]) -> list[McpToolSnapshot]:
+    raw_tools = result.get("tools") or []
+    if not isinstance(raw_tools, list):
+        raise McpHandshakeError("Invalid 'tools' field in tools/list response")
+    snapshots: list[McpToolSnapshot] = []
+    for raw in raw_tools:
+        if not isinstance(raw, dict) or "name" not in raw:
+            continue
+        schema = raw.get("inputSchema") or raw.get("input_schema") or {}
+        snapshots.append(
+            McpToolSnapshot(
+                name=str(raw["name"]),
+                description=str(raw.get("description", "")),
+                input_schema=dict(schema) if isinstance(schema, dict) else {},
+            )
+        )
+    return snapshots

--- a/server/src/raggae/infrastructure/services/url_safety_validator_impl.py
+++ b/server/src/raggae/infrastructure/services/url_safety_validator_impl.py
@@ -1,0 +1,58 @@
+import asyncio
+import ipaddress
+import socket
+from collections.abc import Awaitable, Callable
+from urllib.parse import urlparse
+
+from raggae.domain.exceptions.mcp_exceptions import McpUrlForbiddenError
+
+DnsResolver = Callable[[str], Awaitable[list[str]]]
+
+
+async def _resolve_host(host: str) -> list[str]:
+    """Default async resolver: resolves a hostname to all its A/AAAA records."""
+    loop = asyncio.get_running_loop()
+    infos = await loop.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    return [info[4][0] for info in infos]
+
+
+class UrlSafetyValidatorImpl:
+    """Validates outbound URLs against SSRF: HTTPS-only + denylist of private/reserved IPs."""
+
+    def __init__(self, resolver: DnsResolver | None = None) -> None:
+        self._resolver = resolver or _resolve_host
+
+    async def validate(self, url: str) -> None:
+        parsed = urlparse(url)
+        if parsed.scheme != "https":
+            raise McpUrlForbiddenError(f"URL scheme must be https, got '{parsed.scheme}'")
+        host = parsed.hostname
+        if not host:
+            raise McpUrlForbiddenError("URL must include a hostname")
+
+        try:
+            addresses = await self._resolver(host)
+        except (OSError, McpUrlForbiddenError) as exc:
+            raise McpUrlForbiddenError(f"Cannot resolve host '{host}': {exc}") from exc
+
+        if not addresses:
+            raise McpUrlForbiddenError(f"Host '{host}' resolved to no address")
+
+        for raw in addresses:
+            try:
+                address = ipaddress.ip_address(raw)
+            except ValueError as exc:
+                raise McpUrlForbiddenError(f"Invalid IP address '{raw}' for host '{host}'") from exc
+            if _is_forbidden(address):
+                raise McpUrlForbiddenError(f"Host '{host}' resolves to forbidden address '{raw}'")
+
+
+def _is_forbidden(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        address.is_loopback
+        or address.is_link_local
+        or address.is_private
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    )

--- a/server/tests/integration/test_sqlalchemy_org_mcp_server_repository.py
+++ b/server/tests/integration/test_sqlalchemy_org_mcp_server_repository.py
@@ -1,0 +1,170 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.entities.organization import Organization
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+from raggae.infrastructure.database.models import Base
+from raggae.infrastructure.database.repositories.sqlalchemy_org_mcp_server_repository import (
+    SQLAlchemyOrgMcpServerRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_organization_repository import (
+    SQLAlchemyOrganizationRepository,
+)
+
+
+class TestSQLAlchemyOrgMcpServerRepository:
+    @pytest.fixture
+    async def session_factory(self) -> async_sessionmaker[AsyncSession]:
+        engine = create_async_engine(
+            "postgresql+asyncpg://test:test@localhost:5433/raggae_test",
+            echo=False,
+        )
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.drop_all)
+                await conn.run_sync(Base.metadata.create_all)
+        except Exception as exc:  # pragma: no cover - environment dependent
+            pytest.skip(f"PostgreSQL test database is not reachable: {exc}")
+
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        yield factory
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+    async def _seed_organization(self, session_factory: async_sessionmaker[AsyncSession]) -> Organization:
+        now = datetime.now(UTC)
+        org = Organization(
+            id=uuid4(),
+            name="Acme",
+            slug="acme",
+            description=None,
+            logo_url=None,
+            created_by_user_id=uuid4(),
+            created_at=now,
+            updated_at=now,
+        )
+        await SQLAlchemyOrganizationRepository(session_factory=session_factory).save(org)
+        return org
+
+    def _make_server(
+        self,
+        *,
+        organization_id,
+        slug: str = "notion",
+        name: str = "Notion",
+        auth_type: McpAuthType = McpAuthType.NONE,
+        tools: list[McpToolSnapshot] | None = None,
+    ) -> OrgMcpServer:
+        now = datetime.now(UTC)
+        return OrgMcpServer(
+            id=uuid4(),
+            organization_id=organization_id,
+            name=name,
+            slug=slug,
+            url="https://mcp.example.com",
+            auth_type=auth_type,
+            encrypted_bearer_token="enc" if auth_type == McpAuthType.BEARER else None,
+            token_fingerprint="fp" if auth_type == McpAuthType.BEARER else None,
+            token_suffix="abcd" if auth_type == McpAuthType.BEARER else None,
+            is_active=True,
+            tools_snapshot=tools or [],
+            tools_snapshot_at=now,
+            timeout_seconds=30,
+            created_at=now,
+            updated_at=now,
+            created_by_user_id=uuid4(),
+        )
+
+    @pytest.mark.integration
+    async def test_integration_save_find_list_and_delete(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        org = await self._seed_organization(session_factory)
+        repo = SQLAlchemyOrgMcpServerRepository(session_factory=session_factory)
+        tools = [McpToolSnapshot(name="search", description="Search docs", input_schema={"type": "object"})]
+        server = self._make_server(organization_id=org.id, tools=tools)
+
+        # When
+        await repo.save(server)
+        found_by_id = await repo.find_by_id(server.id, org.id)
+        found_by_slug = await repo.find_by_slug(org.id, "notion")
+        listed = await repo.list_by_org_id(org.id)
+        await repo.delete(server.id, org.id)
+        after_delete = await repo.list_by_org_id(org.id)
+
+        # Then
+        assert found_by_id is not None
+        assert found_by_id.name == "Notion"
+        assert found_by_id.tools_snapshot[0].name == "search"
+        assert found_by_slug is not None and found_by_slug.id == server.id
+        assert len(listed) == 1
+        assert after_delete == []
+
+    @pytest.mark.integration
+    async def test_integration_save_upserts_existing_server(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        org = await self._seed_organization(session_factory)
+        repo = SQLAlchemyOrgMcpServerRepository(session_factory=session_factory)
+        server = self._make_server(organization_id=org.id)
+        await repo.save(server)
+
+        # When — modify and save again
+        updated_server = server.with_updated_settings(
+            name="Notion v2",
+            url="https://new.example.com",
+            timeout_seconds=15,
+            updated_at=datetime.now(UTC),
+        ).deactivate()
+        await repo.save(updated_server)
+
+        # Then
+        reloaded = await repo.find_by_id(server.id, org.id)
+        assert reloaded is not None
+        assert reloaded.name == "Notion v2"
+        assert reloaded.url == "https://new.example.com"
+        assert reloaded.timeout_seconds == 15
+        assert reloaded.is_active is False
+
+    @pytest.mark.integration
+    async def test_integration_unique_constraint_on_org_slug(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        org = await self._seed_organization(session_factory)
+        repo = SQLAlchemyOrgMcpServerRepository(session_factory=session_factory)
+        first = self._make_server(organization_id=org.id, slug="duplicate")
+        second = self._make_server(organization_id=org.id, slug="duplicate")
+        await repo.save(first)
+
+        # When / Then
+        with pytest.raises(IntegrityError):
+            await repo.save(second)
+
+    @pytest.mark.integration
+    async def test_integration_find_by_id_scoped_to_org(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        org_a = await self._seed_organization(session_factory)
+        repo = SQLAlchemyOrgMcpServerRepository(session_factory=session_factory)
+        server = self._make_server(organization_id=org_a.id)
+        await repo.save(server)
+
+        # When / Then — looking up with a different org id must return None
+        other_org_id = uuid4()
+        assert await repo.find_by_id(server.id, other_org_id) is None

--- a/server/tests/integration/test_sqlalchemy_project_mcp_activation_repository.py
+++ b/server/tests/integration/test_sqlalchemy_project_mcp_activation_repository.py
@@ -1,0 +1,226 @@
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.entities.organization import Organization
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+from raggae.domain.entities.user import User
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.infrastructure.database.models import Base
+from raggae.infrastructure.database.repositories.sqlalchemy_org_mcp_server_repository import (
+    SQLAlchemyOrgMcpServerRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_organization_repository import (
+    SQLAlchemyOrganizationRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_project_mcp_activation_repository import (
+    SQLAlchemyProjectMcpActivationRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_project_repository import (
+    SQLAlchemyProjectRepository,
+)
+from raggae.infrastructure.database.repositories.sqlalchemy_user_repository import (
+    SQLAlchemyUserRepository,
+)
+
+
+class TestSQLAlchemyProjectMcpActivationRepository:
+    @pytest.fixture
+    async def session_factory(self) -> async_sessionmaker[AsyncSession]:
+        engine = create_async_engine(
+            "postgresql+asyncpg://test:test@localhost:5433/raggae_test",
+            echo=False,
+        )
+        try:
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.drop_all)
+                await conn.run_sync(Base.metadata.create_all)
+        except Exception as exc:  # pragma: no cover
+            pytest.skip(f"PostgreSQL test database is not reachable: {exc}")
+
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        yield factory
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+    async def _seed_user_org_project_and_server(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> tuple[UUID, UUID, UUID, UUID]:
+        now = datetime.now(UTC)
+        user_id = uuid4()
+        await SQLAlchemyUserRepository(session_factory=session_factory).save(
+            User(
+                id=user_id,
+                email="mcp-activation@example.com",
+                hashed_password="hashed",
+                full_name="MCP User",
+                is_active=True,
+                created_at=now,
+            )
+        )
+        org = Organization(
+            id=uuid4(),
+            name="Acme",
+            slug="acme",
+            description=None,
+            logo_url=None,
+            created_by_user_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        await SQLAlchemyOrganizationRepository(session_factory=session_factory).save(org)
+
+        project = Project(
+            id=uuid4(),
+            user_id=user_id,
+            name="P",
+            description="",
+            system_prompt="",
+            is_published=False,
+            created_at=now,
+            organization_id=org.id,
+        )
+        await SQLAlchemyProjectRepository(session_factory=session_factory).save(project)
+
+        server = OrgMcpServer(
+            id=uuid4(),
+            organization_id=org.id,
+            name="Notion",
+            slug="notion",
+            url="https://mcp.example.com",
+            auth_type=McpAuthType.NONE,
+            encrypted_bearer_token=None,
+            token_fingerprint=None,
+            token_suffix=None,
+            is_active=True,
+            tools_snapshot=[],
+            tools_snapshot_at=now,
+            timeout_seconds=30,
+            created_at=now,
+            updated_at=now,
+            created_by_user_id=user_id,
+        )
+        await SQLAlchemyOrgMcpServerRepository(session_factory=session_factory).save(server)
+        return user_id, org.id, project.id, server.id
+
+    @pytest.mark.integration
+    async def test_integration_save_find_list_and_delete(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        user_id, _org_id, project_id, server_id = await self._seed_user_org_project_and_server(
+            session_factory
+        )
+        repo = SQLAlchemyProjectMcpActivationRepository(session_factory=session_factory)
+        activation = ProjectMcpActivation(
+            project_id=project_id,
+            org_mcp_server_id=server_id,
+            is_active=True,
+            activated_at=datetime.now(UTC),
+            activated_by_user_id=user_id,
+        )
+
+        # When
+        await repo.save(activation)
+        found = await repo.find(project_id, server_id)
+        by_project = await repo.list_by_project_id(project_id)
+        by_server = await repo.list_by_org_mcp_server_id(server_id)
+        await repo.delete(project_id, server_id)
+        after = await repo.find(project_id, server_id)
+
+        # Then
+        assert found is not None and found.is_active is True
+        assert len(by_project) == 1
+        assert len(by_server) == 1
+        assert after is None
+
+    @pytest.mark.integration
+    async def test_integration_save_upserts_existing_activation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        user_id, _, project_id, server_id = await self._seed_user_org_project_and_server(session_factory)
+        repo = SQLAlchemyProjectMcpActivationRepository(session_factory=session_factory)
+        await repo.save(
+            ProjectMcpActivation(
+                project_id=project_id,
+                org_mcp_server_id=server_id,
+                is_active=True,
+                activated_at=datetime.now(UTC),
+                activated_by_user_id=user_id,
+            )
+        )
+
+        # When
+        await repo.save(
+            ProjectMcpActivation(
+                project_id=project_id,
+                org_mcp_server_id=server_id,
+                is_active=False,
+                activated_at=datetime.now(UTC),
+                activated_by_user_id=user_id,
+            )
+        )
+
+        # Then
+        reloaded = await repo.find(project_id, server_id)
+        assert reloaded is not None
+        assert reloaded.is_active is False
+
+    @pytest.mark.integration
+    async def test_integration_delete_by_server_id_cascades(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        user_id, _, project_id, server_id = await self._seed_user_org_project_and_server(session_factory)
+        repo = SQLAlchemyProjectMcpActivationRepository(session_factory=session_factory)
+        await repo.save(
+            ProjectMcpActivation(
+                project_id=project_id,
+                org_mcp_server_id=server_id,
+                is_active=True,
+                activated_at=datetime.now(UTC),
+                activated_by_user_id=user_id,
+            )
+        )
+
+        # When
+        await repo.delete_by_org_mcp_server_id(server_id)
+
+        # Then
+        assert await repo.list_by_org_mcp_server_id(server_id) == []
+
+    @pytest.mark.integration
+    async def test_integration_fk_cascade_on_server_delete(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # Given
+        user_id, org_id, project_id, server_id = await self._seed_user_org_project_and_server(session_factory)
+        activation_repo = SQLAlchemyProjectMcpActivationRepository(session_factory=session_factory)
+        server_repo = SQLAlchemyOrgMcpServerRepository(session_factory=session_factory)
+        await activation_repo.save(
+            ProjectMcpActivation(
+                project_id=project_id,
+                org_mcp_server_id=server_id,
+                is_active=True,
+                activated_at=datetime.now(UTC),
+                activated_by_user_id=user_id,
+            )
+        )
+
+        # When — supprimer le serveur déclenche le ON DELETE CASCADE en base
+        await server_repo.delete(server_id, org_id)
+
+        # Then
+        assert await activation_repo.find(project_id, server_id) is None

--- a/server/tests/unit/infrastructure/services/test_fernet_mcp_bearer_token_crypto_service.py
+++ b/server/tests/unit/infrastructure/services/test_fernet_mcp_bearer_token_crypto_service.py
@@ -1,0 +1,31 @@
+from raggae.infrastructure.services.fernet_mcp_bearer_token_crypto_service import (
+    FernetMcpBearerTokenCryptoService,
+)
+from raggae.infrastructure.services.fernet_provider_api_key_crypto_service import (
+    FernetProviderApiKeyCryptoService,
+)
+
+
+def _make_service() -> FernetMcpBearerTokenCryptoService:
+    # Static key for reproducible tests (Fernet keys are 32 url-safe base64 bytes)
+    test_key = "Z3JhdmlsZW8tdGVzdC1mZXJuZXQta2V5LXNlY3JldHM="
+    inner = FernetProviderApiKeyCryptoService(encryption_key=test_key)
+    return FernetMcpBearerTokenCryptoService(inner=inner)
+
+
+def test_encrypt_then_decrypt_returns_original_token() -> None:
+    service = _make_service()
+    token = "ghp_abcdefghij1234567890"
+
+    encrypted = service.encrypt(token)
+    decrypted = service.decrypt(encrypted)
+
+    assert encrypted != token
+    assert decrypted == token
+
+
+def test_fingerprint_is_stable() -> None:
+    service = _make_service()
+
+    assert service.fingerprint("same") == service.fingerprint("same")
+    assert service.fingerprint("same") != service.fingerprint("other")

--- a/server/tests/unit/infrastructure/services/test_http_mcp_client.py
+++ b/server/tests/unit/infrastructure/services/test_http_mcp_client.py
@@ -1,0 +1,248 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpCallTimeoutError,
+    McpHandshakeError,
+    McpToolNotFoundError,
+    McpUrlForbiddenError,
+)
+from raggae.infrastructure.services.http_mcp_client import HttpMcpClient
+
+
+def _json_response(payload: dict[str, Any], status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status_code=status,
+        headers={"Content-Type": "application/json"},
+        content=json.dumps(payload).encode("utf-8"),
+    )
+
+
+def _sse_response(payload: dict[str, Any]) -> httpx.Response:
+    body = f"event: message\ndata: {json.dumps(payload)}\n\n"
+    return httpx.Response(
+        status_code=200,
+        headers={"Content-Type": "text/event-stream"},
+        content=body.encode("utf-8"),
+    )
+
+
+def _make_client(*, transport: httpx.MockTransport) -> HttpMcpClient:
+    url_validator = AsyncMock()
+    url_validator.validate = AsyncMock(return_value=None)
+    return HttpMcpClient(
+        url_safety_validator=url_validator,
+        http_client_factory=lambda: httpx.AsyncClient(transport=transport),
+    )
+
+
+class TestHttpMcpClientListTools:
+    async def test_list_tools_parses_json_rpc_response(self) -> None:
+        # Given
+        seen_request: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_request["url"] = str(request.url)
+            seen_request["headers"] = dict(request.headers)
+            seen_request["body"] = json.loads(request.content.decode("utf-8"))
+            return _json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": seen_request["body"]["id"],
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "search",
+                                "description": "Search documents",
+                                "inputSchema": {"type": "object"},
+                            }
+                        ]
+                    },
+                }
+            )
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When
+        tools = await client.list_tools(url="https://mcp.example.com/")
+
+        # Then
+        assert len(tools) == 1
+        assert tools[0].name == "search"
+        assert tools[0].input_schema == {"type": "object"}
+        assert seen_request["body"]["method"] == "tools/list"
+        assert "application/json" in seen_request["headers"]["accept"]
+
+    async def test_list_tools_attaches_bearer_token(self) -> None:
+        # Given
+        seen_request: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_request["authorization"] = request.headers.get("authorization")
+            return _json_response({"jsonrpc": "2.0", "id": 1, "result": {"tools": []}})
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When
+        await client.list_tools(url="https://mcp.example.com/", bearer_token="my-token")
+
+        # Then
+        assert seen_request["authorization"] == "Bearer my-token"
+
+    async def test_list_tools_supports_sse_response(self) -> None:
+        # Given
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content.decode("utf-8"))
+            return _sse_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": body["id"],
+                    "result": {"tools": [{"name": "ping", "description": ""}]},
+                }
+            )
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When
+        tools = await client.list_tools(url="https://mcp.example.com/")
+
+        # Then
+        assert [t.name for t in tools] == ["ping"]
+
+    async def test_list_tools_raises_handshake_error_on_http_5xx(self) -> None:
+        # Given
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=503)
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When / Then
+        with pytest.raises(McpHandshakeError):
+            await client.list_tools(url="https://mcp.example.com/")
+
+    async def test_list_tools_raises_handshake_error_on_json_rpc_error(self) -> None:
+        # Given
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return _json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            )
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When / Then
+        with pytest.raises(McpHandshakeError):
+            await client.list_tools(url="https://mcp.example.com/")
+
+    async def test_list_tools_re_validates_url(self) -> None:
+        # Given
+        validator_calls: list[str] = []
+
+        class _RecordingValidator:
+            async def validate(self, url: str) -> None:
+                validator_calls.append(url)
+
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return _json_response({"jsonrpc": "2.0", "id": 1, "result": {"tools": []}})
+
+        client = HttpMcpClient(
+            url_safety_validator=_RecordingValidator(),
+            http_client_factory=lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+
+        # When
+        await client.list_tools(url="https://mcp.example.com/")
+
+        # Then
+        assert validator_calls == ["https://mcp.example.com/"]
+
+    async def test_list_tools_propagates_url_forbidden(self) -> None:
+        # Given
+        class _RejectingValidator:
+            async def validate(self, _url: str) -> None:
+                raise McpUrlForbiddenError("forbidden")
+
+        client = HttpMcpClient(
+            url_safety_validator=_RejectingValidator(),
+            http_client_factory=lambda: httpx.AsyncClient(),
+        )
+
+        # When / Then
+        with pytest.raises(McpUrlForbiddenError):
+            await client.list_tools(url="http://forbidden/")
+
+
+class TestHttpMcpClientCallTool:
+    async def test_call_tool_sends_method_and_arguments(self) -> None:
+        # Given
+        seen_request: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen_request["body"] = json.loads(request.content.decode("utf-8"))
+            return _json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": seen_request["body"]["id"],
+                    "result": {"content": [{"type": "text", "text": "ok"}], "isError": False},
+                }
+            )
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When
+        result = await client.call_tool(
+            url="https://mcp.example.com/",
+            tool="search",
+            arguments={"q": "hello"},
+            timeout_seconds=30,
+        )
+
+        # Then
+        assert seen_request["body"]["method"] == "tools/call"
+        assert seen_request["body"]["params"] == {"name": "search", "arguments": {"q": "hello"}}
+        assert result["isError"] is False
+
+    async def test_call_tool_translates_timeout(self) -> None:
+        # Given
+        def handler(_request: httpx.Request) -> httpx.Response:
+            raise httpx.ReadTimeout("timeout")
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When / Then
+        with pytest.raises(McpCallTimeoutError):
+            await client.call_tool(
+                url="https://mcp.example.com/",
+                tool="search",
+                arguments={},
+                timeout_seconds=1,
+            )
+
+    async def test_call_tool_translates_method_not_found_to_tool_not_found(self) -> None:
+        # Given
+        def handler(_request: httpx.Request) -> httpx.Response:
+            return _json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Tool 'foo' not found"},
+                }
+            )
+
+        client = _make_client(transport=httpx.MockTransport(handler))
+
+        # When / Then
+        with pytest.raises(McpToolNotFoundError):
+            await client.call_tool(
+                url="https://mcp.example.com/",
+                tool="foo",
+                arguments={},
+                timeout_seconds=30,
+            )

--- a/server/tests/unit/infrastructure/services/test_url_safety_validator_impl.py
+++ b/server/tests/unit/infrastructure/services/test_url_safety_validator_impl.py
@@ -1,0 +1,126 @@
+"""Tests anti-SSRF du UrlSafetyValidatorImpl.
+
+Couverture exhaustive des familles d'IP refusées :
+- IPv4 loopback (127/8), private (10/8, 172.16/12, 192.168/16),
+  link-local (169.254/16), multicast, broadcast.
+- IPv6 loopback (::1), link-local (fe80::/10), unique-local (fc00::/7).
+"""
+
+import pytest
+
+from raggae.domain.exceptions.mcp_exceptions import McpUrlForbiddenError
+from raggae.infrastructure.services.url_safety_validator_impl import (
+    UrlSafetyValidatorImpl,
+)
+
+
+class _StaticResolver:
+    def __init__(self, addresses: list[str]) -> None:
+        self._addresses = addresses
+
+    async def __call__(self, _host: str) -> list[str]:
+        return self._addresses
+
+
+class TestUrlSafetyValidatorImpl:
+    async def test_accepts_public_https_host(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["93.184.216.34"]))
+
+        await validator.validate("https://example.com/mcp")
+
+    async def test_rejects_http_scheme(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["93.184.216.34"]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("http://example.com/mcp")
+
+    async def test_rejects_scheme_other_than_http_https(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["93.184.216.34"]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("ftp://example.com/mcp")
+
+    async def test_rejects_url_without_host(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver([]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https:///path-only")
+
+    async def test_rejects_malformed_url(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver([]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("not a url")
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",
+            "127.0.0.5",
+            "127.255.255.255",
+            "10.0.0.1",
+            "10.255.0.5",
+            "172.16.0.1",
+            "172.31.255.254",
+            "192.168.1.1",
+            "169.254.169.254",
+            "224.0.0.1",
+            "255.255.255.255",
+            "0.0.0.0",
+        ],
+    )
+    async def test_rejects_ipv4_forbidden_ranges(self, ip: str) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver([ip]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://internal.example/mcp")
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "::1",
+            "fe80::1",
+            "fe80::abcd:1234",
+            "fc00::1",
+            "fd12:3456:789a::1",
+            "ff02::1",
+        ],
+    )
+    async def test_rejects_ipv6_forbidden_ranges(self, ip: str) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver([ip]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://internal.example/mcp")
+
+    async def test_rejects_when_any_resolved_ip_is_forbidden(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["93.184.216.34", "10.0.0.5"]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://mixed.example/mcp")
+
+    async def test_rejects_literal_ipv4_in_host(self) -> None:
+        # Avec un literal IP dans l'URL, le validator doit aussi détecter le risque.
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["127.0.0.1"]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://127.0.0.1/mcp")
+
+    async def test_accepts_when_all_resolved_ips_are_public(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver(["93.184.216.34", "2606:2800:220:1::1"]))
+
+        await validator.validate("https://mcp.example.com/")
+
+    async def test_rejects_when_dns_returns_no_address(self) -> None:
+        validator = UrlSafetyValidatorImpl(resolver=_StaticResolver([]))
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://unknown.example/")
+
+    async def test_rejects_when_resolver_raises(self) -> None:
+        async def _failing(_host: str) -> list[str]:
+            raise OSError("DNS failure")
+
+        validator = UrlSafetyValidatorImpl(resolver=_failing)
+
+        with pytest.raises(McpUrlForbiddenError):
+            await validator.validate("https://broken.example/")


### PR DESCRIPTION
## Problème

La PR 1 a posé le domaine et les use cases d'administration des MCP au niveau organisation, mais avec uniquement des ports application : aucune persistance, aucun client HTTP, pas de protection anti-SSRF. La fonctionnalité ne peut donc être ni testée en intégration ni exposée.

## Solution

Cette PR fournit l'infrastructure complète qui matérialise les ports introduits en PR 1 : migration Alembic, repositories SQLAlchemy, validation d'URL anti-SSRF, client HTTP/SSE pour le protocole MCP, et adapter de chiffrement réutilisant le service Fernet existant.

## Implémentation

- **Migration Alembic** (`20260629_46_add_org_mcp_servers_and_activations.py`)
  - Table `org_mcp_servers` : id PK, FK CASCADE vers `organizations`, contrainte unique `(organization_id, slug)`, colonne `tools_snapshot` en JSONB, défaut `timeout_seconds = 30`.
  - Table `project_mcp_activations` : clé composite `(project_id, org_mcp_server_id)`, FK CASCADE vers `projects` et `org_mcp_servers`.
  - `downgrade()` propre (drop tables + indexes).
- **Modèles SQLAlchemy** : `OrgMcpServerModel`, `ProjectMcpActivationModel` ; enregistrés dans `models/__init__.py` pour être visibles dans `Base.metadata` lors des tests d'intégration.
- **Repositories**
  - `SQLAlchemyOrgMcpServerRepository` : upsert par id, scoping `organization_id` sur toutes les lectures, méthodes `save`, `find_by_id`, `find_by_slug`, `list_by_org_id`, `delete`. Mapping JSONB ↔ `McpToolSnapshot`.
  - `SQLAlchemyProjectMcpActivationRepository` : upsert par PK composite, `delete_by_org_mcp_server_id` pour la cascade applicative déclenchée par le use case `DeleteOrgMcpServer`.
  - Versions `InMemory*` pour les tests et le mode dev local (`PERSISTENCE_BACKEND=inmemory`).
- **`UrlSafetyValidatorImpl`** (anti-SSRF)
  - Exige le scheme `https`.
  - Résout le hostname via DNS (resolver injectable), refuse toute adresse loopback, link-local, private, multicast, reserved ou unspecified, IPv4 comme IPv6.
  - Toute erreur de résolution ou IP interdite remonte un `McpUrlForbiddenError`.
- **`HttpMcpClient`** (port `McpClient`)
  - Transport Streamable HTTP : POST JSON-RPC 2.0 sur l'endpoint MCP avec en-tête `MCP-Protocol-Version: 2025-06-18`.
  - Accepte les réponses `application/json` (envelope JSON-RPC unique) et `text/event-stream` (parsing SSE jusqu'au payload avec l'id attendu).
  - Re-valide l'URL via `UrlSafetyValidator` avant chaque appel.
  - Traduit timeouts → `McpCallTimeoutError`, erreurs JSON-RPC `-32601`/`-32602` sur `tools/call` → `McpToolNotFoundError`, autres erreurs HTTP/JSON-RPC → `McpHandshakeError`.
- **`FernetMcpBearerTokenCryptoService`** : adapter qui délègue au `FernetProviderApiKeyCryptoService` existant — même clé, même algo, sans coupler les deux domaines côté application.

## Tests

- **40 tests unitaires** ajoutés :
  - `UrlSafetyValidatorImpl` : 28 tests paramétrés couvrant chaque famille d'IPs interdites IPv4 et IPv6 + erreurs DNS.
  - `HttpMcpClient` : 10 tests via `httpx.MockTransport` (JSON, SSE, bearer, 5xx, JSON-RPC error, URL forbidden, timeout, tool not found).
  - `FernetMcpBearerTokenCryptoService` : 2 tests (round-trip + fingerprint stable).
- **8 tests d'intégration** PostgreSQL (skippés si la base de test n'est pas joignable) couvrant CRUD, upsert, unique constraint sur le slug, scoping par organisation et cascade FK.
- Aucun test cassé : **1035 passed, 0 failed, 43 skipped**.

## Recette

1. Récupérer la branche, installer, appliquer la migration :
   ```bash
   cd server && source .venv/bin/activate
   alembic upgrade head        # 20260629_46 applique les deux tables MCP
   alembic downgrade -1        # vérification du downgrade
   alembic upgrade head
   ```
2. Lancer le pipeline qualité :
   ```bash
   pytest                      # 1035 passed, 0 failed, 43 skipped
   ruff format src/ tests/
   ruff check src/ tests/
   mypy src/
   ```
3. Vérifier les tests d'intégration avec un Postgres de test (port 5433, user/db `raggae_test`) :
   ```bash
   pytest tests/integration/test_sqlalchemy_org_mcp_server_repository.py \
          tests/integration/test_sqlalchemy_project_mcp_activation_repository.py -v
   ```
4. Lire `docs/MCP_FEATURE_PLAN.md` (section PR 3) pour la suite : endpoints REST et UI org.

Aucun endpoint ni branchement DI n'est ajouté dans cette PR : aucun comportement existant n'est affecté.