### PR TITLE
feat(mcp): wiring tool-calling dans le flux chat (PR 5b)

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "python-multipart>=0.0.6",
     "httpx>=0.26.0",
     "openai>=1.10.0",
+    "anthropic>=0.40.0",
     "pgvector>=0.2.4",
     "minio>=7.2.0",
     "pypdf>=5.0.0",

--- a/server/src/raggae/application/interfaces/services/tool_capable_llm_service.py
+++ b/server/src/raggae/application/interfaces/services/tool_capable_llm_service.py
@@ -1,0 +1,28 @@
+from typing import Protocol, runtime_checkable
+
+from raggae.domain.value_objects.chat_message import ChatMessage
+from raggae.domain.value_objects.llm_response import LLMResponse
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+
+
+@runtime_checkable
+class ToolCapableLLMService(Protocol):
+    """Optional extension of `LLMService` for providers that support tool calling.
+
+    A concrete LLM adapter may implement both `LLMService` (the legacy single-prompt
+    interface) and `ToolCapableLLMService`. Use `isinstance(service,
+    ToolCapableLLMService)` at runtime to know whether tools can be exposed to it.
+    """
+
+    async def generate_with_tools(
+        self,
+        messages: list[ChatMessage],
+        tools: list[LLMToolDescriptor],
+    ) -> LLMResponse:
+        """Send a structured conversation with available tools.
+
+        Returns either an `LLMTextResponse` (final answer) or an
+        `LLMToolCallResponse` (one or more tool calls to execute before
+        continuing the loop).
+        """
+        ...

