### PR TITLE
feat(stats): tooltip au survol des sparklines

### DIFF
--- a/client/src/components/atoms/stats/sparkline.tsx
+++ b/client/src/components/atoms/stats/sparkline.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 
 interface SparklinePoint {
@@ -18,8 +21,34 @@ export function SparklineCard({ label, points, total }: SparklineCardProps) {
   const sum = total ?? points.reduce((acc, p) => acc + p.value, 0);
   const max = points.reduce((acc, p) => (p.value > acc ? p.value : acc), 0);
 
-  const path = buildPath(points, max);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+  const { path, areaPath, coords } = useMemo(
+    () => buildGeometry(points, max),
+    [points, max],
+  );
+
   const lastValue = points.length > 0 ? points[points.length - 1].value : 0;
+  const hovered = hoverIndex !== null ? points[hoverIndex] : null;
+  const hoveredCoord = hoverIndex !== null ? coords[hoverIndex] : null;
+
+  function handleMove(event: React.MouseEvent<SVGSVGElement>) {
+    if (points.length === 0 || max === 0) return;
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    const rect = svg.getBoundingClientRect();
+    const relativeX = ((event.clientX - rect.left) / rect.width) * VIEWBOX_WIDTH;
+    const stepX = VIEWBOX_WIDTH / Math.max(points.length - 1, 1);
+    const index = Math.round(relativeX / stepX);
+    const clamped = Math.min(Math.max(index, 0), points.length - 1);
+    setHoverIndex(clamped);
+  }
+
+  function handleLeave() {
+    setHoverIndex(null);
+  }
 
   return (
     <Card className="flex flex-col gap-2 p-5">
@@ -29,35 +58,83 @@ export function SparklineCard({ label, points, total }: SparklineCardProps) {
           {sum.toLocaleString("fr-FR")}
         </span>
       </div>
-      <svg
-        viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
-        className="h-16 w-full"
-        preserveAspectRatio="none"
-        role="img"
-        aria-label={`Évolution de ${label}`}
-      >
-        {max > 0 ? (
-          <path
-            d={path}
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={1.5}
-            className="text-primary"
-            vectorEffect="non-scaling-stroke"
-          />
-        ) : (
-          <line
-            x1={0}
-            x2={VIEWBOX_WIDTH}
-            y1={VIEWBOX_HEIGHT / 2}
-            y2={VIEWBOX_HEIGHT / 2}
-            stroke="currentColor"
-            strokeWidth={1}
-            strokeDasharray="3 3"
-            className="text-muted-foreground/40"
-          />
+      <div className="relative">
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          className="h-16 w-full cursor-crosshair"
+          preserveAspectRatio="none"
+          role="img"
+          aria-label={`Évolution de ${label}`}
+          onMouseMove={handleMove}
+          onMouseLeave={handleLeave}
+        >
+          {max > 0 ? (
+            <>
+              <path
+                d={areaPath}
+                fill="currentColor"
+                className="text-primary/10"
+                vectorEffect="non-scaling-stroke"
+              />
+              <path
+                d={path}
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                className="text-primary"
+                vectorEffect="non-scaling-stroke"
+              />
+              {hoveredCoord && (
+                <>
+                  <line
+                    x1={hoveredCoord.x}
+                    x2={hoveredCoord.x}
+                    y1={0}
+                    y2={VIEWBOX_HEIGHT}
+                    stroke="currentColor"
+                    strokeWidth={1}
+                    strokeDasharray="2 2"
+                    className="text-muted-foreground"
+                    vectorEffect="non-scaling-stroke"
+                  />
+                  <circle
+                    cx={hoveredCoord.x}
+                    cy={hoveredCoord.y}
+                    r={3}
+                    className="fill-background stroke-primary"
+                    strokeWidth={1.5}
+                    vectorEffect="non-scaling-stroke"
+                  />
+                </>
+              )}
+            </>
+          ) : (
+            <line
+              x1={0}
+              x2={VIEWBOX_WIDTH}
+              y1={VIEWBOX_HEIGHT / 2}
+              y2={VIEWBOX_HEIGHT / 2}
+              stroke="currentColor"
+              strokeWidth={1}
+              strokeDasharray="3 3"
+              className="text-muted-foreground/40"
+            />
+          )}
+        </svg>
+        {hovered && hoveredCoord && (
+          <div
+            className="pointer-events-none absolute -top-2 z-10 -translate-x-1/2 -translate-y-full rounded-md border bg-popover px-2 py-1 text-xs text-popover-foreground shadow-md"
+            style={{ left: `${(hoveredCoord.x / VIEWBOX_WIDTH) * 100}%` }}
+            role="tooltip"
+          >
+            <div className="font-semibold tabular-nums">
+              {hovered.value.toLocaleString("fr-FR")}
+            </div>
+            <div className="text-muted-foreground">{formatDate(hovered.date)}</div>
+          </div>
         )}
-      </svg>
+      </div>
       <span className="text-xs text-muted-foreground">
         Dernier jour : {lastValue.toLocaleString("fr-FR")}
       </span>
@@ -65,14 +142,41 @@ export function SparklineCard({ label, points, total }: SparklineCardProps) {
   );
 }
 
-function buildPath(points: SparklinePoint[], max: number): string {
-  if (points.length === 0 || max === 0) return "";
+interface Coord {
+  x: number;
+  y: number;
+}
+
+interface Geometry {
+  path: string;
+  areaPath: string;
+  coords: Coord[];
+}
+
+function buildGeometry(points: SparklinePoint[], max: number): Geometry {
+  if (points.length === 0 || max === 0) {
+    return { path: "", areaPath: "", coords: [] };
+  }
   const stepX = VIEWBOX_WIDTH / Math.max(points.length - 1, 1);
-  return points
-    .map((p, i) => {
-      const x = i * stepX;
-      const y = VIEWBOX_HEIGHT - (p.value / max) * VIEWBOX_HEIGHT;
-      return `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`;
-    })
+  const coords: Coord[] = points.map((p, i) => ({
+    x: i * stepX,
+    y: VIEWBOX_HEIGHT - (p.value / max) * VIEWBOX_HEIGHT,
+  }));
+  const path = coords
+    .map((c, i) => `${i === 0 ? "M" : "L"}${c.x.toFixed(2)},${c.y.toFixed(2)}`)
     .join(" ");
+  const firstX = coords[0].x.toFixed(2);
+  const lastX = coords[coords.length - 1].x.toFixed(2);
+  const areaPath = `${path} L${lastX},${VIEWBOX_HEIGHT} L${firstX},${VIEWBOX_HEIGHT} Z`;
+  return { path, areaPath, coords };
+}
+
+function formatDate(iso: string): string {
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return parsed.toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
 }

--- a/client/tests/components/atoms/stats/sparkline.test.tsx
+++ b/client/tests/components/atoms/stats/sparkline.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { SparklineCard } from "@/components/atoms/stats/sparkline";
+import { renderWithProviders } from "../../../helpers/render";
+
+const points = [
+  { date: "2026-06-01", value: 10 },
+  { date: "2026-06-02", value: 20 },
+  { date: "2026-06-03", value: 30 },
+];
+
+describe("SparklineCard", () => {
+  it("should display the label and the aggregated total", () => {
+    renderWithProviders(<SparklineCard label="Messages envoyés" points={points} />);
+    expect(screen.getByText("Messages envoyés")).toBeInTheDocument();
+    // 10 + 20 + 30 = 60 (fr-FR uses NBSP as thousands separator, none needed here)
+    expect(screen.getByText("60")).toBeInTheDocument();
+  });
+
+  it("should use the provided total when given", () => {
+    renderWithProviders(
+      <SparklineCard label="Messages envoyés" points={points} total={999} />,
+    );
+    expect(screen.getByText("999")).toBeInTheDocument();
+  });
+
+  it("should show hover indicator with value and date when the chart is hovered", () => {
+    renderWithProviders(<SparklineCard label="Messages envoyés" points={points} />);
+
+    const chart = screen.getByRole("img", { name: /Messages envoyés/i });
+
+    // Simulate hover near the middle point (index 1, value 20)
+    fireEvent.mouseMove(chart, { clientX: 150, clientY: 30 });
+
+    // The tooltip should show one of the point values
+    // We look for at least one exact value from the dataset
+    const hoveredValueVisible =
+      screen.queryByText("10") ||
+      screen.queryByText("20") ||
+      screen.queryByText("30");
+    expect(hoveredValueVisible).not.toBeNull();
+  });
+
+  it("should hide the hover indicator when mouse leaves the chart", () => {
+    renderWithProviders(<SparklineCard label="Messages envoyés" points={points} />);
+
+    const chart = screen.getByRole("img", { name: /Messages envoyés/i });
+
+    fireEvent.mouseMove(chart, { clientX: 150, clientY: 30 });
+    fireEvent.mouseLeave(chart);
+
+    // No individual point value should be shown outside of the total (60)
+    expect(screen.queryByText("10")).not.toBeInTheDocument();
+    expect(screen.queryByText("20")).not.toBeInTheDocument();
+    expect(screen.queryByText("30")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problème
Sur la page **/stats**, les courbes (sparklines) affichent uniquement la tendance globale sans permettre de lire précisément la valeur associée à un jour donné. Difficile d'exploiter les données au-delà de l'impression visuelle.

## Solution
Enrichir le composant `SparklineCard` avec un indicateur interactif : au survol, on affiche la valeur et la date du point le plus proche du curseur, avec un repère visuel sur la courbe.

## Implémentation
- `client/src/components/atoms/stats/sparkline.tsx` :
  - Ajout d'une **zone remplie** (`primary/10`) sous la courbe pour améliorer le contraste.
  - Suivi de la position de la souris via `onMouseMove` sur le SVG ; calcul du point le plus proche par arrondi à l'index.
  - Rendu conditionnel d'une **ligne verticale pointillée** + **cercle mis en valeur** au point survolé.
  - **Tooltip** en overlay HTML positionné au-dessus du point, affichant la valeur (`fr-FR`) et la date formatée (`jj mois aaaa`).
  - Cleanup au `onMouseLeave`.
- `client/tests/components/atoms/stats/sparkline.test.tsx` : 4 tests couvrant l'affichage du label/total, le total custom, l'apparition du tooltip au survol et sa disparition au `mouseLeave`.

## Recette
1. Se rendre sur `/stats` connecté.
2. Vérifier que chaque sparkline présente désormais une zone légèrement teintée sous la courbe.
3. Survoler une sparkline : une ligne verticale pointillée, un point sur la courbe et une bulle avec la valeur + la date doivent apparaître.
4. Déplacer la souris le long de la courbe : la valeur et la date doivent se mettre à jour au data point le plus proche.
5. Sortir de la sparkline : les indicateurs disparaissent.
6. Vérifier que les sparklines sans données (courbe plate pointillée) ne déclenchent pas d'indicateur au survol.