### PR TITLE
feat(organizations): améliorer la gestion des membres

### DIFF
--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -491,6 +491,8 @@
       "inviteError": "Failed to invite member",
       "inviteAlreadyPending": "An invitation is already pending for this email.",
       "currentMembers": "Current members",
+      "searchPlaceholder": "Search by name or email",
+      "noMembersMatch": "No member matches your search.",
       "joined": "Joined",
       "remove": "Remove",
       "removeSuccess": "Member removed",

--- a/client/messages/fr.json
+++ b/client/messages/fr.json
@@ -491,6 +491,8 @@
       "inviteError": "Erreur lors de l'invitation",
       "inviteAlreadyPending": "Une invitation est déjà en attente pour cet email.",
       "currentMembers": "Membres actuels",
+      "searchPlaceholder": "Rechercher par nom ou email",
+      "noMembersMatch": "Aucun membre ne correspond à votre recherche.",
       "joined": "Rejoint le",
       "remove": "Retirer",
       "removeSuccess": "Membre retiré",

--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -45,6 +45,18 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
   const revokeInvitation = useRevokeOrganizationInvitation(organizationId);
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<OrganizationMemberRole>("user");
+  const [memberSearch, setMemberSearch] = useState("");
+
+  const normalizedSearch = memberSearch.trim().toLowerCase();
+  const filteredMembers = (members ?? []).filter((member) => {
+    if (!normalizedSearch) return true;
+    const fullName = [member.user_first_name, member.user_last_name]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    const email = (member.user_email ?? "").toLowerCase();
+    return fullName.includes(normalizedSearch) || email.includes(normalizedSearch);
+  });
 
   return (
     <div className="rounded-lg border bg-card p-5 space-y-6">
@@ -104,11 +116,19 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
 
       <div className="space-y-2">
         <Label>{t("currentMembers")}</Label>
+        <Input
+          placeholder={t("searchPlaceholder")}
+          value={memberSearch}
+          onChange={(e) => setMemberSearch(e.target.value)}
+          className="max-w-sm"
+        />
         {membersLoading ? (
           <Skeleton className="h-20 w-full" />
+        ) : filteredMembers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t("noMembersMatch")}</p>
         ) : (
           <div className="space-y-2">
-            {members?.map((member) => (
+            {filteredMembers.map((member) => (
               <div
                 key={member.id}
                 className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-card p-3"

--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -23,6 +23,19 @@ import {
 
 const ROLE_OPTIONS: OrganizationMemberRole[] = ["owner", "maker", "user"];
 
+const ROLE_SORT_ORDER: Record<OrganizationMemberRole, number> = {
+  owner: 0,
+  maker: 1,
+  user: 2,
+};
+
+function memberFullName(member: {
+  user_first_name: string | null;
+  user_last_name: string | null;
+}): string {
+  return [member.user_first_name, member.user_last_name].filter(Boolean).join(" ");
+}
+
 type OrganizationMembersPanelProps = {
   organizationId: string;
 };
@@ -48,12 +61,14 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
   const [memberSearch, setMemberSearch] = useState("");
 
   const normalizedSearch = memberSearch.trim().toLowerCase();
-  const filteredMembers = (members ?? []).filter((member) => {
+  const sortedMembers = [...(members ?? [])].sort((a, b) => {
+    const roleDiff = ROLE_SORT_ORDER[a.role] - ROLE_SORT_ORDER[b.role];
+    if (roleDiff !== 0) return roleDiff;
+    return memberFullName(a).localeCompare(memberFullName(b));
+  });
+  const filteredMembers = sortedMembers.filter((member) => {
     if (!normalizedSearch) return true;
-    const fullName = [member.user_first_name, member.user_last_name]
-      .filter(Boolean)
-      .join(" ")
-      .toLowerCase();
+    const fullName = memberFullName(member).toLowerCase();
     const email = (member.user_email ?? "").toLowerCase();
     return fullName.includes(normalizedSearch) || email.includes(normalizedSearch);
   });
@@ -136,9 +151,7 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                 <div className="text-sm">
                   <div className="flex items-baseline gap-2">
                     <p className="font-medium">
-                      {[member.user_first_name, member.user_last_name]
-                        .filter(Boolean)
-                        .join(" ") || member.user_id}
+                      {memberFullName(member) || member.user_id}
                     </p>
                     {member.user_email && (
                       <p className="text-muted-foreground">{member.user_email}</p>

--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -35,6 +35,9 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
   const ownerCount = members?.filter((m) => m.role === "owner").length ?? 0;
   const { data: invitations, isLoading: invitationsLoading } =
     useOrganizationInvitations(organizationId);
+  const sortedInvitations = [...(invitations ?? [])].sort((a, b) =>
+    a.email.localeCompare(b.email),
+  );
   const inviteMember = useInviteOrganizationMember(organizationId);
   const updateRole = useUpdateOrganizationMemberRole(organizationId);
   const removeMember = useRemoveOrganizationMember(organizationId);
@@ -183,10 +186,10 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
           <Skeleton className="h-20 w-full" />
         ) : (
           <div className="space-y-2">
-            {!invitations || invitations.length === 0 ? (
+            {sortedInvitations.length === 0 ? (
               <p className="text-sm text-muted-foreground">{t("noPendingInvitations")}</p>
             ) : (
-              invitations.map((invitation) => (
+              sortedInvitations.map((invitation) => (
                 <div
                   key={invitation.id}
                   className="flex flex-wrap items-center justify-between gap-2 rounded-md border bg-card p-3"

--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -202,7 +202,7 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                       )}
                     </div>
                     <p className="text-muted-foreground">
-                      {t("sentOn")} {new Date(invitation.created_at).toLocaleDateString()}
+                      {t("sentOn")} {new Date(invitation.updated_at).toLocaleDateString()}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -143,6 +143,22 @@ describe("OrganizationMembersPanel", () => {
     expect(expiredRow).toHaveTextContent("Expired");
   });
 
+  it("should sort current members by role (owner > maker > user) then by name", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const expectedOrder = [
+      "Alice Doe",
+      "John Owner",
+      "Zoe White",
+      "Bob Smith",
+      "Charlie Brown",
+    ];
+    const nodes = expectedOrder.map((name) => screen.getByText(name));
+    for (let i = 0; i < nodes.length - 1; i++) {
+      const relation = nodes[i].compareDocumentPosition(nodes[i + 1]);
+      expect(relation & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    }
+  });
+
   it("should filter current members by name using the search input", async () => {
     const user = userEvent.setup();
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -47,6 +47,28 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
         created_at: "2024-01-01T00:00:00Z",
         updated_at: "2024-01-01T00:00:00Z",
       },
+      {
+        id: "inv-zoe",
+        organization_id: "org-1",
+        email: "zoe@example.com",
+        role: "user",
+        status: "pending",
+        invited_by_user_id: "user-1",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "inv-alice",
+        organization_id: "org-1",
+        email: "alice@example.com",
+        role: "user",
+        status: "pending",
+        invited_by_user_id: "user-1",
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        created_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-01-01T00:00:00Z",
+      },
     ],
     isLoading: false,
   }),
@@ -78,5 +100,18 @@ describe("OrganizationMembersPanel", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
     const expiredRow = screen.getByText("expired@example.com").closest("div");
     expect(expiredRow).toHaveTextContent("Expired");
+  });
+
+  it("should render pending invitations sorted alphabetically by email", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const invitationEmails = [
+      "alice@example.com",
+      "expired@example.com",
+      "pending@example.com",
+      "zoe@example.com",
+    ];
+    const rendered = screen.getAllByText(/@example\.com$/).map((el) => el.textContent);
+    const filtered = rendered.filter((email) => email && invitationEmails.includes(email));
+    expect(filtered).toEqual(invitationEmails);
   });
 });

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { OrganizationMembersPanel } from "@/components/organisms/organization/organization-members-panel";
 import { renderWithProviders } from "../../../helpers/render";
@@ -19,6 +20,46 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
         user_email: "john.owner@example.com",
         role: "owner",
         joined_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        id: "member-2",
+        organization_id: "org-1",
+        user_id: "user-2",
+        user_first_name: "Alice",
+        user_last_name: "Doe",
+        user_email: "alice.doe@example.com",
+        role: "owner",
+        joined_at: "2024-02-01T00:00:00Z",
+      },
+      {
+        id: "member-3",
+        organization_id: "org-1",
+        user_id: "user-3",
+        user_first_name: "Bob",
+        user_last_name: "Smith",
+        user_email: "bob.smith@example.com",
+        role: "maker",
+        joined_at: "2024-03-01T00:00:00Z",
+      },
+      {
+        id: "member-4",
+        organization_id: "org-1",
+        user_id: "user-4",
+        user_first_name: "Charlie",
+        user_last_name: "Brown",
+        user_email: "charlie.brown@example.com",
+        role: "user",
+        joined_at: "2024-04-01T00:00:00Z",
+      },
+      {
+        id: "member-5",
+        organization_id: "org-1",
+        user_id: "user-5",
+        user_first_name: "Zoe",
+        user_last_name: "White",
+        user_email: "zoe.white@example.com",
+        role: "owner",
+        joined_at: "2024-05-01T00:00:00Z",
       },
     ],
     isLoading: false,
@@ -100,6 +141,28 @@ describe("OrganizationMembersPanel", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
     const expiredRow = screen.getByText("expired@example.com").closest("div");
     expect(expiredRow).toHaveTextContent("Expired");
+  });
+
+  it("should filter current members by name using the search input", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const search = screen.getByPlaceholderText("Search by name or email");
+    await user.type(search, "alice");
+    expect(screen.getByText("Alice Doe")).toBeInTheDocument();
+    expect(screen.queryByText("Bob Smith")).not.toBeInTheDocument();
+    expect(screen.queryByText("Charlie Brown")).not.toBeInTheDocument();
+    expect(screen.queryByText("John Owner")).not.toBeInTheDocument();
+    expect(screen.queryByText("Zoe White")).not.toBeInTheDocument();
+  });
+
+  it("should filter current members by email using the search input", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const search = screen.getByPlaceholderText("Search by name or email");
+    await user.type(search, "bob.smith");
+    expect(screen.getByText("Bob Smith")).toBeInTheDocument();
+    expect(screen.queryByText("Alice Doe")).not.toBeInTheDocument();
+    expect(screen.queryByText("Charlie Brown")).not.toBeInTheDocument();
   });
 
   it("should display the last sent date using updated_at instead of created_at", () => {

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
         invited_by_user_id: "user-1",
         expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
         created_at: "2024-01-01T00:00:00Z",
-        updated_at: "2024-01-01T00:00:00Z",
+        updated_at: "2024-06-15T00:00:00Z",
       },
       {
         id: "inv-expired",
@@ -100,6 +100,15 @@ describe("OrganizationMembersPanel", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
     const expiredRow = screen.getByText("expired@example.com").closest("div");
     expect(expiredRow).toHaveTextContent("Expired");
+  });
+
+  it("should display the last sent date using updated_at instead of created_at", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const row = screen.getByText("pending@example.com").closest(".rounded-md");
+    const expected = new Date("2024-06-15T00:00:00Z").toLocaleDateString();
+    const legacy = new Date("2024-01-01T00:00:00Z").toLocaleDateString();
+    expect(row).toHaveTextContent(expected);
+    expect(row).not.toHaveTextContent(legacy);
   });
 
   it("should render pending invitations sorted alphabetically by email", () => {


### PR DESCRIPTION
## Problème
La page de gestion des membres d'une organisation manque d'ergonomie :
- les invitations en attente sont affichées dans un ordre arbitraire,
- après un « Renvoyer », la date affichée reste celle de la première invitation,
- il n'est pas possible de rechercher un membre dans la liste,
- les membres apparaissent dans l'ordre d'insertion, ce qui rend la lecture peu prévisible dès qu'on dépasse quelques entrées.

## Solution
Quatre améliorations UX ciblées sur `OrganizationMembersPanel`, chacune isolée dans un commit :

1. Tri alphabétique des invitations en attente par email.
2. Utilisation de `updated_at` (qui est déjà mis à jour par le use case backend `ResendOrganizationInvitation`) pour la mention « Envoyée le », afin de refléter le dernier envoi.
3. Barre de recherche côté front (nom OU email, insensible à la casse) au-dessus de la liste des membres actuels, avec message dédié quand la recherche est vide.
4. Tri stable des membres actuels par rôle (`owner` > `maker` > `user`) puis par nom complet.

Aucun changement de contrat API n'est requis : `updated_at` est déjà exposé par `OrganizationInvitationResponse`.

## Implémentation
- `client/src/components/organisms/organization/organization-members-panel.tsx` : ajout d'un `ROLE_SORT_ORDER`, d'un helper `memberFullName`, du state `memberSearch`, des passes de tri (`sortedMembers`, `sortedInvitations`) et du filtre de recherche.
- `client/messages/{en,fr}.json` : nouvelles clés `searchPlaceholder` et `noMembersMatch`.
- `client/tests/components/organisms/organization/organization-members-panel.test.tsx` : jeu de données enrichi (5 membres / 4 invitations) et 4 nouveaux tests couvrant le tri des invitations, la date `updated_at`, la recherche par nom, la recherche par email et le tri des membres.

## Recette
1. `cd client && npm run dev`, se connecter en tant qu'owner d'une organisation qui a plusieurs membres et plusieurs invitations en attente.
2. Ouvrir la page « Membres » de l'organisation.
3. Vérifier que les invitations en attente sont triées par email (a → z).
4. Cliquer « Renvoyer » sur une invitation datée et vérifier que la mention « Envoyée le » passe à la date du jour.
5. Vérifier que les membres actuels sont triés owners d'abord (par nom), puis makers, puis users.
6. Saisir dans la barre de recherche un fragment de nom (ex. `alice`) puis un fragment d'email (ex. `smith@`) et confirmer que la liste se filtre correctement ; effacer la recherche pour revenir à la liste complète.