--- a/server/src/raggae/application/services/chat_tool_calling_session.py
+++ b/server/src/raggae/application/services/chat_tool_calling_session.py
@@ -1,0 +1,145 @@
+"""Drives a single tool-calling exchange between the LLM and MCP servers.
+
+Given a structured message list and a list of available MCP tools, this service
+sends the conversation to a `ToolCapableLLMService` and, when the LLM requests
+tool calls, executes them via `McpToolExecutor`, appends the tool results to
+the conversation, and loops until the LLM returns a text answer (or the max
+iteration cap is hit). Each tool failure is folded back into the conversation
+as a tool result so the LLM can react gracefully.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from raggae.application.interfaces.services.tool_capable_llm_service import (
+    ToolCapableLLMService,
+)
+from raggae.application.services.mcp_tool_executor import McpToolExecutor
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole
+from raggae.domain.value_objects.llm_response import LLMTextResponse, LLMToolCallResponse
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_ITERATIONS = 6
+
+
+@dataclass(frozen=True)
+class ToolCallingResult:
+    """Result of a tool-calling exchange."""
+
+    final_answer: str
+    tool_invocations: list[str] = field(default_factory=list)  # prefixed tool names invoked
+    iterations: int = 0
+
+
+class ChatToolCallingSession:
+    def __init__(
+        self,
+        llm_service: ToolCapableLLMService,
+        tool_executor: McpToolExecutor,
+        max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+    ) -> None:
+        self._llm_service = llm_service
+        self._tool_executor = tool_executor
+        self._max_iterations = max(1, max_iterations)
+
+    async def run(
+        self,
+        messages: list[ChatMessage],
+        mcp_tools: list[McpToolDescriptor],
+        llm_tools: list[LLMToolDescriptor],
+        organization_id: UUID,
+    ) -> ToolCallingResult:
+        history: list[ChatMessage] = list(messages)
+        invocations: list[str] = []
+        tools_by_name = {tool.prefixed_name: tool for tool in mcp_tools}
+
+        for iteration in range(1, self._max_iterations + 1):
+            response = await self._llm_service.generate_with_tools(messages=history, tools=llm_tools)
+            if isinstance(response, LLMTextResponse):
+                return ToolCallingResult(
+                    final_answer=response.text,
+                    tool_invocations=invocations,
+                    iterations=iteration,
+                )
+            if not isinstance(response, LLMToolCallResponse):
+                # Defensive: unknown response type, stop the loop.
+                return ToolCallingResult(
+                    final_answer="",
+                    tool_invocations=invocations,
+                    iterations=iteration,
+                )
+
+            history.append(
+                ChatMessage(
+                    role=ChatRole.ASSISTANT,
+                    content=None,
+                    tool_calls=response.tool_calls,
+                )
+            )
+            for tool_call in response.tool_calls:
+                invocations.append(tool_call.name)
+                descriptor = tools_by_name.get(tool_call.name)
+                if descriptor is None:
+                    history.append(
+                        ChatMessage(
+                            role=ChatRole.TOOL,
+                            content=json.dumps({"error": f"Unknown tool '{tool_call.name}'"}),
+                            tool_call_id=tool_call.id,
+                            name=tool_call.name,
+                        )
+                    )
+                    continue
+                tool_result_payload = await self._invoke_tool(
+                    descriptor=descriptor,
+                    arguments=tool_call.arguments,
+                    organization_id=organization_id,
+                )
+                history.append(
+                    ChatMessage(
+                        role=ChatRole.TOOL,
+                        content=json.dumps(tool_result_payload),
+                        tool_call_id=tool_call.id,
+                        name=tool_call.name,
+                    )
+                )
+
+        logger.warning(
+            "chat_tool_calling_max_iterations_reached",
+            extra={"iterations": self._max_iterations, "invocations": invocations},
+        )
+        return ToolCallingResult(
+            final_answer=(
+                "I tried to call several tools but did not converge to a final answer. "
+                "Please rephrase your request."
+            ),
+            tool_invocations=invocations,
+            iterations=self._max_iterations,
+        )
+
+    async def _invoke_tool(
+        self,
+        descriptor: McpToolDescriptor,
+        arguments: dict[str, Any],
+        organization_id: UUID,
+    ) -> dict[str, Any]:
+        try:
+            return await self._tool_executor.execute(
+                descriptor=descriptor,
+                arguments=arguments,
+                organization_id=organization_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — we deliberately surface to the LLM
+            logger.warning(
+                "chat_tool_invocation_failed",
+                extra={
+                    "tool_name": descriptor.prefixed_name,
+                    "error": str(exc),
+                },
+            )
+            return {"error": str(exc)}

--- a/server/src/raggae/application/services/mcp_tool_resolver.py
+++ b/server/src/raggae/application/services/mcp_tool_resolver.py
@@ -17,6 +17,7 @@ from raggae.application.interfaces.repositories.project_mcp_activation_repositor
     ProjectMcpActivationRepository,
 )
 from raggae.application.interfaces.repositories.project_repository import ProjectRepository
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
 from raggae.domain.value_objects.mcp_auth_type import McpAuthType
 from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
 
@@ -78,3 +79,17 @@ class McpToolResolver:
         if not slug or not original:
             return None
         return slug, original
+
+    @staticmethod
+    def to_llm_descriptors(
+        descriptors: list[McpToolDescriptor],
+    ) -> list[LLMToolDescriptor]:
+        """Project MCP descriptors onto the LLM-facing schema for tool calling."""
+        return [
+            LLMToolDescriptor(
+                name=d.prefixed_name,
+                description=d.description,
+                parameters=d.input_schema or {"type": "object", "properties": {}},
+            )
+            for d in descriptors
+        ]

--- a/server/src/raggae/application/use_cases/chat/send_message.py
+++ b/server/src/raggae/application/use_cases/chat/send_message.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from uuid import UUID, uuid4
@@ -31,10 +32,16 @@ from raggae.application.interfaces.services.project_reranker_service_resolver im
 from raggae.application.interfaces.services.provider_api_key_resolver import (
     ProviderApiKeyResolver,
 )
+from raggae.application.interfaces.services.tool_capable_llm_service import (
+    ToolCapableLLMService,
+)
 from raggae.application.services.agent_configuration_resolver import (
     AgentConfigurationResolver,
 )
 from raggae.application.services.chat_security_policy import StaticChatSecurityPolicy
+from raggae.application.services.chat_tool_calling_session import ChatToolCallingSession
+from raggae.application.services.mcp_tool_executor import McpToolExecutor
+from raggae.application.services.mcp_tool_resolver import McpToolResolver
 from raggae.application.use_cases.chat.query_relevant_chunks import QueryRelevantChunks
 from raggae.domain.entities.conversation import Conversation
 from raggae.domain.entities.message import Message
@@ -45,9 +52,12 @@ from raggae.domain.exceptions.project_exceptions import (
     ProjectNotFoundError,
     ProjectReindexInProgressError,
 )
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole
 from raggae.domain.value_objects.organization_member_role import OrganizationMemberRole
 from raggae.domain.value_objects.resolved_agent_configuration import ResolvedAgentConfiguration
 from raggae.infrastructure.services.prompt_builder import build_rag_prompt
+
+logger = logging.getLogger(__name__)
 
 _API_KEY_PROVIDERS = {"openai", "gemini", "anthropic"}
 
@@ -68,6 +78,8 @@ class SendMessage:
         project_reranker_service_resolver: ProjectRerankerServiceResolver | None = None,
         organization_member_repository: OrganizationMemberRepository | None = None,
         agent_configuration_resolver: AgentConfigurationResolver | None = None,
+        mcp_tool_resolver: McpToolResolver | None = None,
+        mcp_tool_executor: McpToolExecutor | None = None,
         llm_provider: str = "openai",
         chat_security_policy: ChatSecurityPolicy | None = None,
         default_chunk_limit: int = 8,
@@ -86,6 +98,8 @@ class SendMessage:
         self._project_reranker_service_resolver = project_reranker_service_resolver
         self._organization_member_repository = organization_member_repository
         self._agent_configuration_resolver = agent_configuration_resolver
+        self._mcp_tool_resolver = mcp_tool_resolver
+        self._mcp_tool_executor = mcp_tool_executor
         self._llm_provider = llm_provider
         self._default_chunk_limit = max(1, default_chunk_limit)
         self._max_chunk_limit = max(1, max_chunk_limit)
@@ -215,6 +229,64 @@ class SendMessage:
             effective_limit,
         )
         relevant_chunks.sort(key=lambda c: (str(c.document_id), c.chunk_index or 0))
+
+        # Tool-calling branch: if the project has activated MCP tools and the LLM
+        # supports them, run a tool-calling session in parallel with RAG so the
+        # model can search external systems and combine results with the
+        # locally retrieved chunks.
+        tool_calling_response = await self._maybe_run_tool_calling(
+            project=project,
+            user_id=user_id,
+            user_message=message,
+            relevant_chunks=relevant_chunks,
+            conversation_id=conversation.id,
+            current_user_message_id=current_user_message_id,
+            history_window_size=effective_history_window_size,
+            history_max_chars=effective_history_max_chars,
+        )
+        if tool_calling_response is not None:
+            answer, used_tools = tool_calling_response
+            source_documents = self._extract_source_documents(relevant_chunks)
+            reliability_percent = self._compute_reliability_percent(relevant_chunks) if relevant_chunks else 0
+            await self._message_repository.save(
+                Message(
+                    id=uuid4(),
+                    conversation_id=conversation.id,
+                    role="assistant",
+                    content=answer,
+                    source_documents=source_documents,
+                    reliability_percent=reliability_percent,
+                    created_at=datetime.now(UTC),
+                )
+            )
+            if is_new_conversation:
+                title = await self._build_conversation_title(
+                    user_message=message,
+                    assistant_answer=answer,
+                    project=project,
+                    user_id=user_id,
+                )
+                await self._conversation_repository.update_title(conversation.id, title)
+            logger.info(
+                "chat_message_used_mcp_tools",
+                extra={
+                    "project_id": str(project_id),
+                    "conversation_id": str(conversation.id),
+                    "tool_invocations": used_tools,
+                },
+            )
+            return ChatMessageResponseDTO(
+                project_id=project_id,
+                conversation_id=conversation.id,
+                message=message,
+                answer=answer,
+                chunks=relevant_chunks,
+                retrieval_strategy_used=retrieval_result.strategy_used,
+                retrieval_execution_time_ms=retrieval_result.execution_time_ms,
+                history_messages_used=0,
+                chunks_used=len(relevant_chunks),
+            )
+
         if not relevant_chunks:
             fallback_answer = "I could not find relevant context to answer your message."
             await self._message_repository.save(
@@ -538,6 +610,103 @@ class SendMessage:
             history_messages_used=len(conversation_history),
             chunks_used=len(relevant_chunks),
         )
+
+    async def _maybe_run_tool_calling(
+        self,
+        *,
+        project: Project,
+        user_id: UUID,
+        user_message: str,
+        relevant_chunks: list[RetrievedChunkDTO],
+        conversation_id: UUID,
+        current_user_message_id: UUID | None,
+        history_window_size: int,
+        history_max_chars: int,
+    ) -> tuple[str, list[str]] | None:
+        """If MCP tools are activated for the project and the LLM supports them,
+        run a tool-calling session and return ``(answer, used_tool_names)``;
+        return ``None`` to fall back to the standard RAG-only behavior.
+        """
+        if self._mcp_tool_resolver is None or self._mcp_tool_executor is None:
+            return None
+        if project.organization_id is None:
+            return None
+        mcp_descriptors = await self._mcp_tool_resolver.resolve(project.id)
+        if not mcp_descriptors:
+            return None
+
+        resolved_config = await self._resolve_config(project=project, user_id=user_id)
+        llm_service = await self._resolve_llm_service(
+            resolved_config=resolved_config, project=project, user_id=user_id
+        )
+        if not isinstance(llm_service, ToolCapableLLMService):
+            logger.info(
+                "chat_mcp_tools_skipped_provider_not_compatible",
+                extra={"project_id": str(project.id), "llm": type(llm_service).__name__},
+            )
+            return None
+
+        history_messages = await self._build_conversation_history(
+            conversation_id=conversation_id,
+            current_user_message_id=current_user_message_id,
+            history_window_size=history_window_size,
+            history_max_chars=history_max_chars,
+        )
+        system_message = self._build_tool_calling_system_message(
+            project=project, relevant_chunks=relevant_chunks
+        )
+        messages: list[ChatMessage] = [
+            ChatMessage(role=ChatRole.SYSTEM, content=system_message),
+        ]
+        messages.extend(
+            ChatMessage(role=ChatRole.ASSISTANT, content=line[len("Assistant: ") :])
+            if line.startswith("Assistant: ")
+            else ChatMessage(role=ChatRole.USER, content=line[len("User: ") :])
+            if line.startswith("User: ")
+            else ChatMessage(role=ChatRole.USER, content=line)
+            for line in history_messages
+        )
+        messages.append(ChatMessage(role=ChatRole.USER, content=user_message))
+
+        llm_tools = McpToolResolver.to_llm_descriptors(mcp_descriptors)
+        session = ChatToolCallingSession(llm_service=llm_service, tool_executor=self._mcp_tool_executor)
+        result = await session.run(
+            messages=messages,
+            mcp_tools=mcp_descriptors,
+            llm_tools=llm_tools,
+            organization_id=project.organization_id,
+        )
+        sanitized = self._chat_security_policy.sanitize_model_answer(result.final_answer)
+        return sanitized, result.tool_invocations
+
+    def _build_tool_calling_system_message(
+        self,
+        *,
+        project: Project,
+        relevant_chunks: list[RetrievedChunkDTO],
+    ) -> str:
+        """Compose the SYSTEM message that opens a tool-calling conversation.
+
+        Carries the project's system prompt plus any locally retrieved RAG
+        context, so the LLM can combine both knowledge sources with the
+        available MCP tools.
+        """
+        parts: list[str] = []
+        if project.system_prompt:
+            parts.append(project.system_prompt.strip())
+        if relevant_chunks:
+            context_parts = [
+                f"[Source: {chunk.document_file_name or 'unknown'}]\n{chunk.content}"
+                for chunk in relevant_chunks
+            ]
+            parts.append(
+                "Retrieved project context (use it when relevant):\n\n" + "\n\n---\n\n".join(context_parts)
+            )
+        parts.append(
+            "You can call the available MCP tools to fetch external information. "
+            "If retrieved context is sufficient, you may answer without calling tools."
+        )
+        return "\n\n".join(parts)
 
     async def _resolve_config(self, project: Project, user_id: UUID) -> ResolvedAgentConfiguration | None:
         if self._agent_configuration_resolver is None:

--- a/server/src/raggae/domain/value_objects/chat_message.py
+++ b/server/src/raggae/domain/value_objects/chat_message.py
@@ -1,0 +1,45 @@
+"""Value objects describing messages exchanged with a tool-capable LLM.
+
+These types replace the single-string `prompt` used by `LLMService.generate_answer`
+once a conversation enters a tool-calling loop. Each conversation step is now a
+structured `ChatMessage`, and the LLM can return either a final text answer or
+one-or-more tool calls.
+"""
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class ChatRole(StrEnum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    """One tool invocation requested by the LLM during a tool-calling round."""
+
+    id: str
+    name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ChatMessage:
+    """Single message in a tool-capable LLM conversation.
+
+    - SYSTEM / USER / ASSISTANT: `content` carries the text. ASSISTANT may also
+      carry `tool_calls` (without `content`) when the model decided to call tools
+      rather than respond.
+    - TOOL: response to a previous ToolCall; `tool_call_id` references the
+      assistant's ToolCall.id, and `name` is the tool's prefixed name.
+    """
+
+    role: ChatRole
+    content: str | None = None
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_call_id: str | None = None
+    name: str | None = None

--- a/server/src/raggae/domain/value_objects/llm_response.py
+++ b/server/src/raggae/domain/value_objects/llm_response.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass, field
+
+from raggae.domain.value_objects.chat_message import ToolCall
+
+
+@dataclass(frozen=True)
+class LLMTextResponse:
+    """The LLM returned a final textual answer."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class LLMToolCallResponse:
+    """The LLM requested one or more tool invocations before producing a final answer."""
+
+    tool_calls: list[ToolCall] = field(default_factory=list)
+
+
+LLMResponse = LLMTextResponse | LLMToolCallResponse

