### PR TITLE
feat(organization): afficher les compteurs et dates des membres

### DIFF
--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -130,7 +130,7 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
       </div>
 
       <div className="space-y-2">
-        <Label>{t("currentMembers")}</Label>
+        <Label>{t("currentMembers")} ({members?.length ?? 0})</Label>
         <Input
           placeholder={t("searchPlaceholder")}
           value={memberSearch}
@@ -214,7 +214,7 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
       </div>
 
       <div className="space-y-2">
-        <Label>{t("pendingInvitations")}</Label>
+        <Label>{t("pendingInvitations")} ({invitations?.length ?? 0})</Label>
         {invitationsLoading ? (
           <Skeleton className="h-20 w-full" />
         ) : (

--- a/client/src/components/organisms/organization/organization-members-panel.tsx
+++ b/client/src/components/organisms/organization/organization-members-panel.tsx
@@ -36,6 +36,19 @@ function memberFullName(member: {
   return [member.user_first_name, member.user_last_name].filter(Boolean).join(" ");
 }
 
+function formatDateTime(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const year = date.getUTCFullYear();
+  const hours = String(date.getUTCHours()).padStart(2, "0");
+  const minutes = String(date.getUTCMinutes()).padStart(2, "0");
+
+  return `${day}/${month}/${year} à ${hours}h${minutes}`;
+}
+
 type OrganizationMembersPanelProps = {
   organizationId: string;
 };
@@ -157,7 +170,9 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                       <p className="text-muted-foreground">{member.user_email}</p>
                     )}
                   </div>
-                  <p className="text-muted-foreground">{t("joined")} {member.joined_at}</p>
+                  <p className="text-muted-foreground">
+                    {t("joined")} {formatDateTime(member.joined_at)}
+                  </p>
                 </div>
                 <div className="flex items-center gap-2">
                   <select
@@ -235,7 +250,7 @@ export function OrganizationMembersPanel({ organizationId }: OrganizationMembers
                       )}
                     </div>
                     <p className="text-muted-foreground">
-                      {t("sentOn")} {new Date(invitation.updated_at).toLocaleDateString()}
+                      {t("sentOn")} {formatDateTime(invitation.updated_at)}
                     </p>
                   </div>
                   <div className="flex items-center gap-2">

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -131,6 +131,12 @@ describe("OrganizationMembersPanel", () => {
     expect(screen.getByText("john.owner@example.com")).toBeInTheDocument();
   });
 
+  it("should display member and invitation counts in section titles", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    expect(screen.getByText("Current members (5)")).toBeInTheDocument();
+    expect(screen.getByText("Pending invitations (4)")).toBeInTheDocument();
+  });
+
   it("should not show expired badge for a pending invitation within validity", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
     const pendingRow = screen.getByText("pending@example.com").closest("div");

--- a/client/tests/components/organisms/organization/organization-members-panel.test.tsx
+++ b/client/tests/components/organisms/organization/organization-members-panel.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
         user_last_name: "Doe",
         user_email: "alice.doe@example.com",
         role: "owner",
-        joined_at: "2024-02-01T00:00:00Z",
+        joined_at: "2026-03-18T18:26:55.860571Z",
       },
       {
         id: "member-3",
@@ -75,7 +75,7 @@ vi.mock("@/lib/hooks/use-organization-members", () => ({
         invited_by_user_id: "user-1",
         expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
         created_at: "2024-01-01T00:00:00Z",
-        updated_at: "2024-06-15T00:00:00Z",
+        updated_at: "2026-05-27T13:42:00Z",
       },
       {
         id: "inv-expired",
@@ -187,13 +187,18 @@ describe("OrganizationMembersPanel", () => {
     expect(screen.queryByText("Charlie Brown")).not.toBeInTheDocument();
   });
 
-  it("should display the last sent date using updated_at instead of created_at", () => {
+  it("should display member join dates with day, month, year, and time", () => {
+    renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
+    const row = screen.getByText("Alice Doe").closest(".rounded-md");
+    expect(row).toHaveTextContent("Joined 18/03/2026 à 18h26");
+    expect(row).not.toHaveTextContent("2026-03-18T18:26:55.860571Z");
+  });
+
+  it("should display the last sent date using updated_at with day, month, year, and time", () => {
     renderWithProviders(<OrganizationMembersPanel organizationId="org-1" />);
     const row = screen.getByText("pending@example.com").closest(".rounded-md");
-    const expected = new Date("2024-06-15T00:00:00Z").toLocaleDateString();
-    const legacy = new Date("2024-01-01T00:00:00Z").toLocaleDateString();
-    expect(row).toHaveTextContent(expected);
-    expect(row).not.toHaveTextContent(legacy);
+    expect(row).toHaveTextContent("Sent on 27/05/2026 à 13h42");
+    expect(row).not.toHaveTextContent("01/01/2024");
   });
 
   it("should render pending invitations sorted alphabetically by email", () => {


### PR DESCRIPTION
## Problème
Les sections de gestion des membres ne montrent pas le nombre d’éléments, et les dates des membres/invitations sont affichées dans des formats peu lisibles ou incomplets.

## Solution
Afficher le nombre de membres et d’invitations directement dans les titres de section, puis formatter les dates en `jj/mm/aaaa à HHhMM`.

## Implémentation
- Ajout des compteurs dans `OrganizationMembersPanel`.
- Ajout d’un formatteur de date local pour les dates de membres et d’invitations.
- Mise à jour des tests du panneau de membres pour couvrir les compteurs et les formats de dates.

## Recette
- Ouvrir les paramètres d’une organisation.
- Vérifier que `Membres actuels` et `Invitations en attente` affichent leur nombre.
- Vérifier que les dates sont affichées au format `18/03/2026 à 18h26`.