### PR TITLE
feat(mcp): activations MCP par projet (PR 4/6)

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -164,10 +164,24 @@
     },
     "settings": {
       "notFound": "Project not found",
+      "mcp": {
+        "title": "MCP servers",
+        "description": "Activate the MCP servers your organization declared. Their tools will be exposed to the LLM during conversations.",
+        "providerWarning": "Tool calling requires a provider that supports it (OpenAI, Anthropic, Gemini, Mistral). Other backends will ignore activated MCP servers.",
+        "empty": "No MCP server is available for this project. Ask an organization owner to declare one.",
+        "toolsCount": "{count} tools",
+        "viewTools": "View tools",
+        "toolsTitle": "Tools exposed by {name}",
+        "toolsLastRefresh": "Last refreshed on {date}",
+        "activated": "MCP server activated for this project",
+        "deactivated": "MCP server deactivated for this project",
+        "toggleError": "Failed to toggle MCP server"
+      },
       "tabs": {
         "general": "General",
         "instructions": "Instructions",
         "knowledge": "Knowledge",
+        "mcp": "MCP",
         "advanced": "Advanced",
         "publication": "Publication",
         "models": "Models",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -164,10 +164,24 @@
     },
     "settings": {
       "notFound": "Projet introuvable",
+      "mcp": {
+        "title": "Serveurs MCP",
+        "description": "Activez les serveurs MCP déclarés par votre organisation. Leurs outils seront exposés au LLM pendant les conversations.",
+        "providerWarning": "Le tool calling requiert un provider compatible (OpenAI, Anthropic, Gemini, Mistral). Les autres backends ignoreront les serveurs MCP activés.",
+        "empty": "Aucun serveur MCP n'est disponible pour ce projet. Demandez à un owner de l'organisation d'en déclarer un.",
+        "toolsCount": "{count} outils",
+        "viewTools": "Voir les outils",
+        "toolsTitle": "Outils exposés par {name}",
+        "toolsLastRefresh": "Dernier rafraîchissement le {date}",
+        "activated": "Serveur MCP activé pour ce projet",
+        "deactivated": "Serveur MCP désactivé pour ce projet",
+        "toggleError": "Erreur lors du basculement du serveur MCP"
+      },
       "tabs": {
         "general": "Général",
         "instructions": "Instructions",
         "knowledge": "Connaissances",
+        "mcp": "MCP",
         "advanced": "Avancé",
         "publication": "Publication",
         "models": "Modèles",

--- a/client/src/components/organisms/project/settings/project-mcp-panel.tsx
+++ b/client/src/components/organisms/project/settings/project-mcp-panel.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { McpStatusBadge } from "@/components/atoms/mcp/mcp-status-badge";
+import { McpToolsList } from "@/components/molecules/mcp/mcp-tools-list";
+import { Card } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import {
+  useActivateProjectMcp,
+  useDeactivateProjectMcp,
+  useProjectMcpActivations,
+} from "@/lib/hooks/use-project-mcp-activations";
+import type { OrgMcpServerResponse } from "@/lib/types/api";
+
+type ProjectMcpPanelProps = {
+  projectId: string;
+};
+
+export function ProjectMcpPanel({ projectId }: ProjectMcpPanelProps) {
+  const t = useTranslations("projects.settings.mcp");
+
+  const { data: views, isLoading } = useProjectMcpActivations(projectId);
+  const activate = useActivateProjectMcp(projectId);
+  const deactivate = useDeactivateProjectMcp(projectId);
+
+  const [openServer, setOpenServer] = useState<OrgMcpServerResponse | null>(null);
+
+  function handleToggle(server: OrgMcpServerResponse, isActivated: boolean) {
+    if (isActivated) {
+      deactivate.mutate(server.id, {
+        onSuccess: () => toast.success(t("deactivated")),
+        onError: () => toast.error(t("toggleError")),
+      });
+    } else {
+      activate.mutate(server.id, {
+        onSuccess: () => toast.success(t("activated")),
+        onError: (error) =>
+          toast.error((error as Error).message || t("toggleError")),
+      });
+    }
+  }
+
+  return (
+    <Card className="space-y-4 p-5">
+      <div className="space-y-1">
+        <h2 className="text-lg font-medium">{t("title")}</h2>
+        <p className="text-sm text-muted-foreground">{t("description")}</p>
+        <p className="text-xs text-amber-700 dark:text-amber-400">{t("providerWarning")}</p>
+      </div>
+
+      {isLoading ? (
+        <Skeleton className="h-14 w-full" />
+      ) : views?.length ? (
+        <div className="space-y-2">
+          {views.map((view) => {
+            const server = view.org_mcp_server;
+            return (
+              <div
+                key={server.id}
+                className="flex flex-wrap items-center justify-between gap-3 rounded-md border bg-card p-3"
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="text-sm font-medium">{server.name}</p>
+                  <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                    {server.slug}
+                  </span>
+                  <McpStatusBadge isActive={view.is_activated} />
+                  <span className="text-xs text-muted-foreground">
+                    {t("toolsCount", { count: server.tools_snapshot.length })}
+                  </span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={view.is_activated}
+                    disabled={activate.isPending || deactivate.isPending}
+                    onCheckedChange={() => handleToggle(server, view.is_activated)}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="cursor-pointer"
+                    onClick={() => setOpenServer(server)}
+                  >
+                    {t("viewTools")}
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">{t("empty")}</p>
+      )}
+
+      <Dialog
+        open={openServer !== null}
+        onOpenChange={(open) => !open && setOpenServer(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {openServer ? t("toolsTitle", { name: openServer.name }) : ""}
+            </DialogTitle>
+            <DialogDescription>
+              {openServer
+                ? t("toolsLastRefresh", {
+                    date: new Date(openServer.tools_snapshot_at).toLocaleString(),
+                  })
+                : ""}
+            </DialogDescription>
+          </DialogHeader>
+          {openServer && <McpToolsList tools={openServer.tools_snapshot} />}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+}

--- a/client/src/components/templates/project/project-settings-template.tsx
+++ b/client/src/components/templates/project/project-settings-template.tsx
@@ -9,11 +9,18 @@ import { PageTemplate } from "@/components/templates/page-template";
 import { ProjectGeneralPanel } from "@/components/organisms/project/settings/project-general-panel";
 import { ProjectInstructionsPanel } from "@/components/organisms/project/settings/project-instructions-panel";
 import { ProjectKnowledgePanel } from "@/components/organisms/project/settings/project-knowledge-panel";
+import { ProjectMcpPanel } from "@/components/organisms/project/settings/project-mcp-panel";
 import { ProjectAdvancedPanel } from "@/components/organisms/project/settings/project-advanced-panel";
 import { ProjectName } from "@/components/organisms/project/project-name";
 import { ProjectSnapshotsSheet } from "@/components/organisms/project/project-snapshots-sheet";
 
-const SETTINGS_TABS = ["General", "Instructions", "Knowledge", "Advanced"] as const;
+const SETTINGS_TABS = [
+  "General",
+  "Instructions",
+  "Knowledge",
+  "MCP",
+  "Advanced",
+] as const;
 type SettingsTab = (typeof SETTINGS_TABS)[number];
 
 interface ProjectSettingsTemplateProps {
@@ -35,6 +42,7 @@ export function ProjectSettingsTemplate({ projectId }: ProjectSettingsTemplatePr
     General: t("tabs.general"),
     Instructions: t("tabs.instructions"),
     Knowledge: t("tabs.knowledge"),
+    MCP: t("tabs.mcp"),
     Advanced: t("tabs.advanced"),
   };
 
@@ -89,6 +97,7 @@ export function ProjectSettingsTemplate({ projectId }: ProjectSettingsTemplatePr
         {activeTab === "General" && <ProjectGeneralPanel projectId={projectId} />}
         {activeTab === "Instructions" && <ProjectInstructionsPanel projectId={projectId} />}
         {activeTab === "Knowledge" && <ProjectKnowledgePanel projectId={projectId} />}
+        {activeTab === "MCP" && <ProjectMcpPanel projectId={projectId} />}
         {activeTab === "Advanced" && <ProjectAdvancedPanel projectId={projectId} />}
       </div>
 

--- a/client/src/lib/api/project-mcp-activations.ts
+++ b/client/src/lib/api/project-mcp-activations.ts
@@ -1,0 +1,34 @@
+import { apiFetch } from "@/lib/api/client";
+import type { ProjectMcpActivationViewResponse } from "@/lib/types/api";
+
+export function listProjectMcpActivations(
+  token: string,
+  projectId: string,
+): Promise<ProjectMcpActivationViewResponse[]> {
+  return apiFetch<ProjectMcpActivationViewResponse[]>(
+    `/projects/${projectId}/mcp-activations`,
+    { token },
+  );
+}
+
+export function activateProjectMcp(
+  token: string,
+  projectId: string,
+  mcpServerId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/projects/${projectId}/mcp-activations/${mcpServerId}`,
+    { method: "POST", token },
+  );
+}
+
+export function deactivateProjectMcp(
+  token: string,
+  projectId: string,
+  mcpServerId: string,
+): Promise<void> {
+  return apiFetch<void>(
+    `/projects/${projectId}/mcp-activations/${mcpServerId}`,
+    { method: "DELETE", token },
+  );
+}

--- a/client/src/lib/hooks/use-project-mcp-activations.ts
+++ b/client/src/lib/hooks/use-project-mcp-activations.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  activateProjectMcp,
+  deactivateProjectMcp,
+  listProjectMcpActivations,
+} from "@/lib/api/project-mcp-activations";
+import { useAuth } from "./use-auth";
+
+const queryKey = (projectId: string | null | undefined) =>
+  ["project-mcp-activations", projectId] as const;
+
+export function useProjectMcpActivations(projectId: string | null | undefined) {
+  const { token } = useAuth();
+
+  return useQuery({
+    queryKey: queryKey(projectId),
+    queryFn: () => listProjectMcpActivations(token!, projectId!),
+    enabled: !!token && !!projectId,
+  });
+}
+
+export function useActivateProjectMcp(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (mcpServerId: string) =>
+      activateProjectMcp(token!, projectId, mcpServerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKey(projectId) });
+    },
+  });
+}
+
+export function useDeactivateProjectMcp(projectId: string) {
+  const { token } = useAuth();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (mcpServerId: string) =>
+      deactivateProjectMcp(token!, projectId, mcpServerId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKey(projectId) });
+    },
+  });
+}

--- a/client/src/lib/types/api.ts
+++ b/client/src/lib/types/api.ts
@@ -513,3 +513,8 @@ export interface UpdateOrgMcpServerRequest {
   auth_type: McpAuthType | null;
   bearer_token: string | null;
 }
+
+export interface ProjectMcpActivationViewResponse {
+  org_mcp_server: OrgMcpServerResponse;
+  is_activated: boolean;
+}

--- a/client/tests/components/organisms/project/project-mcp-panel.test.tsx
+++ b/client/tests/components/organisms/project/project-mcp-panel.test.tsx
@@ -1,0 +1,77 @@
+import { screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectMcpPanel } from "@/components/organisms/project/settings/project-mcp-panel";
+import type { ProjectMcpActivationViewResponse } from "@/lib/types/api";
+import { renderWithProviders } from "../../../helpers/render";
+
+vi.mock("@/lib/hooks/use-auth", () => ({
+  useAuth: () => ({ token: "mock-token", user: { id: "user-1" } }),
+}));
+
+const mockState: {
+  views: ProjectMcpActivationViewResponse[];
+  isLoading: boolean;
+} = { views: [], isLoading: false };
+
+vi.mock("@/lib/hooks/use-project-mcp-activations", () => ({
+  useProjectMcpActivations: () => ({
+    data: mockState.views,
+    isLoading: mockState.isLoading,
+  }),
+  useActivateProjectMcp: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeactivateProjectMcp: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+function makeView(
+  overrides: Partial<ProjectMcpActivationViewResponse> = {},
+): ProjectMcpActivationViewResponse {
+  const now = new Date().toISOString();
+  return {
+    org_mcp_server: {
+      id: "srv-1",
+      organization_id: "org-1",
+      name: "Notion",
+      slug: "notion",
+      url: "https://mcp.notion.test/",
+      auth_type: "bearer",
+      masked_token: "...wxyz",
+      is_active: true,
+      tools_snapshot: [
+        { name: "search", description: "Search", input_schema: {} },
+      ],
+      tools_snapshot_at: now,
+      timeout_seconds: 30,
+      created_at: now,
+      updated_at: now,
+    },
+    is_activated: false,
+    ...overrides,
+  };
+}
+
+describe("ProjectMcpPanel", () => {
+  beforeEach(() => {
+    mockState.views = [];
+    mockState.isLoading = false;
+  });
+
+  it("renders title and provider warning", () => {
+    renderWithProviders(<ProjectMcpPanel projectId="prj-1" />);
+    expect(screen.getByRole("heading", { name: /mcp servers/i })).toBeInTheDocument();
+    expect(screen.getByText(/tool calling requires a provider/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when no MCP server is available", () => {
+    renderWithProviders(<ProjectMcpPanel projectId="prj-1" />);
+    expect(screen.getByText(/no mcp server is available/i)).toBeInTheDocument();
+  });
+
+  it("lists each available server with its activation status", () => {
+    mockState.views = [makeView({ is_activated: true })];
+    renderWithProviders(<ProjectMcpPanel projectId="prj-1" />);
+
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+    expect(screen.getByText("notion")).toBeInTheDocument();
+    expect(screen.getByText(/1 tools/i)).toBeInTheDocument();
+  });
+});

--- a/server/src/raggae/application/dto/project_mcp_activation_view_dto.py
+++ b/server/src/raggae/application/dto/project_mcp_activation_view_dto.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+
+
+@dataclass(frozen=True)
+class ProjectMcpActivationViewDTO:
+    """Aggregated view of an MCP server with its activation status for a project."""
+
+    org_mcp_server: OrgMcpServerDTO
+    is_activated: bool

--- a/server/src/raggae/application/use_cases/project_mcp/_access.py
+++ b/server/src/raggae/application/use_cases/project_mcp/_access.py
@@ -1,0 +1,41 @@
+"""Shared project-access checks for project_mcp use cases."""
+
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.entities.project import Project
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+
+
+async def load_project_for_user(
+    *,
+    project_id: UUID,
+    user_id: UUID,
+    project_repository: ProjectRepository,
+    organization_member_repository: OrganizationMemberRepository,
+) -> Project:
+    """Load a project and ensure the user can access it.
+
+    Access rules (V1, MCP activations):
+    - The user is the owner of a user-owned project, or
+    - The project is org-owned and the user is a member of that organization (any role).
+
+    Raises `ProjectNotFoundError` to avoid leaking the existence of inaccessible projects.
+    """
+    project = await project_repository.find_by_id(project_id)
+    if project is None:
+        raise ProjectNotFoundError(f"Project {project_id} not found")
+    if project.user_id == user_id:
+        return project
+    if project.organization_id is None:
+        raise ProjectNotFoundError(f"Project {project_id} not found")
+    member = await organization_member_repository.find_by_organization_and_user(
+        organization_id=project.organization_id,
+        user_id=user_id,
+    )
+    if member is None:
+        raise ProjectNotFoundError(f"Project {project_id} not found")
+    return project

--- a/server/src/raggae/application/use_cases/project_mcp/activate_project_mcp.py
+++ b/server/src/raggae/application/use_cases/project_mcp/activate_project_mcp.py
@@ -1,0 +1,61 @@
+from datetime import UTC, datetime
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_mcp_activation_repository import (
+    ProjectMcpActivationRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.use_cases.project_mcp._access import load_project_for_user
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpAccessDeniedError,
+    McpServerNotFoundError,
+)
+
+
+class ActivateProjectMcp:
+    """Use case: activate one organization MCP server for a project."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        project_mcp_activation_repository: ProjectMcpActivationRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._org_mcp_server_repository = org_mcp_server_repository
+        self._activation_repository = project_mcp_activation_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, project_id: UUID, mcp_server_id: UUID, user_id: UUID) -> None:
+        project = await load_project_for_user(
+            project_id=project_id,
+            user_id=user_id,
+            project_repository=self._project_repository,
+            organization_member_repository=self._member_repository,
+        )
+        if project.organization_id is None:
+            raise McpAccessDeniedError(f"Project {project_id} has no organization and cannot use MCP servers")
+
+        server = await self._org_mcp_server_repository.find_by_id(mcp_server_id, project.organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {mcp_server_id} not found")
+        if not server.is_active:
+            raise McpAccessDeniedError(f"MCP server {mcp_server_id} is deactivated at organization level")
+
+        await self._activation_repository.save(
+            ProjectMcpActivation(
+                project_id=project_id,
+                org_mcp_server_id=mcp_server_id,
+                is_active=True,
+                activated_at=datetime.now(UTC),
+                activated_by_user_id=user_id,
+            )
+        )

--- a/server/src/raggae/application/use_cases/project_mcp/deactivate_project_mcp.py
+++ b/server/src/raggae/application/use_cases/project_mcp/deactivate_project_mcp.py
@@ -1,0 +1,49 @@
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_mcp_activation_repository import (
+    ProjectMcpActivationRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.use_cases.project_mcp._access import load_project_for_user
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpAccessDeniedError,
+    McpServerNotFoundError,
+)
+
+
+class DeactivateProjectMcp:
+    """Use case: deactivate one MCP server for a project (deletes the activation row)."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        project_mcp_activation_repository: ProjectMcpActivationRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._org_mcp_server_repository = org_mcp_server_repository
+        self._activation_repository = project_mcp_activation_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, project_id: UUID, mcp_server_id: UUID, user_id: UUID) -> None:
+        project = await load_project_for_user(
+            project_id=project_id,
+            user_id=user_id,
+            project_repository=self._project_repository,
+            organization_member_repository=self._member_repository,
+        )
+        if project.organization_id is None:
+            raise McpAccessDeniedError(f"Project {project_id} has no organization and cannot use MCP servers")
+
+        server = await self._org_mcp_server_repository.find_by_id(mcp_server_id, project.organization_id)
+        if server is None:
+            raise McpServerNotFoundError(f"MCP server {mcp_server_id} not found")
+
+        await self._activation_repository.delete(project_id, mcp_server_id)

--- a/server/src/raggae/application/use_cases/project_mcp/list_project_mcp_activations.py
+++ b/server/src/raggae/application/use_cases/project_mcp/list_project_mcp_activations.py
@@ -1,0 +1,58 @@
+from uuid import UUID
+
+from raggae.application.dto.project_mcp_activation_view_dto import ProjectMcpActivationViewDTO
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.organization_member_repository import (
+    OrganizationMemberRepository,
+)
+from raggae.application.interfaces.repositories.project_mcp_activation_repository import (
+    ProjectMcpActivationRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.application.use_cases.org_mcp._mapping import to_dto
+from raggae.application.use_cases.project_mcp._access import load_project_for_user
+
+
+class ListProjectMcpActivations:
+    """Use case: list MCP servers available to a project with their activation status."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        project_mcp_activation_repository: ProjectMcpActivationRepository,
+        organization_member_repository: OrganizationMemberRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._org_mcp_server_repository = org_mcp_server_repository
+        self._activation_repository = project_mcp_activation_repository
+        self._member_repository = organization_member_repository
+
+    async def execute(self, project_id: UUID, user_id: UUID) -> list[ProjectMcpActivationViewDTO]:
+        project = await load_project_for_user(
+            project_id=project_id,
+            user_id=user_id,
+            project_repository=self._project_repository,
+            organization_member_repository=self._member_repository,
+        )
+        if project.organization_id is None:
+            return []
+
+        org_servers = await self._org_mcp_server_repository.list_by_org_id(project.organization_id)
+        activations = await self._activation_repository.list_by_project_id(project_id)
+        activation_by_server = {a.org_mcp_server_id: a for a in activations}
+
+        views: list[ProjectMcpActivationViewDTO] = []
+        for server in org_servers:
+            if not server.is_active:
+                continue
+            activation = activation_by_server.get(server.id)
+            views.append(
+                ProjectMcpActivationViewDTO(
+                    org_mcp_server=to_dto(server),
+                    is_activated=activation is not None and activation.is_active,
+                )
+            )
+        return views

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -211,6 +211,15 @@ from raggae.application.use_cases.project.reindex_project import ReindexProject
 from raggae.application.use_cases.project.unpublish_project import UnpublishProject
 from raggae.application.use_cases.project.update_project import UpdateProject
 from raggae.application.use_cases.project.update_project_configuration import UpdateProjectConfiguration
+from raggae.application.use_cases.project_mcp.activate_project_mcp import (
+    ActivateProjectMcp,
+)
+from raggae.application.use_cases.project_mcp.deactivate_project_mcp import (
+    DeactivateProjectMcp,
+)
+from raggae.application.use_cases.project_mcp.list_project_mcp_activations import (
+    ListProjectMcpActivations,
+)
 from raggae.application.use_cases.project_snapshot.get_project_snapshot import GetProjectSnapshot
 from raggae.application.use_cases.project_snapshot.list_project_snapshots import ListProjectSnapshots
 from raggae.application.use_cases.project_snapshot.restore_project_snapshot import (
@@ -1236,6 +1245,33 @@ def get_delete_org_mcp_server_use_case() -> DeleteOrgMcpServer:
         org_mcp_server_repository=_org_mcp_server_repository,
         organization_member_repository=_organization_member_repository,
         project_mcp_activation_repository=_project_mcp_activation_repository,
+    )
+
+
+def get_list_project_mcp_activations_use_case() -> ListProjectMcpActivations:
+    return ListProjectMcpActivations(
+        project_repository=_project_repository,
+        org_mcp_server_repository=_org_mcp_server_repository,
+        project_mcp_activation_repository=_project_mcp_activation_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_activate_project_mcp_use_case() -> ActivateProjectMcp:
+    return ActivateProjectMcp(
+        project_repository=_project_repository,
+        org_mcp_server_repository=_org_mcp_server_repository,
+        project_mcp_activation_repository=_project_mcp_activation_repository,
+        organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_deactivate_project_mcp_use_case() -> DeactivateProjectMcp:
+    return DeactivateProjectMcp(
+        project_repository=_project_repository,
+        org_mcp_server_repository=_org_mcp_server_repository,
+        project_mcp_activation_repository=_project_mcp_activation_repository,
+        organization_member_repository=_organization_member_repository,
     )
 
 

--- a/server/src/raggae/presentation/api/v1/endpoints/project_mcp_activations.py
+++ b/server/src/raggae/presentation/api/v1/endpoints/project_mcp_activations.py
@@ -1,0 +1,123 @@
+import logging
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from raggae.application.dto.org_mcp_server_dto import OrgMcpServerDTO
+from raggae.application.use_cases.project_mcp.activate_project_mcp import ActivateProjectMcp
+from raggae.application.use_cases.project_mcp.deactivate_project_mcp import DeactivateProjectMcp
+from raggae.application.use_cases.project_mcp.list_project_mcp_activations import (
+    ListProjectMcpActivations,
+)
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpAccessDeniedError,
+    McpServerNotFoundError,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.presentation.api.dependencies import (
+    get_activate_project_mcp_use_case,
+    get_current_user_id,
+    get_deactivate_project_mcp_use_case,
+    get_list_project_mcp_activations_use_case,
+)
+from raggae.presentation.api.v1.schemas.org_mcp_server_schemas import (
+    McpToolSnapshotResponse,
+    OrgMcpServerResponse,
+)
+from raggae.presentation.api.v1.schemas.project_mcp_activation_schemas import (
+    ProjectMcpActivationViewResponse,
+)
+
+router = APIRouter(
+    prefix="/projects/{project_id}/mcp-activations",
+    tags=["project-mcp-activations"],
+    dependencies=[Depends(get_current_user_id)],
+)
+logger = logging.getLogger(__name__)
+
+
+def _server_dto_to_response(dto: OrgMcpServerDTO) -> OrgMcpServerResponse:
+    return OrgMcpServerResponse(
+        id=dto.id,
+        organization_id=dto.organization_id,
+        name=dto.name,
+        slug=dto.slug,
+        url=dto.url,
+        auth_type=dto.auth_type,
+        masked_token=dto.masked_token,
+        is_active=dto.is_active,
+        tools_snapshot=[
+            McpToolSnapshotResponse(
+                name=t.name,
+                description=t.description,
+                input_schema=t.input_schema,
+            )
+            for t in dto.tools_snapshot
+        ],
+        tools_snapshot_at=dto.tools_snapshot_at,
+        timeout_seconds=dto.timeout_seconds,
+        created_at=dto.created_at,
+        updated_at=dto.updated_at,
+    )
+
+
+@router.get("")
+async def list_project_mcp_activations(
+    project_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ListProjectMcpActivations, Depends(get_list_project_mcp_activations_use_case)],
+) -> list[ProjectMcpActivationViewResponse]:
+    try:
+        views = await use_case.execute(project_id=project_id, user_id=user_id)
+    except ProjectNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found") from exc
+    return [
+        ProjectMcpActivationViewResponse(
+            org_mcp_server=_server_dto_to_response(view.org_mcp_server),
+            is_activated=view.is_activated,
+        )
+        for view in views
+    ]
+
+
+@router.post("/{mcp_server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def activate_project_mcp(
+    project_id: UUID,
+    mcp_server_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[ActivateProjectMcp, Depends(get_activate_project_mcp_use_case)],
+) -> None:
+    try:
+        await use_case.execute(project_id=project_id, mcp_server_id=mcp_server_id, user_id=user_id)
+    except ProjectNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found") from exc
+    except McpServerNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found") from exc
+    except McpAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc
+    logger.info(
+        "project_mcp_activated",
+        extra={
+            "project_id": str(project_id),
+            "mcp_server_id": str(mcp_server_id),
+            "user_id": str(user_id),
+        },
+    )
+
+
+@router.delete("/{mcp_server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def deactivate_project_mcp(
+    project_id: UUID,
+    mcp_server_id: UUID,
+    user_id: Annotated[UUID, Depends(get_current_user_id)],
+    use_case: Annotated[DeactivateProjectMcp, Depends(get_deactivate_project_mcp_use_case)],
+) -> None:
+    try:
+        await use_case.execute(project_id=project_id, mcp_server_id=mcp_server_id, user_id=user_id)
+    except ProjectNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found") from exc
+    except McpServerNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found") from exc
+    except McpAccessDeniedError as exc:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(exc)) from exc

--- a/server/src/raggae/presentation/api/v1/schemas/project_mcp_activation_schemas.py
+++ b/server/src/raggae/presentation/api/v1/schemas/project_mcp_activation_schemas.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from raggae.presentation.api.v1.schemas.org_mcp_server_schemas import OrgMcpServerResponse
+
+
+class ProjectMcpActivationViewResponse(BaseModel):
+    org_mcp_server: OrgMcpServerResponse
+    is_activated: bool

--- a/server/src/raggae/presentation/main.py
+++ b/server/src/raggae/presentation/main.py
@@ -23,6 +23,9 @@ from raggae.presentation.api.v1.endpoints.org_model_credentials import (
     router as org_model_credentials_router,
 )
 from raggae.presentation.api.v1.endpoints.organizations import router as organizations_router
+from raggae.presentation.api.v1.endpoints.project_mcp_activations import (
+    router as project_mcp_activations_router,
+)
 from raggae.presentation.api.v1.endpoints.project_snapshots import (
     router as project_snapshots_router,
 )
@@ -85,6 +88,7 @@ app.include_router(model_catalog_router, prefix="/api/v1")
 app.include_router(model_credentials_router, prefix="/api/v1")
 app.include_router(org_model_credentials_router, prefix="/api/v1")
 app.include_router(org_mcp_servers_router, prefix="/api/v1")
+app.include_router(project_mcp_activations_router, prefix="/api/v1")
 app.include_router(stats_router, prefix="/api/v1")
 app.include_router(system_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")

--- a/server/tests/e2e/test_project_mcp_activation_endpoints.py
+++ b/server/tests/e2e/test_project_mcp_activation_endpoints.py
@@ -1,0 +1,189 @@
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+class _FakeUrlSafetyValidator:
+    async def validate(self, _url: str) -> None:
+        return None
+
+
+class _FakeMcpClient:
+    def __init__(self) -> None:
+        self.tools = [McpToolSnapshot(name="search", description="Search", input_schema={})]
+
+    async def list_tools(self, url: str, bearer_token: str | None = None) -> list[McpToolSnapshot]:
+        return list(self.tools)
+
+    async def call_tool(self, *args: object, **kwargs: object) -> dict[str, object]:
+        return {}
+
+
+@pytest.fixture
+async def fake_mcp_services() -> AsyncIterator[None]:
+    from raggae.presentation.api import dependencies
+
+    original_validator = dependencies._url_safety_validator
+    original_client = dependencies._mcp_client
+    dependencies._url_safety_validator = _FakeUrlSafetyValidator()
+    dependencies._mcp_client = _FakeMcpClient()
+    try:
+        yield
+    finally:
+        dependencies._url_safety_validator = original_validator
+        dependencies._mcp_client = original_client
+
+
+class TestProjectMcpActivationEndpoints:
+    async def _auth_headers(self, client: AsyncClient) -> dict[str, str]:
+        unique = uuid4().hex
+        email = f"{unique}@example.com"
+        await client.post(
+            "/api/v1/auth/register",
+            json={
+                "email": email,
+                "password": "SecurePass123!",
+                "full_name": "MCP User",
+            },
+        )
+        login = await client.post(
+            "/api/v1/auth/login",
+            json={"email": email, "password": "SecurePass123!"},
+        )
+        return {"Authorization": f"Bearer {login.json()['access_token']}"}
+
+    async def _create_org(self, client: AsyncClient, headers: dict[str, str]) -> str:
+        response = await client.post(
+            "/api/v1/organizations",
+            json={"name": "Acme", "description": "MCP test"},
+            headers=headers,
+        )
+        return response.json()["id"]
+
+    async def _create_org_project(self, client: AsyncClient, headers: dict[str, str], org_id: str) -> str:
+        response = await client.post(
+            "/api/v1/projects",
+            json={
+                "name": "Project A",
+                "description": "MCP project",
+                "organization_id": org_id,
+            },
+            headers=headers,
+        )
+        assert response.status_code == 201, response.text
+        return response.json()["id"]
+
+    async def _declare_mcp(
+        self,
+        client: AsyncClient,
+        headers: dict[str, str],
+        org_id: str,
+        slug: str = "notion",
+    ) -> str:
+        response = await client.post(
+            f"/api/v1/organizations/{org_id}/mcp-servers",
+            json={
+                "name": slug.capitalize(),
+                "url": f"https://mcp.{slug}.test/",
+                "auth_type": "none",
+                "bearer_token": None,
+                "timeout_seconds": 30,
+            },
+            headers=headers,
+        )
+        assert response.status_code == 201, response.text
+        return response.json()["id"]
+
+    async def test_list_activate_deactivate_cycle(
+        self,
+        client: AsyncClient,
+        fake_mcp_services: None,  # noqa: ARG002 — fixture only sets up state
+    ) -> None:
+        headers = await self._auth_headers(client)
+        org_id = await self._create_org(client, headers)
+        project_id = await self._create_org_project(client, headers, org_id)
+        mcp_id = await self._declare_mcp(client, headers, org_id)
+
+        # Initially listed but not activated
+        listed = await client.get(f"/api/v1/projects/{project_id}/mcp-activations", headers=headers)
+        assert listed.status_code == 200
+        views = listed.json()
+        assert len(views) == 1
+        assert views[0]["org_mcp_server"]["id"] == mcp_id
+        assert views[0]["is_activated"] is False
+
+        # Activate
+        activate = await client.post(
+            f"/api/v1/projects/{project_id}/mcp-activations/{mcp_id}", headers=headers
+        )
+        assert activate.status_code == 204
+
+        after_activate = await client.get(f"/api/v1/projects/{project_id}/mcp-activations", headers=headers)
+        assert after_activate.json()[0]["is_activated"] is True
+
+        # Deactivate
+        deactivate = await client.delete(
+            f"/api/v1/projects/{project_id}/mcp-activations/{mcp_id}", headers=headers
+        )
+        assert deactivate.status_code == 204
+
+        after_deactivate = await client.get(f"/api/v1/projects/{project_id}/mcp-activations", headers=headers)
+        assert after_deactivate.json()[0]["is_activated"] is False
+
+    async def test_inactive_org_mcp_is_hidden_from_listing(
+        self,
+        client: AsyncClient,
+        fake_mcp_services: None,  # noqa: ARG002
+    ) -> None:
+        headers = await self._auth_headers(client)
+        org_id = await self._create_org(client, headers)
+        project_id = await self._create_org_project(client, headers, org_id)
+        mcp_id = await self._declare_mcp(client, headers, org_id)
+
+        # Deactivate at org level
+        await client.patch(
+            f"/api/v1/organizations/{org_id}/mcp-servers/{mcp_id}/deactivate",
+            headers=headers,
+        )
+
+        # The project no longer sees it
+        listed = await client.get(f"/api/v1/projects/{project_id}/mcp-activations", headers=headers)
+        assert listed.status_code == 200
+        assert listed.json() == []
+
+    async def test_activate_returns_403_when_server_is_inactive_at_org_level(
+        self,
+        client: AsyncClient,
+        fake_mcp_services: None,  # noqa: ARG002
+    ) -> None:
+        headers = await self._auth_headers(client)
+        org_id = await self._create_org(client, headers)
+        project_id = await self._create_org_project(client, headers, org_id)
+        mcp_id = await self._declare_mcp(client, headers, org_id)
+        await client.patch(
+            f"/api/v1/organizations/{org_id}/mcp-servers/{mcp_id}/deactivate",
+            headers=headers,
+        )
+
+        activate = await client.post(
+            f"/api/v1/projects/{project_id}/mcp-activations/{mcp_id}", headers=headers
+        )
+        assert activate.status_code == 403
+
+    async def test_user_without_access_to_project_gets_404(
+        self,
+        client: AsyncClient,
+        fake_mcp_services: None,  # noqa: ARG002
+    ) -> None:
+        headers = await self._auth_headers(client)
+        org_id = await self._create_org(client, headers)
+        project_id = await self._create_org_project(client, headers, org_id)
+        await self._declare_mcp(client, headers, org_id)
+
+        outsider_headers = await self._auth_headers(client)
+        listed = await client.get(f"/api/v1/projects/{project_id}/mcp-activations", headers=outsider_headers)
+        assert listed.status_code == 404

--- a/server/tests/unit/application/use_cases/project_mcp/_helpers.py
+++ b/server/tests/unit/application/use_cases/project_mcp/_helpers.py
@@ -1,0 +1,74 @@
+"""Shared test helpers for project_mcp use cases."""
+
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+
+
+def make_project(
+    *,
+    project_id: UUID | None = None,
+    user_id: UUID | None = None,
+    organization_id: UUID | None = None,
+) -> Project:
+    return Project(
+        id=project_id or uuid4(),
+        user_id=user_id or uuid4(),
+        name="P",
+        description="",
+        system_prompt="",
+        is_published=False,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def make_member(role: str) -> object:
+    return type("Member", (), {"role": role})()
+
+
+def make_server(
+    *,
+    server_id: UUID | None = None,
+    organization_id: UUID | None = None,
+    slug: str = "notion",
+    is_active: bool = True,
+) -> OrgMcpServer:
+    now = datetime.now(UTC)
+    return OrgMcpServer(
+        id=server_id or uuid4(),
+        organization_id=organization_id or uuid4(),
+        name=slug.capitalize(),
+        slug=slug,
+        url="https://mcp.example.com",
+        auth_type=McpAuthType.NONE,
+        encrypted_bearer_token=None,
+        token_fingerprint=None,
+        token_suffix=None,
+        is_active=is_active,
+        tools_snapshot=[],
+        tools_snapshot_at=now,
+        timeout_seconds=30,
+        created_at=now,
+        updated_at=now,
+        created_by_user_id=uuid4(),
+    )
+
+
+def make_activation(
+    *,
+    project_id: UUID,
+    server_id: UUID,
+    is_active: bool = True,
+) -> ProjectMcpActivation:
+    return ProjectMcpActivation(
+        project_id=project_id,
+        org_mcp_server_id=server_id,
+        is_active=is_active,
+        activated_at=datetime.now(UTC),
+        activated_by_user_id=uuid4(),
+    )

--- a/server/tests/unit/application/use_cases/project_mcp/test_activate_deactivate_project_mcp.py
+++ b/server/tests/unit/application/use_cases/project_mcp/test_activate_deactivate_project_mcp.py
@@ -1,0 +1,195 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_mcp.activate_project_mcp import ActivateProjectMcp
+from raggae.application.use_cases.project_mcp.deactivate_project_mcp import DeactivateProjectMcp
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpAccessDeniedError,
+    McpServerNotFoundError,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_member, make_project, make_server
+
+
+def _build_activate(
+    *,
+    project,
+    org_server: object | None = None,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.MAKER,
+) -> tuple[ActivateProjectMcp, dict[str, AsyncMock]]:
+    project_repo = AsyncMock()
+    project_repo.find_by_id = AsyncMock(return_value=project)
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=org_server)
+    activation_repo = AsyncMock()
+    activation_repo.save = AsyncMock()
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    use_case = ActivateProjectMcp(
+        project_repository=project_repo,
+        org_mcp_server_repository=server_repo,
+        project_mcp_activation_repository=activation_repo,
+        organization_member_repository=member_repo,
+    )
+    return use_case, {
+        "activation_repo": activation_repo,
+        "server_repo": server_repo,
+    }
+
+
+def _build_deactivate(
+    *,
+    project,
+    org_server: object | None = None,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.MAKER,
+) -> tuple[DeactivateProjectMcp, dict[str, AsyncMock]]:
+    project_repo = AsyncMock()
+    project_repo.find_by_id = AsyncMock(return_value=project)
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=org_server)
+    activation_repo = AsyncMock()
+    activation_repo.delete = AsyncMock()
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    use_case = DeactivateProjectMcp(
+        project_repository=project_repo,
+        org_mcp_server_repository=server_repo,
+        project_mcp_activation_repository=activation_repo,
+        organization_member_repository=member_repo,
+    )
+    return use_case, {
+        "activation_repo": activation_repo,
+        "server_repo": server_repo,
+    }
+
+
+class TestActivateProjectMcp:
+    async def test_activate_persists_activation(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        use_case, deps = _build_activate(project=project, org_server=server)
+
+        # When
+        await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+        # Then
+        deps["activation_repo"].save.assert_awaited_once()
+        saved = deps["activation_repo"].save.await_args.args[0]
+        assert saved.project_id == project.id
+        assert saved.org_mcp_server_id == server.id
+        assert saved.is_active is True
+
+    async def test_activate_raises_when_server_not_found(self) -> None:
+        # Given
+        project = make_project(organization_id=uuid4())
+        use_case, _ = _build_activate(project=project, org_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(project_id=project.id, mcp_server_id=uuid4(), user_id=uuid4())
+
+    async def test_activate_raises_when_server_scoped_lookup_returns_none(self) -> None:
+        # Given — the repo `find_by_id` is scoped by `organization_id`; a server that
+        # belongs to a different org cannot be loaded for this project and is treated
+        # as "not found".
+        project = make_project(organization_id=uuid4())
+        use_case, _ = _build_activate(project=project, org_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(project_id=project.id, mcp_server_id=uuid4(), user_id=uuid4())
+
+    async def test_activate_raises_when_server_is_inactive_at_org_level(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id, is_active=False)
+        use_case, _ = _build_activate(project=project, org_server=server)
+
+        # When / Then
+        with pytest.raises(McpAccessDeniedError):
+            await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+    async def test_activate_raises_when_user_has_no_access_to_project(self) -> None:
+        # Given
+        project = make_project(organization_id=uuid4())
+        server = make_server(organization_id=project.organization_id)
+        use_case, _ = _build_activate(project=project, org_server=server, member_role=None)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+    async def test_activate_raises_when_project_is_user_owned_only(self) -> None:
+        # Given — a user-owned project cannot use org MCPs
+        owner_id = uuid4()
+        project = make_project(user_id=owner_id, organization_id=None)
+        server = make_server()  # any org
+        use_case, _ = _build_activate(project=project, org_server=server, member_role=None)
+
+        # When / Then
+        with pytest.raises(McpAccessDeniedError):
+            await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=owner_id)
+
+    async def test_activate_uses_current_timestamp(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        use_case, deps = _build_activate(project=project, org_server=server)
+        before = datetime.now(UTC)
+
+        # When
+        await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+        # Then
+        saved = deps["activation_repo"].save.await_args.args[0]
+        assert saved.activated_at >= before
+
+
+class TestDeactivateProjectMcp:
+    async def test_deactivate_deletes_activation(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        use_case, deps = _build_deactivate(project=project, org_server=server)
+
+        # When
+        await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+        # Then
+        deps["activation_repo"].delete.assert_awaited_once_with(project.id, server.id)
+
+    async def test_deactivate_raises_when_server_scoped_lookup_returns_none(self) -> None:
+        # Given
+        project = make_project(organization_id=uuid4())
+        use_case, _ = _build_deactivate(project=project, org_server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await use_case.execute(project_id=project.id, mcp_server_id=uuid4(), user_id=uuid4())
+
+    async def test_deactivate_is_idempotent_when_no_activation_exists(self) -> None:
+        # Given — the activation may not exist; the use case still completes.
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        use_case, deps = _build_deactivate(project=project, org_server=server)
+
+        # When
+        await use_case.execute(project_id=project.id, mcp_server_id=server.id, user_id=uuid4())
+
+        # Then — delete called even if there was nothing to delete (repo no-ops)
+        deps["activation_repo"].delete.assert_awaited_once()

--- a/server/tests/unit/application/use_cases/project_mcp/test_list_project_mcp_activations.py
+++ b/server/tests/unit/application/use_cases/project_mcp/test_list_project_mcp_activations.py
@@ -1,0 +1,128 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.use_cases.project_mcp.list_project_mcp_activations import (
+    ListProjectMcpActivations,
+)
+from raggae.domain.exceptions.project_exceptions import ProjectNotFoundError
+from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
+
+from ._helpers import make_activation, make_member, make_project, make_server
+
+
+def _build_use_case(
+    *,
+    project,
+    member_role: OrganizationMemberRole | None = OrganizationMemberRole.MAKER,
+    org_servers: list[object] | None = None,
+    activations: list[object] | None = None,
+) -> ListProjectMcpActivations:
+    project_repo = AsyncMock()
+    project_repo.find_by_id = AsyncMock(return_value=project)
+    server_repo = AsyncMock()
+    server_repo.list_by_org_id = AsyncMock(return_value=org_servers or [])
+    activation_repo = AsyncMock()
+    activation_repo.list_by_project_id = AsyncMock(return_value=activations or [])
+    member_repo = AsyncMock()
+    member_repo.find_by_organization_and_user = AsyncMock(
+        return_value=(make_member(member_role) if member_role is not None else None)
+    )
+    return ListProjectMcpActivations(
+        project_repository=project_repo,
+        org_mcp_server_repository=server_repo,
+        project_mcp_activation_repository=activation_repo,
+        organization_member_repository=member_repo,
+    )
+
+
+class TestListProjectMcpActivations:
+    async def test_returns_only_active_org_servers_with_activation_status(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        active_server = make_server(organization_id=org_id, slug="notion", is_active=True)
+        inactive_server = make_server(organization_id=org_id, slug="archived", is_active=False)
+        activation = make_activation(project_id=project.id, server_id=active_server.id, is_active=True)
+        use_case = _build_use_case(
+            project=project,
+            org_servers=[active_server, inactive_server],
+            activations=[activation],
+        )
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=uuid4())
+
+        # Then — only the active server is exposed, with its activation status
+        assert len(result) == 1
+        assert result[0].org_mcp_server.slug == "notion"
+        assert result[0].is_activated is True
+
+    async def test_marks_server_as_not_activated_when_no_activation_row(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        use_case = _build_use_case(project=project, org_servers=[server], activations=[])
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=uuid4())
+
+        # Then
+        assert len(result) == 1
+        assert result[0].is_activated is False
+
+    async def test_marks_server_as_not_activated_when_activation_is_false(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = make_project(organization_id=org_id)
+        server = make_server(organization_id=org_id)
+        activation = make_activation(project_id=project.id, server_id=server.id, is_active=False)
+        use_case = _build_use_case(project=project, org_servers=[server], activations=[activation])
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=uuid4())
+
+        # Then
+        assert result[0].is_activated is False
+
+    async def test_returns_empty_list_for_user_owned_project(self) -> None:
+        # Given
+        project = make_project(organization_id=None)  # user-owned, no org
+        use_case = _build_use_case(project=project, org_servers=[], activations=[])
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=project.user_id)
+
+        # Then
+        assert result == []
+
+    async def test_raises_when_project_does_not_exist(self) -> None:
+        # Given
+        use_case = _build_use_case(project=None)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=uuid4(), user_id=uuid4())
+
+    async def test_raises_when_user_has_no_access_to_org_project(self) -> None:
+        # Given
+        project = make_project(organization_id=uuid4())
+        use_case = _build_use_case(project=project, member_role=None)
+
+        # When / Then
+        with pytest.raises(ProjectNotFoundError):
+            await use_case.execute(project_id=project.id, user_id=uuid4())
+
+    async def test_user_who_owns_the_project_can_list_without_org_membership(self) -> None:
+        # Given — user-owned project, user is owner, no org context
+        owner_id = uuid4()
+        project = make_project(user_id=owner_id, organization_id=None)
+        use_case = _build_use_case(project=project, member_role=None)
+
+        # When
+        result = await use_case.execute(project_id=project.id, user_id=owner_id)
+
+        # Then
+        assert result == []


### PR DESCRIPTION
## Problème

Les PR 1-3 permettent à une organisation de déclarer des serveurs MCP, mais aucun projet ne peut encore opter pour les utiliser. Sans cette pièce, le snapshot d'outils reste de la métadonnée morte.

## Solution

Cette PR introduit l'opt-in MCP par projet : trois use cases côté application, trois endpoints REST et un onglet « MCP » dans la page de paramètres projet. Aucun branchement chat n'est encore fait (PR 5).

## Implémentation

### Application

- DTO agrégée `ProjectMcpActivationViewDTO { org_mcp_server, is_activated }`.
- Use cases sous `application/use_cases/project_mcp/` :
  - `ListProjectMcpActivations` : ne renvoie que les MCP org `is_active=true`, avec leur statut d'activation pour le projet courant. Retourne `[]` pour un projet user-owned.
  - `ActivateProjectMcp` : refuse les projets sans org, les MCP désactivés au niveau org, et les serveurs introuvables (scoping `organization_id`).
  - `DeactivateProjectMcp` : supprime la ligne d'activation (idempotent).
- Helper partagé `_access.load_project_for_user` : owner direct du projet ou membre de l'org (n'importe quel rôle), retourne `ProjectNotFoundError` pour ne pas leaker l'existence.

### Backend

- Schemas `ProjectMcpActivationViewResponse` + réutilisation de `OrgMcpServerResponse`.
- Routes sous `/api/v1/projects/{project_id}/mcp-activations` :
  - `GET` → vue agrégée
  - `POST /{mcp_server_id}` → activate (204)
  - `DELETE /{mcp_server_id}` → deactivate (204)
- DI dans `dependencies.py` (3 nouvelles factories).
- Log structuré `project_mcp_activated` à chaque activation.

### Frontend

- Type `ProjectMcpActivationViewResponse` dans `api.ts`.
- Client `lib/api/project-mcp-activations.ts` (manuel, cohérent avec le reste).
- Hooks `useProjectMcpActivations`, `useActivateProjectMcp`, `useDeactivateProjectMcp` avec invalidation par clé `[project-mcp-activations, projectId]`.
- Organism `organisms/project/settings/project-mcp-panel.tsx` : toggle d'activation par MCP, badge actif/inactif, dialog de visualisation des tools, warning provider compatibility.
- Nouvel onglet « MCP » dans le template `project-settings-template.tsx`.
- Traductions complètes fr/en.

### Tests

- **17 tests unitaires** sur les use cases (Given/When/Then, mocks `AsyncMock`).
- **4 tests E2E** : cycle list → activate → deactivate, filtrage des MCP org désactivés, refus 403 sur MCP inactif, 404 pour utilisateur sans accès.
- **3 tests Vitest** sur l'organism (titre, warning, état vide, liste des MCP avec statut).
- Total : **1060 passed, 0 failed, 43 skipped** côté backend ; **473 passed** côté frontend.

## Recette

1. `cd server && source .venv/bin/activate && pytest` → 1060 verts.
2. `ruff format`, `ruff check`, `mypy src/` → clean.
3. `cd ../client && npx vitest run` → 473 verts.
4. Démarrer l'app, dans un projet d'organisation où l'org a déjà déclaré au moins un MCP (PR 3), ouvrir **Settings → MCP** :
   - Voir la liste des MCP de l'org actifs.
   - Toggler l'activation, observer le badge.
   - Cliquer sur « View tools » pour voir le snapshot.
   - Désactiver le MCP au niveau org → il disparaît du listing projet.
5. Lire `docs/MCP_FEATURE_PLAN.md` section PR 5 pour la suite : intégration des tools dans le flux chat.

Aucun comportement existant n'est modifié hors ajout du nouvel onglet.