--- a/server/src/raggae/domain/value_objects/llm_tool_descriptor.py
+++ b/server/src/raggae/domain/value_objects/llm_tool_descriptor.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LLMToolDescriptor:
+    """Description of one tool exposed to a tool-capable LLM.
+
+    `name` is the identifier the LLM will use when calling the tool back
+    (typically the MCP prefixed name `<slug>__<tool_name>`). `parameters` is a
+    JSON Schema describing the arguments.
+    """
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=dict)

--- a/server/src/raggae/infrastructure/services/anthropic_llm_service.py
+++ b/server/src/raggae/infrastructure/services/anthropic_llm_service.py
@@ -1,0 +1,211 @@
+"""LLM adapter for Anthropic Claude (messages API).
+
+Implements `LLMService` (single-prompt text generation) and
+`ToolCapableLLMService` (structured conversation with tool calling) using the
+Anthropic Python SDK. The mapping between our domain `ChatMessage` and
+Anthropic's payload follows the official `messages.create` schema:
+https://docs.anthropic.com/en/api/messages
+"""
+
+import logging
+from collections.abc import AsyncIterator
+from time import perf_counter
+from typing import Any
+
+from anthropic import AsyncAnthropic
+
+from raggae.domain.exceptions.document_exceptions import LLMGenerationError
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole, ToolCall
+from raggae.domain.value_objects.llm_response import (
+    LLMResponse,
+    LLMTextResponse,
+    LLMToolCallResponse,
+)
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_TOKENS = 4096
+
+
+class AnthropicLLMService:
+    """LLM service implementation backed by Anthropic Claude messages API."""
+
+    def __init__(self, api_key: str, model: str, max_tokens: int = _DEFAULT_MAX_TOKENS) -> None:
+        self._client = AsyncAnthropic(api_key=api_key)
+        self._model = model
+        self._max_tokens = max_tokens
+
+    async def generate_answer(self, prompt: str) -> str:
+        started_at = perf_counter()
+        logger.info(
+            "llm_request_started",
+            extra={"backend": "anthropic", "model": self._model},
+        )
+        try:
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = _extract_text_from_content_blocks(response.content)
+            elapsed_ms = (perf_counter() - started_at) * 1000.0
+            logger.info(
+                "llm_request_succeeded",
+                extra={
+                    "backend": "anthropic",
+                    "model": self._model,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            return text
+        except Exception as exc:  # pragma: no cover - provider dependent
+            elapsed_ms = (perf_counter() - started_at) * 1000.0
+            logger.exception(
+                "llm_request_failed",
+                extra={
+                    "backend": "anthropic",
+                    "model": self._model,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            raise LLMGenerationError(f"Failed to generate answer: {exc}") from exc
+
+    async def generate_answer_stream(self, prompt: str) -> AsyncIterator[str]:
+        # Streaming not yet wired into the chat use case; expose the same one-shot
+        # answer as a single chunk to keep the LLMService contract honored.
+        text = await self.generate_answer(prompt)
+        yield text
+
+    async def generate_with_tools(
+        self,
+        messages: list[ChatMessage],
+        tools: list[LLMToolDescriptor],
+    ) -> LLMResponse:
+        system_prompt = _extract_system_prompt(messages)
+        anthropic_messages = _build_anthropic_messages(messages)
+        anthropic_tools = [_tool_to_anthropic(t) for t in tools] if tools else None
+
+        started_at = perf_counter()
+        logger.info(
+            "llm_tools_request_started",
+            extra={"backend": "anthropic", "model": self._model, "tools_count": len(tools)},
+        )
+        try:
+            kwargs: dict[str, Any] = {
+                "model": self._model,
+                "max_tokens": self._max_tokens,
+                "messages": anthropic_messages,
+            }
+            if system_prompt is not None:
+                kwargs["system"] = system_prompt
+            if anthropic_tools is not None:
+                kwargs["tools"] = anthropic_tools
+            response = await self._client.messages.create(**kwargs)
+        except Exception as exc:
+            elapsed_ms = (perf_counter() - started_at) * 1000.0
+            logger.exception(
+                "llm_tools_request_failed",
+                extra={
+                    "backend": "anthropic",
+                    "model": self._model,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            raise LLMGenerationError(f"Failed to generate with tools: {exc}") from exc
+
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+        logger.info(
+            "llm_tools_request_succeeded",
+            extra={
+                "backend": "anthropic",
+                "model": self._model,
+                "elapsed_ms": round(elapsed_ms, 2),
+            },
+        )
+
+        tool_calls = _extract_tool_calls(response.content)
+        if tool_calls:
+            return LLMToolCallResponse(tool_calls=tool_calls)
+        return LLMTextResponse(text=_extract_text_from_content_blocks(response.content))
+
+
+def _extract_system_prompt(messages: list[ChatMessage]) -> str | None:
+    """Anthropic carries the system prompt as a top-level `system` argument."""
+    system_parts = [m.content or "" for m in messages if m.role == ChatRole.SYSTEM and m.content]
+    if not system_parts:
+        return None
+    return "\n\n".join(system_parts)
+
+
+def _build_anthropic_messages(messages: list[ChatMessage]) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    for message in messages:
+        if message.role == ChatRole.SYSTEM:
+            continue
+        if message.role == ChatRole.TOOL:
+            output.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": message.tool_call_id or "",
+                            "content": message.content or "",
+                        }
+                    ],
+                }
+            )
+            continue
+        if message.role == ChatRole.ASSISTANT and message.tool_calls:
+            blocks: list[dict[str, Any]] = []
+            if message.content:
+                blocks.append({"type": "text", "text": message.content})
+            for tc in message.tool_calls:
+                blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": tc.id,
+                        "name": tc.name,
+                        "input": tc.arguments,
+                    }
+                )
+            output.append({"role": "assistant", "content": blocks})
+            continue
+        output.append({"role": message.role.value, "content": message.content or ""})
+    return output
+
+
+def _tool_to_anthropic(tool: LLMToolDescriptor) -> dict[str, Any]:
+    return {
+        "name": tool.name,
+        "description": tool.description,
+        "input_schema": tool.parameters or {"type": "object", "properties": {}},
+    }
+
+
+def _extract_text_from_content_blocks(blocks: Any) -> str:
+    parts: list[str] = []
+    for block in blocks or []:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            parts.append(getattr(block, "text", "") or "")
+    return "".join(parts)
+
+
+def _extract_tool_calls(blocks: Any) -> list[ToolCall]:
+    tool_calls: list[ToolCall] = []
+    for block in blocks or []:
+        if getattr(block, "type", None) != "tool_use":
+            continue
+        arguments = getattr(block, "input", None) or {}
+        if not isinstance(arguments, dict):
+            arguments = {}
+        tool_calls.append(
+            ToolCall(
+                id=getattr(block, "id", ""),
+                name=getattr(block, "name", ""),
+                arguments=arguments,
+            )
+        )
+    return tool_calls

