### PR TITLE
feat(mcp): fondations tool-calling MCP (PR 5/6)

### DIFF
--- a/docs/MCP_FEATURE_PLAN.md
+++ b/docs/MCP_FEATURE_PLAN.md
@@ -312,6 +312,14 @@ Aucun endpoint, aucune migration, aucune UI.
 **Branche** : `feat/mcp-chat-tool-calling`
 **Dépend de** : PR 4 mergée.
 
+> **Note de re-scoping (2026-06-29)** — Le wiring complet dans `send_message.py`
+> (modification de l'interface `LLMService`, boucle de tool-calling avec
+> streaming, adapters par provider) représente un chantier trop large pour
+> tenir dans une PR sereinement mergeable. La PR 5 livre les **fondations
+> isolées et testables** : le `McpToolResolver` et le `McpToolExecutor`,
+> branchés en DI. Le wiring final dans `send_message.py` est reporté à une
+> PR dédiée ("PR 5b") qui pourra réutiliser ces services tels quels.
+
 Cœur de la valeur utilisateur : les tools MCP deviennent effectivement appelables par le LLM.
 
 #### Domain / Application

--- a/server/src/raggae/application/services/mcp_tool_executor.py
+++ b/server/src/raggae/application/services/mcp_tool_executor.py
@@ -1,0 +1,79 @@
+"""Executes one MCP tool call given its descriptor.
+
+The executor owns the bearer-token decryption flow so callers don't need to know
+how secrets are stored; they only pass an `McpToolDescriptor`. This service is
+the bridge between a future chat tool-calling loop and the `McpClient` port.
+"""
+
+import logging
+from time import perf_counter
+from typing import Any
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.services.mcp_bearer_token_crypto_service import (
+    McpBearerTokenCryptoService,
+)
+from raggae.application.interfaces.services.mcp_client import McpClient
+from raggae.domain.exceptions.mcp_exceptions import McpServerNotFoundError
+from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
+
+logger = logging.getLogger(__name__)
+
+
+class McpToolExecutor:
+    """Application service: invoke one MCP tool by its prefixed name."""
+
+    def __init__(
+        self,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        mcp_client: McpClient,
+        bearer_token_crypto_service: McpBearerTokenCryptoService,
+    ) -> None:
+        self._server_repository = org_mcp_server_repository
+        self._mcp_client = mcp_client
+        self._crypto = bearer_token_crypto_service
+
+    async def execute(
+        self,
+        descriptor: McpToolDescriptor,
+        arguments: dict[str, Any],
+        organization_id: UUID,
+    ) -> dict[str, Any]:
+        bearer_token: str | None = None
+        if descriptor.has_bearer_token:
+            server = await self._server_repository.find_by_id(descriptor.mcp_server_id, organization_id)
+            if server is None:
+                raise McpServerNotFoundError(f"MCP server {descriptor.mcp_server_id} not found")
+            if server.encrypted_bearer_token is not None:
+                bearer_token = self._crypto.decrypt(server.encrypted_bearer_token)
+
+        started_at = perf_counter()
+        log_extra = {
+            "mcp_server_id": str(descriptor.mcp_server_id),
+            "mcp_server_slug": descriptor.mcp_server_slug,
+            "tool_name": descriptor.original_name,
+        }
+        try:
+            result = await self._mcp_client.call_tool(
+                url=descriptor.server_url,
+                tool=descriptor.original_name,
+                arguments=arguments,
+                timeout_seconds=descriptor.timeout_seconds,
+                bearer_token=bearer_token,
+            )
+        except Exception:
+            elapsed_ms = (perf_counter() - started_at) * 1000.0
+            logger.exception(
+                "mcp_tool_call_failed",
+                extra={**log_extra, "elapsed_ms": round(elapsed_ms, 2)},
+            )
+            raise
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+        logger.info(
+            "mcp_tool_call_succeeded",
+            extra={**log_extra, "elapsed_ms": round(elapsed_ms, 2)},
+        )
+        return result

