### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.21",
         "class-variance-authority": "^0.7.1",

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "raggae"
-version = "0.1.0"
+version = "0.2.0"
 description = "RAG Generator Agent Expert - Platform for creating RAG-based conversational agents"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Problème
Cumul de features non publiées depuis `v0.1.0` — les artefacts Docker publiés n'ont pas de tag SemVer correspondant à l'état actuel.

## Solution
Bump mineur en `v0.2.0` (features non-breaking) et release via tag `v*` pour déclencher la publication des images `raggae-server:0.2.0` et `raggae-client:0.2.0`.

## Implémentation
- `client/package.json`, `client/package-lock.json`, `server/pyproject.toml` : `0.1.0` → `0.2.0`.

Contenu de la release (8 commits) :
- feat(mcp): domaine et use cases org MCP (PR 1/6, #133)
- feat(mcp): infrastructure MCP (PR 2/6, #134)
- feat(mcp): endpoints REST et UI organisation (PR 3/6, #135)
- feat(mcp): activations MCP par projet (PR 4/6, #136)
- feat(mcp): fondations tool-calling MCP (PR 5/6, #137)
- feat(mcp): stats plateforme MCP (PR 6/6, #138)
- feat(mcp): wiring tool-calling dans le flux chat (PR 5b, #139)
- feat(stats): tooltip au survol des sparklines (#140)

## Recette
1. Merger cette PR sur `main`.
2. Créer et pousser le tag `v0.2.0` sur `main`.
3. Vérifier que le workflow `CI / Build & Publish` publie les images `ghcr.io/jbuget/raggae-server:0.2.0` et `ghcr.io/jbuget/raggae-client:0.2.0`.