--- a/server/src/raggae/infrastructure/services/openai_llm_service.py
+++ b/server/src/raggae/infrastructure/services/openai_llm_service.py
@@ -1,16 +1,29 @@
+import json
 import logging
 from collections.abc import AsyncIterator
 from time import perf_counter
+from typing import Any
 
 from openai import AsyncOpenAI
 
 from raggae.domain.exceptions.document_exceptions import LLMGenerationError
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole, ToolCall
+from raggae.domain.value_objects.llm_response import (
+    LLMResponse,
+    LLMTextResponse,
+    LLMToolCallResponse,
+)
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
 
 logger = logging.getLogger(__name__)
 
 
 class OpenAILLMService:
-    """LLM service implementation backed by OpenAI chat completions."""
+    """LLM service implementation backed by OpenAI chat completions.
+
+    Implements both `LLMService` (single-prompt text generation) and
+    `ToolCapableLLMService` (structured conversation with tool calling).
+    """
 
     def __init__(self, api_key: str, model: str) -> None:
         self._client = AsyncOpenAI(api_key=api_key)
@@ -86,3 +99,101 @@ class OpenAILLMService:
                 },
             )
             raise LLMGenerationError(f"Failed to stream answer: {exc}") from exc
+
+    async def generate_with_tools(
+        self,
+        messages: list[ChatMessage],
+        tools: list[LLMToolDescriptor],
+    ) -> LLMResponse:
+        openai_messages = [_message_to_openai(m) for m in messages]
+        openai_tools = [_tool_to_openai(t) for t in tools] if tools else None
+
+        started_at = perf_counter()
+        logger.info(
+            "llm_tools_request_started",
+            extra={"backend": "openai", "model": self._model, "tools_count": len(tools)},
+        )
+        try:
+            response = await self._client.chat.completions.create(
+                model=self._model,
+                messages=openai_messages,  # type: ignore[arg-type]
+                tools=openai_tools,  # type: ignore[arg-type]
+            )
+        except Exception as exc:
+            elapsed_ms = (perf_counter() - started_at) * 1000.0
+            logger.exception(
+                "llm_tools_request_failed",
+                extra={
+                    "backend": "openai",
+                    "model": self._model,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            raise LLMGenerationError(f"Failed to generate with tools: {exc}") from exc
+
+        elapsed_ms = (perf_counter() - started_at) * 1000.0
+        logger.info(
+            "llm_tools_request_succeeded",
+            extra={
+                "backend": "openai",
+                "model": self._model,
+                "elapsed_ms": round(elapsed_ms, 2),
+            },
+        )
+        choice = response.choices[0].message
+        raw_tool_calls = getattr(choice, "tool_calls", None) or []
+        if raw_tool_calls:
+            return LLMToolCallResponse(
+                tool_calls=[_openai_tool_call_to_domain(tc) for tc in raw_tool_calls],
+            )
+        return LLMTextResponse(text=choice.content or "")
+
+
+def _message_to_openai(message: ChatMessage) -> dict[str, Any]:
+    if message.role == ChatRole.TOOL:
+        return {
+            "role": "tool",
+            "tool_call_id": message.tool_call_id or "",
+            "content": message.content or "",
+        }
+    if message.role == ChatRole.ASSISTANT and message.tool_calls:
+        return {
+            "role": "assistant",
+            "content": message.content,
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.arguments),
+                    },
+                }
+                for tc in message.tool_calls
+            ],
+        }
+    return {"role": message.role.value, "content": message.content or ""}
+
+
+def _tool_to_openai(tool: LLMToolDescriptor) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.parameters or {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _openai_tool_call_to_domain(raw_tool_call: Any) -> ToolCall:
+    args_raw = raw_tool_call.function.arguments if raw_tool_call.function else "{}"
+    try:
+        arguments = json.loads(args_raw) if args_raw else {}
+    except json.JSONDecodeError:
+        arguments = {}
+    return ToolCall(
+        id=raw_tool_call.id,
+        name=raw_tool_call.function.name if raw_tool_call.function else "",
+        arguments=arguments,
+    )

--- a/server/src/raggae/infrastructure/services/project_llm_service_resolver.py
+++ b/server/src/raggae/infrastructure/services/project_llm_service_resolver.py
@@ -3,6 +3,7 @@ from raggae.application.interfaces.services.provider_api_key_crypto_service impo
     ProviderApiKeyCryptoService,
 )
 from raggae.infrastructure.config.settings import Settings