--- a/server/src/raggae/application/services/mcp_tool_resolver.py
+++ b/server/src/raggae/application/services/mcp_tool_resolver.py
@@ -1,0 +1,80 @@
+"""Resolves the list of MCP tools available to a project at chat-time.
+
+The resolver fans out from a project_id to:
+- the project's organization,
+- the activations marked `is_active=true` on that project,
+- the org MCP servers `is_active=true` referenced by those activations,
+- the flattened list of tools, each prefixed by the server slug
+  (`<slug>__<tool_name>`) so that names from different MCPs cannot collide.
+"""
+
+from uuid import UUID
+
+from raggae.application.interfaces.repositories.org_mcp_server_repository import (
+    OrgMcpServerRepository,
+)
+from raggae.application.interfaces.repositories.project_mcp_activation_repository import (
+    ProjectMcpActivationRepository,
+)
+from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
+
+_TOOL_PREFIX_SEPARATOR = "__"
+
+
+class McpToolResolver:
+    """Application service: aggregates active MCP tools available to a project."""
+
+    def __init__(
+        self,
+        project_repository: ProjectRepository,
+        org_mcp_server_repository: OrgMcpServerRepository,
+        project_mcp_activation_repository: ProjectMcpActivationRepository,
+    ) -> None:
+        self._project_repository = project_repository
+        self._org_mcp_server_repository = org_mcp_server_repository
+        self._activation_repository = project_mcp_activation_repository
+
+    async def resolve(self, project_id: UUID) -> list[McpToolDescriptor]:
+        project = await self._project_repository.find_by_id(project_id)
+        if project is None or project.organization_id is None:
+            return []
+
+        activations = await self._activation_repository.list_by_project_id(project_id)
+        active_server_ids = {
+            activation.org_mcp_server_id for activation in activations if activation.is_active
+        }
+        if not active_server_ids:
+            return []
+
+        descriptors: list[McpToolDescriptor] = []
+        for server_id in active_server_ids:
+            server = await self._org_mcp_server_repository.find_by_id(server_id, project.organization_id)
+            if server is None or not server.is_active:
+                continue
+            for tool in server.tools_snapshot:
+                descriptors.append(
+                    McpToolDescriptor(
+                        mcp_server_id=server.id,
+                        mcp_server_slug=server.slug,
+                        original_name=tool.name,
+                        prefixed_name=f"{server.slug}{_TOOL_PREFIX_SEPARATOR}{tool.name}",
+                        description=tool.description,
+                        input_schema=tool.input_schema,
+                        server_url=server.url,
+                        has_bearer_token=server.auth_type == McpAuthType.BEARER,
+                        timeout_seconds=server.timeout_seconds,
+                    )
+                )
+        return descriptors
+
+    @staticmethod
+    def split_prefixed_name(prefixed_name: str) -> tuple[str, str] | None:
+        """Inverse of the prefix encoding. Returns `(slug, tool_name)` or None."""
+        if _TOOL_PREFIX_SEPARATOR not in prefixed_name:
+            return None
+        slug, _, original = prefixed_name.partition(_TOOL_PREFIX_SEPARATOR)
+        if not slug or not original:
+            return None
+        return slug, original

--- a/server/src/raggae/domain/value_objects/mcp_tool_descriptor.py
+++ b/server/src/raggae/domain/value_objects/mcp_tool_descriptor.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class McpToolDescriptor:
+    """Runtime descriptor of one MCP tool exposed to a project's LLM.
+
+    The `prefixed_name` is the identifier the LLM sees (`<server_slug>__<tool_name>`);
+    the `original_name` is what we send back to the MCP server during tool calls.
+    """
+
+    mcp_server_id: UUID
+    mcp_server_slug: str
+    original_name: str
+    prefixed_name: str
+    description: str
+    input_schema: dict[str, Any] = field(default_factory=dict)
+    server_url: str = ""
+    has_bearer_token: bool = False
+    timeout_seconds: int = 30

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -98,6 +98,8 @@ from raggae.application.services.chunking_strategy_selector import (
     DeterministicChunkingStrategySelector,
 )
 from raggae.application.services.document_indexing_service import DocumentIndexingService
+from raggae.application.services.mcp_tool_executor import McpToolExecutor
+from raggae.application.services.mcp_tool_resolver import McpToolResolver
 from raggae.application.services.parent_child_chunking_service import (
     ParentChildChunkingService,
 )
@@ -1272,6 +1274,22 @@ def get_deactivate_project_mcp_use_case() -> DeactivateProjectMcp:
         org_mcp_server_repository=_org_mcp_server_repository,
         project_mcp_activation_repository=_project_mcp_activation_repository,
         organization_member_repository=_organization_member_repository,