+from raggae.infrastructure.services.anthropic_llm_service import AnthropicLLMService
 from raggae.infrastructure.services.gemini_llm_service import GeminiLLMService
 from raggae.infrastructure.services.in_memory_llm_service import InMemoryLLMService
 from raggae.infrastructure.services.ollama_llm_service import OllamaLLMService
@@ -43,6 +44,13 @@ class ProjectLLMServiceResolver:
             )
             effective_model = model or self._resolve_default_model(effective_backend)
             return GeminiLLMService(api_key=api_key, model=effective_model)
+
+        if effective_backend == "anthropic":
+            api_key = self._resolve_api_key(
+                encrypted_api_key, self._resolve_default_api_key(effective_backend)
+            )
+            effective_model = model or self._resolve_default_model(effective_backend)
+            return AnthropicLLMService(api_key=api_key, model=effective_model)
 
         if effective_backend == "ollama":
             effective_model = model or self._resolve_default_model(effective_backend)

--- a/server/src/raggae/presentation/api/dependencies.py
+++ b/server/src/raggae/presentation/api/dependencies.py
@@ -939,6 +939,8 @@ def get_send_message_use_case() -> SendMessage:
         project_reranker_service_resolver=_project_reranker_service_resolver,
         organization_member_repository=_organization_member_repository,
         agent_configuration_resolver=_agent_configuration_resolver,
+        mcp_tool_resolver=get_mcp_tool_resolver(),
+        mcp_tool_executor=get_mcp_tool_executor(),
         llm_provider=settings.default_llm_provider,
         default_chunk_limit=settings.retrieval_default_chunk_limit,
         history_window_size=settings.chat_history_window_size,

--- a/server/tests/unit/application/services/test_chat_tool_calling_session.py
+++ b/server/tests/unit/application/services/test_chat_tool_calling_session.py
@@ -1,0 +1,181 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from raggae.application.services.chat_tool_calling_session import (
+    ChatToolCallingSession,
+)
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole, ToolCall
+from raggae.domain.value_objects.llm_response import (
+    LLMTextResponse,
+    LLMToolCallResponse,
+)
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+from raggae.domain.value_objects.mcp_tool_descriptor import McpToolDescriptor
+
+
+def _make_mcp_descriptor(prefixed_name: str = "notion__search") -> McpToolDescriptor:
+    return McpToolDescriptor(
+        mcp_server_id=uuid4(),
+        mcp_server_slug="notion",
+        original_name="search",
+        prefixed_name=prefixed_name,
+        description="Search",
+        input_schema={},
+        server_url="https://mcp.example.com",
+        has_bearer_token=False,
+        timeout_seconds=30,
+    )
+
+
+def _make_llm_descriptor(name: str = "notion__search") -> LLMToolDescriptor:
+    return LLMToolDescriptor(name=name, description="Search", parameters={})
+
+
+def _build_session(
+    *,
+    llm_responses: list,
+    executor_results: list | None = None,
+    executor_raises: Exception | None = None,
+) -> tuple[ChatToolCallingSession, dict]:
+    llm = AsyncMock()
+    llm.generate_with_tools = AsyncMock(side_effect=list(llm_responses))
+    executor = AsyncMock()
+    if executor_raises is not None:
+        executor.execute = AsyncMock(side_effect=executor_raises)
+    else:
+        executor.execute = AsyncMock(side_effect=list(executor_results or []))
+    session = ChatToolCallingSession(llm_service=llm, tool_executor=executor, max_iterations=5)
+    return session, {"llm": llm, "executor": executor}
+
+
+class TestChatToolCallingSession:
+    async def test_returns_final_answer_when_llm_replies_directly(self) -> None:
+        # Given
+        session, deps = _build_session(llm_responses=[LLMTextResponse(text="Hi there")])
+
+        # When
+        result = await session.run(
+            messages=[ChatMessage(role=ChatRole.USER, content="hello")],
+            mcp_tools=[],
+            llm_tools=[],
+            organization_id=uuid4(),
+        )
+
+        # Then
+        assert result.final_answer == "Hi there"
+        assert result.iterations == 1
+        assert result.tool_invocations == []
+        deps["executor"].execute.assert_not_awaited()
+
+    async def test_routes_tool_call_to_executor_and_completes(self) -> None:
+        # Given
+        descriptor = _make_mcp_descriptor()
+        first = LLMToolCallResponse(
+            tool_calls=[ToolCall(id="call_1", name=descriptor.prefixed_name, arguments={"q": "x"})],
+        )
+        second = LLMTextResponse(text="Final answer using tool result")
+        session, deps = _build_session(
+            llm_responses=[first, second],
+            executor_results=[{"content": "match"}],
+        )
+
+        # When
+        result = await session.run(
+            messages=[ChatMessage(role=ChatRole.USER, content="search")],
+            mcp_tools=[descriptor],
+            llm_tools=[_make_llm_descriptor()],
+            organization_id=uuid4(),
+        )
+
+        # Then
+        assert result.final_answer == "Final answer using tool result"
+        assert result.iterations == 2
+        assert result.tool_invocations == [descriptor.prefixed_name]
+        deps["executor"].execute.assert_awaited_once()
+        # Verify the executor was called with the right descriptor and arguments
+        call_kwargs = deps["executor"].execute.await_args.kwargs
+        assert call_kwargs["descriptor"] is descriptor
+        assert call_kwargs["arguments"] == {"q": "x"}
+
+    async def test_unknown_tool_returns_error_to_llm_and_continues(self) -> None:
+        # Given
+        first = LLMToolCallResponse(
+            tool_calls=[ToolCall(id="call_1", name="ghost__delete", arguments={})],
+        )
+        second = LLMTextResponse(text="Sorry, ignored")
+        session, deps = _build_session(llm_responses=[first, second])
+
+        # When
+        result = await session.run(
+            messages=[ChatMessage(role=ChatRole.USER, content="x")],
+            mcp_tools=[_make_mcp_descriptor()],
+            llm_tools=[],
+            organization_id=uuid4(),
+        )
+
+        # Then
+        assert result.final_answer == "Sorry, ignored"
+        # Executor must NOT be called for unknown tools
+        deps["executor"].execute.assert_not_awaited()
+        # The second LLM call must include the error tool message
+        second_call_kwargs = deps["llm"].generate_with_tools.await_args_list[1].kwargs
+        last_msg = second_call_kwargs["messages"][-1]
+        assert last_msg.role == ChatRole.TOOL
+        assert "Unknown tool" in last_msg.content
+
+    async def test_tool_execution_failure_is_surfaced_as_tool_result(self) -> None:
+        # Given
+        descriptor = _make_mcp_descriptor()
+        first = LLMToolCallResponse(
+            tool_calls=[ToolCall(id="call_1", name=descriptor.prefixed_name, arguments={})],
+        )
+        second = LLMTextResponse(text="Could not search")
+        session, deps = _build_session(
+            llm_responses=[first, second],
+            executor_raises=RuntimeError("timeout"),
+        )
+
+        # When
+        result = await session.run(
+            messages=[ChatMessage(role=ChatRole.USER, content="x")],
+            mcp_tools=[descriptor],
+            llm_tools=[_make_llm_descriptor()],
+            organization_id=uuid4(),
+        )
+
+        # Then
+        assert result.final_answer == "Could not search"
+        # Verify the tool result message contains the error payload
+        second_call_kwargs = deps["llm"].generate_with_tools.await_args_list[1].kwargs
+        last_msg = second_call_kwargs["messages"][-1]
+        assert last_msg.role == ChatRole.TOOL
+        assert "timeout" in last_msg.content
+
+    async def test_stops_at_max_iterations_with_fallback_answer(self) -> None:
+        # Given — always returns a tool call, never converges
+        descriptor = _make_mcp_descriptor()
+        looping_response = LLMToolCallResponse(
+            tool_calls=[ToolCall(id="call_loop", name=descriptor.prefixed_name, arguments={})],
+        )
+        # 5 LLM responses for max_iterations=5
+        session, deps = _build_session(
+            llm_responses=[looping_response] * 5,
+            executor_results=[{"ok": True}] * 5,
+        )
+
+        # When
+        result = await session.run(
+            messages=[ChatMessage(role=ChatRole.USER, content="x")],
+            mcp_tools=[descriptor],
+            llm_tools=[_make_llm_descriptor()],
+            organization_id=uuid4(),
+        )
+
+        # Then
+        assert result.iterations == 5
+        assert "did not converge" in result.final_answer
+
+    async def test_dummy_now_to_keep_imports_alive(self) -> None:
+        # Keep `datetime`/`UTC` import valid by exercising a no-op assertion
+        assert datetime.now(UTC) is not None