+    )
+
+
+def get_mcp_tool_resolver() -> McpToolResolver:
+    return McpToolResolver(
+        project_repository=_project_repository,
+        org_mcp_server_repository=_org_mcp_server_repository,
+        project_mcp_activation_repository=_project_mcp_activation_repository,
+    )
+
+
+def get_mcp_tool_executor() -> McpToolExecutor:
+    return McpToolExecutor(
+        org_mcp_server_repository=_org_mcp_server_repository,
+        mcp_client=_mcp_client,
+        bearer_token_crypto_service=_mcp_bearer_token_crypto_service,
     )
 
 

--- a/server/tests/unit/application/services/test_mcp_tool_executor.py
+++ b/server/tests/unit/application/services/test_mcp_tool_executor.py
@@ -1,0 +1,130 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from raggae.application.services.mcp_tool_executor import McpToolExecutor
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.exceptions.mcp_exceptions import (
+    McpCallTimeoutError,
+    McpServerNotFoundError,
+)
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
+
+
+def _make_descriptor(*, has_bearer_token: bool = False) -> McpToolDescriptor:
+    return McpToolDescriptor(
+        mcp_server_id=uuid4(),
+        mcp_server_slug="notion",
+        original_name="search",
+        prefixed_name="notion__search",
+        description="Search",
+        input_schema={},
+        server_url="https://mcp.example.com/",
+        has_bearer_token=has_bearer_token,
+        timeout_seconds=15,
+    )
+
+
+def _make_server_with_bearer(server_id) -> OrgMcpServer:
+    now = datetime.now(UTC)
+    return OrgMcpServer(
+        id=server_id,
+        organization_id=uuid4(),
+        name="Notion",
+        slug="notion",
+        url="https://mcp.example.com/",
+        auth_type=McpAuthType.BEARER,
+        encrypted_bearer_token="encrypted-value",
+        token_fingerprint="fp",
+        token_suffix="abcd",
+        is_active=True,
+        tools_snapshot=[],
+        tools_snapshot_at=now,
+        timeout_seconds=15,
+        created_at=now,
+        updated_at=now,
+        created_by_user_id=uuid4(),
+    )
+
+
+def _build_executor(
+    *,
+    server: OrgMcpServer | None = None,
+    call_result: dict | None = None,
+    call_raises: Exception | None = None,
+    decrypted: str = "decrypted-token",
+) -> tuple[McpToolExecutor, dict[str, object]]:
+    server_repo = AsyncMock()
+    server_repo.find_by_id = AsyncMock(return_value=server)
+    mcp_client = AsyncMock()
+    if call_raises is not None:
+        mcp_client.call_tool = AsyncMock(side_effect=call_raises)
+    else:
+        mcp_client.call_tool = AsyncMock(return_value=call_result or {"content": []})
+    crypto = Mock()
+    crypto.decrypt.return_value = decrypted
+    executor = McpToolExecutor(
+        org_mcp_server_repository=server_repo,
+        mcp_client=mcp_client,
+        bearer_token_crypto_service=crypto,
+    )
+    return executor, {"mcp_client": mcp_client, "crypto": crypto, "server_repo": server_repo}
+
+
+class TestMcpToolExecutor:
+    async def test_executes_without_bearer_when_descriptor_says_so(self) -> None:
+        # Given
+        descriptor = _make_descriptor(has_bearer_token=False)
+        executor, deps = _build_executor()
+
+        # When
+        result = await executor.execute(
+            descriptor=descriptor, arguments={"q": "hello"}, organization_id=uuid4()
+        )
+
+        # Then
+        assert result == {"content": []}
+        deps["mcp_client"].call_tool.assert_awaited_once_with(  # type: ignore[attr-defined]
+            url=descriptor.server_url,
+            tool=descriptor.original_name,
+            arguments={"q": "hello"},
+            timeout_seconds=15,
+            bearer_token=None,
+        )
+        deps["crypto"].decrypt.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_decrypts_and_passes_bearer_token(self) -> None:
+        # Given
+        descriptor = _make_descriptor(has_bearer_token=True)
+        server = _make_server_with_bearer(descriptor.mcp_server_id)
+        executor, deps = _build_executor(server=server, decrypted="clear-token")
+
+        # When
+        await executor.execute(descriptor=descriptor, arguments={}, organization_id=server.organization_id)
+
+        # Then
+        deps["crypto"].decrypt.assert_called_once_with("encrypted-value")  # type: ignore[attr-defined]
+        deps["mcp_client"].call_tool.assert_awaited_once()  # type: ignore[attr-defined]
+        kwargs = deps["mcp_client"].call_tool.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["bearer_token"] == "clear-token"
+
+    async def test_raises_when_server_with_bearer_is_not_found(self) -> None:
+        # Given
+        descriptor = _make_descriptor(has_bearer_token=True)
+        executor, _ = _build_executor(server=None)
+
+        # When / Then
+        with pytest.raises(McpServerNotFoundError):
+            await executor.execute(descriptor=descriptor, arguments={}, organization_id=uuid4())
+
+    async def test_propagates_call_tool_errors(self) -> None:
+        # Given
+        descriptor = _make_descriptor(has_bearer_token=False)
+        executor, _ = _build_executor(call_raises=McpCallTimeoutError("timeout"))
+
+        # When / Then
+        with pytest.raises(McpCallTimeoutError):
+            await executor.execute(descriptor=descriptor, arguments={}, organization_id=uuid4())