--- a/server/tests/unit/infrastructure/services/test_anthropic_llm_service.py
+++ b/server/tests/unit/infrastructure/services/test_anthropic_llm_service.py
@@ -1,0 +1,141 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole, ToolCall
+from raggae.domain.value_objects.llm_response import LLMTextResponse, LLMToolCallResponse
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+from raggae.infrastructure.services.anthropic_llm_service import AnthropicLLMService
+
+
+def _make_service(create_mock: AsyncMock) -> AnthropicLLMService:
+    service = AnthropicLLMService(api_key="sk-ant", model="claude-3-5-sonnet")
+    service._client = SimpleNamespace(  # type: ignore[assignment]
+        messages=SimpleNamespace(create=create_mock)
+    )
+    return service
+
+
+def _text_response(text: str) -> Any:
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text=text)])
+
+
+def _tool_use_response(name: str, arguments: dict[str, Any], call_id: str = "toolu_1") -> Any:
+    return SimpleNamespace(content=[SimpleNamespace(type="tool_use", id=call_id, name=name, input=arguments)])
+
+
+class TestAnthropicGenerateWithTools:
+    async def test_returns_text_response(self) -> None:
+        create_mock = AsyncMock(return_value=_text_response("Hello"))
+        service = _make_service(create_mock)
+
+        result = await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="Hi")],
+            tools=[],
+        )
+
+        assert isinstance(result, LLMTextResponse)
+        assert result.text == "Hello"
+
+    async def test_returns_tool_call_response(self) -> None:
+        create_mock = AsyncMock(
+            return_value=_tool_use_response(name="notion__search", arguments={"q": "x"}, call_id="toolu_xyz")
+        )
+        service = _make_service(create_mock)
+
+        result = await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="search")],
+            tools=[
+                LLMToolDescriptor(
+                    name="notion__search",
+                    description="Search",
+                    parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+                )
+            ],
+        )
+
+        assert isinstance(result, LLMToolCallResponse)
+        assert result.tool_calls[0].id == "toolu_xyz"
+        assert result.tool_calls[0].name == "notion__search"
+        assert result.tool_calls[0].arguments == {"q": "x"}
+
+    async def test_extracts_system_prompt_to_top_level(self) -> None:
+        create_mock = AsyncMock(return_value=_text_response("ok"))
+        service = _make_service(create_mock)
+
+        await service.generate_with_tools(
+            messages=[
+                ChatMessage(role=ChatRole.SYSTEM, content="You are helpful."),
+                ChatMessage(role=ChatRole.USER, content="hi"),
+            ],
+            tools=[],
+        )
+
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["system"] == "You are helpful."
+        # The system message must NOT appear in the messages array
+        assert all(m["role"] != "system" for m in kwargs["messages"])
+
+    async def test_tool_use_then_tool_result_round_trip(self) -> None:
+        # Given — an assistant message with a tool_use followed by a tool result
+        create_mock = AsyncMock(return_value=_text_response("final"))
+        service = _make_service(create_mock)
+
+        await service.generate_with_tools(
+            messages=[
+                ChatMessage(role=ChatRole.USER, content="search docs"),
+                ChatMessage(
+                    role=ChatRole.ASSISTANT,
+                    content=None,
+                    tool_calls=[ToolCall(id="toolu_1", name="notion__search", arguments={"q": "report"})],
+                ),
+                ChatMessage(
+                    role=ChatRole.TOOL,
+                    content='{"hits":[]}',
+                    tool_call_id="toolu_1",
+                    name="notion__search",
+                ),
+            ],
+            tools=[],
+        )
+
+        kwargs = create_mock.await_args.kwargs
+        msgs = kwargs["messages"]
+        # Assistant message carries a tool_use block
+        assistant = next(m for m in msgs if m["role"] == "assistant")
+        assert assistant["content"][0]["type"] == "tool_use"
+        assert assistant["content"][0]["id"] == "toolu_1"
+        assert assistant["content"][0]["input"] == {"q": "report"}
+        # Tool result is folded into a user message with tool_result block
+        tool_user = msgs[-1]
+        assert tool_user["role"] == "user"
+        assert tool_user["content"][0]["type"] == "tool_result"
+        assert tool_user["content"][0]["tool_use_id"] == "toolu_1"
+        assert tool_user["content"][0]["content"] == '{"hits":[]}'
+
+    async def test_tools_are_serialized_to_anthropic_format(self) -> None:
+        create_mock = AsyncMock(return_value=_text_response(""))
+        service = _make_service(create_mock)
+
+        await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")],
+            tools=[
+                LLMToolDescriptor(
+                    name="notion__search",
+                    description="Search Notion",
+                    parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+                )
+            ],
+        )
+
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["tools"] == [
+            {
+                "name": "notion__search",
+                "description": "Search Notion",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            }
+        ]

--- a/server/tests/unit/infrastructure/services/test_openai_tool_calling.py
+++ b/server/tests/unit/infrastructure/services/test_openai_tool_calling.py
@@ -1,0 +1,186 @@
+"""Unit tests for OpenAILLMService.generate_with_tools.
+
+We patch the AsyncOpenAI client to avoid any network call and verify both the
+shape of the payload sent to OpenAI and the parsing of the response into
+domain `LLMResponse` value objects.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+from raggae.domain.value_objects.chat_message import ChatMessage, ChatRole, ToolCall
+from raggae.domain.value_objects.llm_response import LLMTextResponse, LLMToolCallResponse
+from raggae.domain.value_objects.llm_tool_descriptor import LLMToolDescriptor
+from raggae.infrastructure.services.openai_llm_service import OpenAILLMService
+
+
+def _make_service(create_mock: AsyncMock) -> OpenAILLMService:
+    service = OpenAILLMService(api_key="sk-test", model="gpt-4o-mini")
+    # Patch the inner AsyncOpenAI client directly to keep type checkers happy
+    service._client = SimpleNamespace(  # type: ignore[assignment]
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
+    )
+    return service
+
+
+def _openai_text_response(text: str) -> Any:
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=text, tool_calls=None))])
+
+
+def _openai_tool_call_response(name: str, arguments: dict[str, Any], call_id: str = "call_1") -> Any:
+    function = SimpleNamespace(name=name, arguments=json.dumps(arguments))
+    tool_call = SimpleNamespace(id=call_id, function=function)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tool_call]))]
+    )
+
+
+class TestOpenAIGenerateWithTools:
+    async def test_returns_text_response_when_model_answers(self) -> None:
+        # Given
+        create_mock = AsyncMock(return_value=_openai_text_response("Hello"))
+        service = _make_service(create_mock)
+
+        # When
+        result = await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="Hi")],
+            tools=[],
+        )
+
+        # Then
+        assert isinstance(result, LLMTextResponse)
+        assert result.text == "Hello"
+
+    async def test_returns_tool_call_response_when_model_calls_a_tool(self) -> None:
+        # Given
+        create_mock = AsyncMock(
+            return_value=_openai_tool_call_response(
+                name="notion__search", arguments={"q": "report"}, call_id="call_xyz"
+            )
+        )
+        service = _make_service(create_mock)
+        descriptor = LLMToolDescriptor(
+            name="notion__search",
+            description="Search Notion",
+            parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+
+        # When
+        result = await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="search the report")],
+            tools=[descriptor],
+        )
+
+        # Then
+        assert isinstance(result, LLMToolCallResponse)
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].id == "call_xyz"
+        assert result.tool_calls[0].name == "notion__search"
+        assert result.tool_calls[0].arguments == {"q": "report"}
+
+    async def test_payload_uses_openai_tool_format(self) -> None:
+        # Given
+        create_mock = AsyncMock(return_value=_openai_text_response(""))
+        service = _make_service(create_mock)
+        descriptor = LLMToolDescriptor(
+            name="notion__search",
+            description="Search",
+            parameters={"type": "object", "properties": {"q": {"type": "string"}}},
+        )
+
+        # When
+        await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")],
+            tools=[descriptor],
+        )
+
+        # Then
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"
+        assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+        assert kwargs["tools"] == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "notion__search",
+                    "description": "Search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+
+    async def test_serializes_assistant_message_with_tool_calls(self) -> None:
+        # Given
+        create_mock = AsyncMock(return_value=_openai_text_response("done"))
+        service = _make_service(create_mock)
+        assistant_msg = ChatMessage(
+            role=ChatRole.ASSISTANT,
+            content=None,
+            tool_calls=[ToolCall(id="call_1", name="notion__search", arguments={"q": "hi"})],
+        )
+
+        # When
+        await service.generate_with_tools(
+            messages=[
+                ChatMessage(role=ChatRole.USER, content="search"),
+                assistant_msg,
+                ChatMessage(
+                    role=ChatRole.TOOL,
+                    content='{"result":"ok"}',
+                    tool_call_id="call_1",
+                    name="notion__search",
+                ),
+            ],
+            tools=[],
+        )
+
+        # Then — assistant message carries serialized tool_calls
+        kwargs = create_mock.await_args.kwargs
+        sent_messages = kwargs["messages"]
+        assert sent_messages[1]["role"] == "assistant"
+        assert sent_messages[1]["tool_calls"][0]["function"]["name"] == "notion__search"
+        assert sent_messages[1]["tool_calls"][0]["function"]["arguments"] == '{"q": "hi"}'
+        # Tool reply message is well-formed
+        assert sent_messages[2]["role"] == "tool"
+        assert sent_messages[2]["tool_call_id"] == "call_1"
+        assert sent_messages[2]["content"] == '{"result":"ok"}'
+
+    async def test_empty_tools_list_sends_no_tools_param(self) -> None:
+        # Given
+        create_mock = AsyncMock(return_value=_openai_text_response("hi"))
+        service = _make_service(create_mock)
+
+        # When
+        await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")],
+            tools=[],
+        )
+
+        # Then
+        kwargs = create_mock.await_args.kwargs
+        assert kwargs["tools"] is None
+
+    async def test_invalid_arguments_json_falls_back_to_empty_dict(self) -> None:
+        # Given — defensive parsing when the model returns malformed JSON
+        function = SimpleNamespace(name="notion__search", arguments="not json")
+        tool_call = SimpleNamespace(id="call_1", function=function)
+        bad_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tool_call]))]
+        )
+        create_mock = AsyncMock(return_value=bad_response)
+        service = _make_service(create_mock)
+
+        # When
+        result = await service.generate_with_tools(
+            messages=[ChatMessage(role=ChatRole.USER, content="hi")],
+            tools=[],
+        )
+
+        # Then
+        assert isinstance(result, LLMToolCallResponse)
+        assert result.tool_calls[0].arguments == {}


### PR DESCRIPTION
## Problème

À la fin de la série MCP, un utilisateur pouvait déclarer un serveur MCP, l'activer dans un projet et voir ses outils en UI, mais en posant une question liée à ce MCP, le chat répondait `"I could not find relevant context to answer your message."` — le RAG sortait à vide et le LLM n'avait jamais vu les outils.

Le wiring avait été explicitement reporté en PR 5 (note dans `docs/MCP_FEATURE_PLAN.md`) pour éviter de modifier le use case `send_message.py` (~34k lignes) en même temps qu'on définissait les fondations. Cette PR 5b livre ce wiring.

## Solution

Trois choix de cadrage figés avec l'utilisateur :
- **Providers** : OpenAI + Anthropic.
- **RAG + MCP en parallèle** : le LLM reçoit les chunks RAG dans le system message *et* les outils MCP en `tools=[...]`. Il décide.
- **Non-streaming uniquement** : seul `execute()` est modifié ; `execute_stream()` conserve le comportement actuel.

## Implémentation

### Domaine + Application

- Value objects `ChatMessage`, `ChatRole`, `ToolCall`, `LLMToolDescriptor`, `LLMResponse` (union `LLMTextResponse | LLMToolCallResponse`).
- Port `ToolCapableLLMService` (runtime_checkable) — un adapter LLM peut implémenter à la fois `LLMService` (single-prompt) et `ToolCapableLLMService` (messages structurés).
- Helper `McpToolResolver.to_llm_descriptors(...)` qui projette `McpToolDescriptor` en `LLMToolDescriptor` (parameters = inputSchema MCP).
- Service `ChatToolCallingSession` : prend une liste de messages + tools MCP/LLM, boucle (cap à 6 itérations) entre `LLMService.generate_with_tools` et `McpToolExecutor.execute`. Tools inconnus / exceptions sont remontés comme `tool_result` d'erreur pour que le modèle s'adapte.

### Infrastructure

- `OpenAILLMService` étendu : `generate_with_tools` sérialise les messages au format OpenAI Chat Completions (incl. `tool_calls` côté assistant et `role=tool` pour les réponses), parse la réponse en `LLMTextResponse` ou `LLMToolCallResponse`.
- `AnthropicLLMService` créé from scratch (dépendance `anthropic>=0.40.0`). Mapping conforme à la spec `messages.create` : `system` au top-level, blocs `tool_use` côté assistant, `tool_result` côté user.
- `project_llm_service_resolver` enregistre `anthropic`.

### Use case

- `SendMessage.__init__` accepte `mcp_tool_resolver` / `mcp_tool_executor` optionnels.
- Dans `execute()`, après le sort des chunks, on appelle `_maybe_run_tool_calling` :
  - retourne `None` si aucun MCP activé ou si le LLM n'est pas tool-capable → comportement historique.
  - sinon construit un SYSTEM message (system prompt + chunks RAG retrouvés), une conversation history et appelle `ChatToolCallingSession.run(...)`. La réponse remplace le fallback "no context".
- DI : `get_send_message_use_case` injecte `get_mcp_tool_resolver()` et `get_mcp_tool_executor()`.

## Tests

- **17 nouveaux tests unitaires** :
  - OpenAI generate_with_tools : 6 (texte, tool call, format payload, round-trip tool_calls, no tools, args JSON malformés).
  - Anthropic generate_with_tools : 5 (texte, tool_use, system prompt extracté, round-trip tool_use/tool_result, tools format).
  - ChatToolCallingSession : 6 (réponse directe, routage tool, tool inconnu, exécution échouée, max iterations, garde-fous).
- Total backend : **1094 passed, 0 failed, 43 skipped**.
- mypy / ruff / format : clean.

## Recette

1. Appliquer la branche, `pip install -e ".[dev,test]"` (ajout d'`anthropic`), `alembic upgrade head`.
2. Backend qualité : `pytest && ruff format src/ tests/ && ruff check src/ tests/ && mypy src/`.
3. Test fonctionnel réel (le scénario qui motivait la PR) :
   - Reprendre le projet déjà câblé avec le MCP Outline (organisation + activation projet).
   - S'assurer que le projet utilise OpenAI ou Anthropic avec une clé valide.
   - Reposer la question `"regarde dans Outline la dernière page d'entrée de journal de WAATcher et fais m'en un résumé"`.
   - Le LLM doit maintenant appeler les tools Outline et synthétiser la réponse.
4. Vérifier les logs : entrées `llm_tools_request_started`, `mcp_tool_call_succeeded`, `chat_message_used_mcp_tools`.

## Limites volontaires

- **Streaming non câblé** : `execute_stream` continue sans tool calling. Tâche future.
- **Gemini / Mistral non câblés** : le warning UI existant ("provider non compatible") reste valable pour eux. Tâche future si besoin.
- Pas de retry serveur sur erreur d'outil : l'erreur est remontée au LLM qui décide.