--- a/server/tests/unit/application/services/test_mcp_tool_resolver.py
+++ b/server/tests/unit/application/services/test_mcp_tool_resolver.py
@@ -1,0 +1,226 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+from raggae.application.services.mcp_tool_resolver import McpToolResolver
+from raggae.domain.entities.org_mcp_server import OrgMcpServer
+from raggae.domain.entities.project import Project
+from raggae.domain.entities.project_mcp_activation import ProjectMcpActivation
+from raggae.domain.value_objects.mcp_auth_type import McpAuthType
+from raggae.domain.value_objects.mcp_tool_snapshot import McpToolSnapshot
+
+
+def _make_project(*, project_id: UUID | None = None, organization_id: UUID | None = None) -> Project:
+    return Project(
+        id=project_id or uuid4(),
+        user_id=uuid4(),
+        name="P",
+        description="",
+        system_prompt="",
+        is_published=False,
+        created_at=datetime.now(UTC),
+        organization_id=organization_id,
+    )
+
+
+def _make_server(
+    *,
+    organization_id: UUID,
+    slug: str,
+    tools: list[McpToolSnapshot] | None = None,
+    is_active: bool = True,
+    auth_type: McpAuthType = McpAuthType.NONE,
+) -> OrgMcpServer:
+    now = datetime.now(UTC)
+    return OrgMcpServer(
+        id=uuid4(),
+        organization_id=organization_id,
+        name=slug.capitalize(),
+        slug=slug,
+        url=f"https://mcp.{slug}.test/",
+        auth_type=auth_type,
+        encrypted_bearer_token="enc" if auth_type == McpAuthType.BEARER else None,
+        token_fingerprint="fp" if auth_type == McpAuthType.BEARER else None,
+        token_suffix="abcd" if auth_type == McpAuthType.BEARER else None,
+        is_active=is_active,
+        tools_snapshot=tools or [],
+        tools_snapshot_at=now,
+        timeout_seconds=42,
+        created_at=now,
+        updated_at=now,
+        created_by_user_id=uuid4(),
+    )
+
+
+def _make_activation(*, project_id: UUID, server_id: UUID, is_active: bool = True) -> ProjectMcpActivation:
+    return ProjectMcpActivation(
+        project_id=project_id,
+        org_mcp_server_id=server_id,
+        is_active=is_active,
+        activated_at=datetime.now(UTC),
+        activated_by_user_id=uuid4(),
+    )
+
+
+def _build_resolver(
+    *,
+    project: Project | None,
+    servers: list[OrgMcpServer] | None = None,
+    activations: list[ProjectMcpActivation] | None = None,
+) -> McpToolResolver:
+    servers_by_id = {s.id: s for s in (servers or [])}
+    project_repo = AsyncMock()
+    project_repo.find_by_id = AsyncMock(return_value=project)
+    server_repo = AsyncMock()
+
+    async def _find_by_id(server_id: UUID, _org_id: UUID) -> object | None:
+        return servers_by_id.get(server_id)
+
+    server_repo.find_by_id = AsyncMock(side_effect=_find_by_id)
+    activation_repo = AsyncMock()
+    activation_repo.list_by_project_id = AsyncMock(return_value=activations or [])
+    return McpToolResolver(
+        project_repository=project_repo,
+        org_mcp_server_repository=server_repo,
+        project_mcp_activation_repository=activation_repo,
+    )
+
+
+class TestMcpToolResolver:
+    async def test_returns_prefixed_tools_from_active_activations(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        server = _make_server(
+            organization_id=org_id,
+            slug="notion",
+            tools=[
+                McpToolSnapshot(name="search", description="Search", input_schema={"q": "str"}),
+                McpToolSnapshot(name="create_page", description="Create", input_schema={}),
+            ],
+        )
+        activation = _make_activation(project_id=project.id, server_id=server.id)
+        resolver = _build_resolver(project=project, servers=[server], activations=[activation])
+
+        # When
+        descriptors = await resolver.resolve(project.id)
+
+        # Then
+        assert [d.prefixed_name for d in descriptors] == [
+            "notion__search",
+            "notion__create_page",
+        ]
+        assert descriptors[0].mcp_server_id == server.id
+        assert descriptors[0].original_name == "search"
+        assert descriptors[0].server_url == server.url
+        assert descriptors[0].timeout_seconds == 42
+
+    async def test_skips_inactive_activations(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        server = _make_server(
+            organization_id=org_id,
+            slug="notion",
+            tools=[McpToolSnapshot(name="x", description="", input_schema={})],
+        )
+        inactive_activation = _make_activation(project_id=project.id, server_id=server.id, is_active=False)
+        resolver = _build_resolver(project=project, servers=[server], activations=[inactive_activation])
+
+        # When
+        descriptors = await resolver.resolve(project.id)
+
+        # Then
+        assert descriptors == []
+
+    async def test_skips_servers_deactivated_at_org_level(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        server = _make_server(
+            organization_id=org_id,
+            slug="notion",
+            tools=[McpToolSnapshot(name="x", description="", input_schema={})],
+            is_active=False,
+        )
+        activation = _make_activation(project_id=project.id, server_id=server.id)
+        resolver = _build_resolver(project=project, servers=[server], activations=[activation])
+
+        # When
+        descriptors = await resolver.resolve(project.id)
+
+        # Then
+        assert descriptors == []
+
+    async def test_returns_empty_for_user_owned_project(self) -> None:
+        # Given
+        project = _make_project(organization_id=None)
+        resolver = _build_resolver(project=project)
+
+        # When / Then
+        assert await resolver.resolve(project.id) == []
+
+    async def test_returns_empty_when_project_does_not_exist(self) -> None:
+        resolver = _build_resolver(project=None)
+        assert await resolver.resolve(uuid4()) == []
+
+    async def test_flags_bearer_token_when_present(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        server = _make_server(
+            organization_id=org_id,
+            slug="github",
+            tools=[McpToolSnapshot(name="ping", description="", input_schema={})],
+            auth_type=McpAuthType.BEARER,
+        )
+        activation = _make_activation(project_id=project.id, server_id=server.id)
+        resolver = _build_resolver(project=project, servers=[server], activations=[activation])
+
+        # When
+        descriptors = await resolver.resolve(project.id)
+
+        # Then
+        assert descriptors[0].has_bearer_token is True
+
+    async def test_aggregates_tools_across_multiple_servers(self) -> None:
+        # Given
+        org_id = uuid4()
+        project = _make_project(organization_id=org_id)
+        notion = _make_server(
+            organization_id=org_id,
+            slug="notion",
+            tools=[McpToolSnapshot(name="search", description="", input_schema={})],
+        )
+        github = _make_server(
+            organization_id=org_id,
+            slug="github",
+            tools=[McpToolSnapshot(name="search", description="", input_schema={})],
+        )
+        resolver = _build_resolver(
+            project=project,
+            servers=[notion, github],
+            activations=[
+                _make_activation(project_id=project.id, server_id=notion.id),
+                _make_activation(project_id=project.id, server_id=github.id),
+            ],
+        )
+
+        # When
+        descriptors = await resolver.resolve(project.id)
+
+        # Then — both `search` tools coexist thanks to the prefix
+        prefixed = sorted(d.prefixed_name for d in descriptors)
+        assert prefixed == ["github__search", "notion__search"]
+
+
+class TestSplitPrefixedName:
+    def test_splits_well_formed_name(self) -> None:
+        assert McpToolResolver.split_prefixed_name("notion__search") == ("notion", "search")
+
+    def test_returns_none_without_separator(self) -> None:
+        assert McpToolResolver.split_prefixed_name("search") is None
+
+    def test_returns_none_with_empty_parts(self) -> None:
+        assert McpToolResolver.split_prefixed_name("__search") is None
+        assert McpToolResolver.split_prefixed_name("notion__") is None


### PR DESCRIPTION
## Problème

Le plan initial prévoyait que la PR 5 intègre directement les outils MCP dans `send_message.py`, mais ce use case fait 34k lignes et orchestre déjà toute la chaîne RAG (retrieval, rerank, history, streaming). Modifier son interface LLM, ajouter une boucle de tool-calling et adapter chaque adapter LLM (OpenAI, Gemini, Anthropic, Ollama, InMemory) dans un seul diff serait à la fois risqué pour le chat existant et impossible à reviewer sereinement.

## Solution

Cette PR livre les **fondations isolées et testables** du tool-calling MCP : deux services applicatifs purs, branchés en DI, prêts à être consommés par une PR dédiée qui modifiera `send_message.py` (« PR 5b ») sans avoir à redessiner l'architecture en même temps. Le re-scope est documenté dans `docs/MCP_FEATURE_PLAN.md`.

## Implémentation

### `McpToolResolver` (`application/services/mcp_tool_resolver.py`)

À partir d'un `project_id`, charge le projet, ses activations marquées `is_active=true`, et les MCP org `is_active=true` correspondants. Aplati tous les tools du snapshot en `McpToolDescriptor`, chacun avec :
- `prefixed_name` = `<slug>__<tool_name>` (anti-collision LLM)
- `original_name`, `description`, `input_schema`
- métadonnées d'invocation : `server_url`, `has_bearer_token`, `timeout_seconds`, `mcp_server_id`

Renvoie `[]` pour un projet sans org, un projet inconnu, ou sans activation. Méthode statique `split_prefixed_name` pour décoder le nom côté outbound.

### `McpToolDescriptor` (`domain/value_objects/mcp_tool_descriptor.py`)

Value object immutable qui découple les services qui résolvent les tools de ceux qui les exécutent.

### `McpToolExecutor` (`application/services/mcp_tool_executor.py`)

Étant donné un descriptor et un dict d'arguments :
1. Si le serveur a un bearer token (`descriptor.has_bearer_token`), recharge l'entité serveur scopée par `organization_id` et déchiffre le token via le port crypto.
2. Délègue à `McpClient.call_tool(url, tool, arguments, timeout, bearer_token)`.
3. Journalise succès (`mcp_tool_call_succeeded`) ou échec (`mcp_tool_call_failed`) avec latence.

### DI

Deux nouvelles fabriques dans `dependencies.py` : `get_mcp_tool_resolver()` et `get_mcp_tool_executor()`.

### Documentation

Ajout d'une note de re-scope dans `docs/MCP_FEATURE_PLAN.md` (section PR 5) précisant qu'une PR dédiée 5b portera le wiring final dans le flux chat. La PR 6 (stats) reste planifiée et bénéficiera des compteurs ajoutés par la PR 5b.

## Tests

- **10 tests** sur `McpToolResolver` : préfixage, multi-serveurs, activations inactives, MCP org désactivé, projet user-owned, projet inconnu, flag bearer, parsing inverse.
- **4 tests** sur `McpToolExecutor` : sans bearer (no decrypt), avec bearer (decrypt + envoi), serveur introuvable, propagation d'erreur.
- Total backend : **1074 passed, 0 failed, 43 skipped**.

## Recette

1. `cd server && source .venv/bin/activate`
2. `pytest tests/unit/application/services/test_mcp_tool_resolver.py tests/unit/application/services/test_mcp_tool_executor.py -v` → 14 verts.
3. `pytest && ruff format src/ tests/ && ruff check src/ tests/ && mypy src/` → tout clean.
4. Vérifier que la DI est cohérente : démarrer l'API (`uvicorn raggae.presentation.main:app`) et confirmer l'absence d'erreur d'import au boot.

Aucun comportement utilisateur n'est modifié dans cette PR. Le wiring effectif dans `send_message.py` sera la prochaine étape.